### PR TITLE
Implement recruit search and hero hiring system

### DIFF
--- a/WinFormsApp2/HeroViewForm.Designer.cs
+++ b/WinFormsApp2/HeroViewForm.Designer.cs
@@ -1,0 +1,140 @@
+using System.Windows.Forms;
+using System.Drawing;
+
+namespace WinFormsApp2
+{
+    partial class HeroViewForm
+    {
+        private System.ComponentModel.IContainer? components = null;
+        private Label lblName;
+        private Label lblStr;
+        private Label lblDex;
+        private Label lblInt;
+        private NumericUpDown numStr;
+        private NumericUpDown numDex;
+        private NumericUpDown numInt;
+        private Label lblPoints;
+        private Button btnHire;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            lblName = new Label();
+            lblStr = new Label();
+            lblDex = new Label();
+            lblInt = new Label();
+            numStr = new NumericUpDown();
+            numDex = new NumericUpDown();
+            numInt = new NumericUpDown();
+            lblPoints = new Label();
+            btnHire = new Button();
+            ((System.ComponentModel.ISupportInitialize)numStr).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)numDex).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)numInt).BeginInit();
+            SuspendLayout();
+            //
+            // lblName
+            //
+            lblName.AutoSize = true;
+            lblName.Location = new Point(12, 9);
+            lblName.Name = "lblName";
+            lblName.Size = new Size(38, 15);
+            lblName.Text = "Name";
+            //
+            // lblStr
+            //
+            lblStr.AutoSize = true;
+            lblStr.Location = new Point(12, 37);
+            lblStr.Name = "lblStr";
+            lblStr.Size = new Size(41, 15);
+            lblStr.Text = "STR:";
+            //
+            // lblDex
+            //
+            lblDex.AutoSize = true;
+            lblDex.Location = new Point(12, 66);
+            lblDex.Name = "lblDex";
+            lblDex.Size = new Size(42, 15);
+            lblDex.Text = "DEX:";
+            //
+            // lblInt
+            //
+            lblInt.AutoSize = true;
+            lblInt.Location = new Point(12, 95);
+            lblInt.Name = "lblInt";
+            lblInt.Size = new Size(31, 15);
+            lblInt.Text = "INT:";
+            //
+            // numStr
+            //
+            numStr.Location = new Point(70, 35);
+            numStr.Maximum = new decimal(new int[] {10,0,0,0});
+            numStr.Name = "numStr";
+            numStr.Size = new Size(50, 23);
+            numStr.ValueChanged += StatsChanged;
+            //
+            // numDex
+            //
+            numDex.Location = new Point(70, 64);
+            numDex.Maximum = new decimal(new int[] {10,0,0,0});
+            numDex.Name = "numDex";
+            numDex.Size = new Size(50, 23);
+            numDex.ValueChanged += StatsChanged;
+            //
+            // numInt
+            //
+            numInt.Location = new Point(70, 93);
+            numInt.Maximum = new decimal(new int[] {10,0,0,0});
+            numInt.Name = "numInt";
+            numInt.Size = new Size(50, 23);
+            numInt.ValueChanged += StatsChanged;
+            //
+            // lblPoints
+            //
+            lblPoints.AutoSize = true;
+            lblPoints.Location = new Point(12, 125);
+            lblPoints.Name = "lblPoints";
+            lblPoints.Size = new Size(87, 15);
+            lblPoints.Text = "Points left: 10";
+            //
+            // btnHire
+            //
+            btnHire.Location = new Point(12, 153);
+            btnHire.Name = "btnHire";
+            btnHire.Size = new Size(200, 23);
+            btnHire.Text = "Hire Hero";
+            btnHire.UseVisualStyleBackColor = true;
+            btnHire.Click += btnHire_Click;
+            //
+            // HeroViewForm
+            //
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(224, 191);
+            Controls.Add(btnHire);
+            Controls.Add(lblPoints);
+            Controls.Add(numInt);
+            Controls.Add(numDex);
+            Controls.Add(numStr);
+            Controls.Add(lblInt);
+            Controls.Add(lblDex);
+            Controls.Add(lblStr);
+            Controls.Add(lblName);
+            Name = "HeroViewForm";
+            Text = "Hero";
+            ((System.ComponentModel.ISupportInitialize)numStr).EndInit();
+            ((System.ComponentModel.ISupportInitialize)numDex).EndInit();
+            ((System.ComponentModel.ISupportInitialize)numInt).EndInit();
+            ResumeLayout(false);
+            PerformLayout();
+        }
+    }
+}

--- a/WinFormsApp2/HeroViewForm.cs
+++ b/WinFormsApp2/HeroViewForm.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Windows.Forms;
+using MySql.Data.MySqlClient;
+
+namespace WinFormsApp2
+{
+    public partial class HeroViewForm : Form
+    {
+        private readonly RecruitCandidate _candidate;
+        private readonly int _userId;
+        private readonly int _searchCost;
+        private readonly int _hireCost;
+
+        public HeroViewForm(int userId, RecruitCandidate candidate, int searchCost)
+        {
+            _userId = userId;
+            _candidate = candidate;
+            _searchCost = searchCost;
+            _hireCost = 10 + (int)Math.Ceiling(searchCost * 0.1);
+            InitializeComponent();
+            lblName.Text = candidate.Name;
+            lblStr.Text = $"STR: {candidate.Strength}";
+            lblDex.Text = $"DEX: {candidate.Dexterity}";
+            lblInt.Text = $"INT: {candidate.Intelligence}";
+            btnHire.Text = $"Hire Hero ({_hireCost} gold)";
+        }
+
+        private void StatsChanged(object? sender, EventArgs e)
+        {
+            int spent = (int)numStr.Value + (int)numDex.Value + (int)numInt.Value;
+            int remaining = 10 - spent;
+            if (remaining < 0)
+            {
+                var control = (NumericUpDown)sender!;
+                control.Value += remaining;
+                spent = (int)numStr.Value + (int)numDex.Value + (int)numInt.Value;
+                remaining = 10 - spent;
+            }
+            numStr.Maximum = (int)numStr.Value + remaining;
+            numDex.Maximum = (int)numDex.Value + remaining;
+            numInt.Maximum = (int)numInt.Value + remaining;
+            lblPoints.Text = $"Points left: {remaining}";
+        }
+
+        private void btnHire_Click(object? sender, EventArgs e)
+        {
+            int finalStr = _candidate.Strength + (int)numStr.Value;
+            int finalDex = _candidate.Dexterity + (int)numDex.Value;
+            int finalInt = _candidate.Intelligence + (int)numInt.Value;
+            int hp = 10 + 5 * finalStr;
+            int mana = 10 + 5 * finalInt;
+
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using MySqlCommand goldCmd = new MySqlCommand("SELECT gold FROM users WHERE id=@id", conn);
+            goldCmd.Parameters.AddWithValue("@id", _userId);
+            int gold = Convert.ToInt32(goldCmd.ExecuteScalar());
+            if (gold < _hireCost)
+            {
+                MessageBox.Show("Not enough gold to hire this hero.");
+                return;
+            }
+            using MySqlCommand updateGold = new MySqlCommand("UPDATE users SET gold=gold-@cost WHERE id=@id", conn);
+            updateGold.Parameters.AddWithValue("@cost", _hireCost);
+            updateGold.Parameters.AddWithValue("@id", _userId);
+            updateGold.ExecuteNonQuery();
+
+            using MySqlCommand insert = new MySqlCommand("INSERT INTO characters(account_id, name, current_hp, max_hp, mana, experience_points, action_speed, strength, dex, intelligence, melee_defense, magic_defense) VALUES(@acc,@name,@hp,@maxHp,@mana,0,@speed,@str,@dex,@int,0,0)", conn);
+            insert.Parameters.AddWithValue("@acc", _userId);
+            insert.Parameters.AddWithValue("@name", _candidate.Name);
+            insert.Parameters.AddWithValue("@hp", hp);
+            insert.Parameters.AddWithValue("@maxHp", hp);
+            insert.Parameters.AddWithValue("@mana", mana);
+            insert.Parameters.AddWithValue("@speed", _candidate.ActionSpeed);
+            insert.Parameters.AddWithValue("@str", finalStr);
+            insert.Parameters.AddWithValue("@dex", finalDex);
+            insert.Parameters.AddWithValue("@int", finalInt);
+            insert.ExecuteNonQuery();
+
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+    }
+}

--- a/WinFormsApp2/RPGForm.Designer.cs
+++ b/WinFormsApp2/RPGForm.Designer.cs
@@ -11,6 +11,7 @@ namespace WinFormsApp2
         private System.ComponentModel.IContainer? components = null;
         private ListBox lstParty;
         private Button btnHire;
+        private Button btnInspect;
         private Label lblGold;
         private Label lblTotalExp;
 
@@ -33,6 +34,7 @@ namespace WinFormsApp2
         {
             lstParty = new ListBox();
             btnHire = new Button();
+            btnInspect = new Button();
             lblGold = new Label();
             lblTotalExp = new Label();
             SuspendLayout();
@@ -44,39 +46,51 @@ namespace WinFormsApp2
             lstParty.Location = new Point(12, 12);
             lstParty.Name = "lstParty";
             lstParty.Size = new Size(260, 154);
+            lstParty.SelectedIndexChanged += lstParty_SelectedIndexChanged;
             // 
             // btnHire
             // 
             btnHire.Location = new Point(12, 172);
             btnHire.Name = "btnHire";
             btnHire.Size = new Size(260, 23);
-            btnHire.Text = "Hire Party Member";
+            btnHire.Text = "Search for new recruits";
             btnHire.UseVisualStyleBackColor = true;
             btnHire.Click += btnHire_Click;
-            // 
+            //
+            // btnInspect
+            //
+            btnInspect.Enabled = false;
+            btnInspect.Location = new Point(12, 201);
+            btnInspect.Name = "btnInspect";
+            btnInspect.Size = new Size(260, 23);
+            btnInspect.Text = "Inspect";
+            btnInspect.UseVisualStyleBackColor = true;
+            btnInspect.Click += btnInspect_Click;
+            //
             // lblGold
-            // 
+            //
             lblGold.AutoSize = true;
-            lblGold.Location = new Point(12, 208);
+            lblGold.Location = new Point(12, 237);
             lblGold.Name = "lblGold";
             lblGold.Size = new Size(35, 15);
             lblGold.Text = "Gold:";
-            // 
+            //
             // lblTotalExp
-            // 
+            //
             lblTotalExp.AutoSize = true;
-            lblTotalExp.Location = new Point(12, 233);
+            lblTotalExp.Location = new Point(12, 262);
             lblTotalExp.Name = "lblTotalExp";
             lblTotalExp.Size = new Size(69, 15);
             lblTotalExp.Text = "Party EXP:";
-            // 
+            //
             // RPGForm
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(284, 261);
+            ClientSize = new Size(284, 291);
             Controls.Add(lblTotalExp);
             Controls.Add(lblGold);
+            Controls.Add(btnInspect);
             Controls.Add(btnHire);
             Controls.Add(lstParty);
             Name = "RPGForm";

--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Windows.Forms;
 using MySql.Data.MySqlClient;
 
@@ -7,6 +8,8 @@ namespace WinFormsApp2
     public partial class RPGForm : Form
     {
         private readonly int _userId;
+        private int _searchCost;
+        private int _playerGold;
 
         public RPGForm(int userId)
         {
@@ -39,18 +42,88 @@ namespace WinFormsApp2
             reader.Close();
 
             lblTotalExp.Text = $"Party EXP: {totalExp}";
-            btnHire.Enabled = lstParty.Items.Count < 5;
+
+            int level = totalExp / 100 + 1;
+            _searchCost = 100 + level * 10 + lstParty.Items.Count * 20;
 
             using MySqlCommand goldCmd = new MySqlCommand("SELECT gold FROM users WHERE id=@id", conn);
             goldCmd.Parameters.AddWithValue("@id", _userId);
             object? goldResult = goldCmd.ExecuteScalar();
-            int gold = goldResult == null ? 0 : Convert.ToInt32(goldResult);
-            lblGold.Text = $"Gold: {gold}";
+            _playerGold = goldResult == null ? 0 : Convert.ToInt32(goldResult);
+            lblGold.Text = $"Gold: {_playerGold}";
+
+            btnHire.Text = $"Search for new recruits ({_searchCost} gold)";
+            btnHire.Enabled = lstParty.Items.Count < 5 && _playerGold >= _searchCost;
+            btnInspect.Enabled = false;
+            btnInspect.Text = "Inspect";
         }
 
         private void btnHire_Click(object? sender, EventArgs e)
         {
-            MessageBox.Show("Hire Party Member window coming soon.");
+            if (_playerGold < _searchCost)
+            {
+                MessageBox.Show("Not enough gold to search for recruits.");
+                return;
+            }
+
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using MySqlCommand payCmd = new MySqlCommand("UPDATE users SET gold = gold - @cost WHERE id=@id", conn);
+            payCmd.Parameters.AddWithValue("@cost", _searchCost);
+            payCmd.Parameters.AddWithValue("@id", _userId);
+            payCmd.ExecuteNonQuery();
+
+            LoadPartyData();
+
+            var rng = new Random();
+            var candidates = new System.Collections.Generic.List<RecruitCandidate>();
+            for (int i = 0; i < 3; i++)
+            {
+                candidates.Add(RecruitCandidate.Generate(rng, i));
+            }
+            using var recruitForm = new RecruitForm(_userId, candidates, _searchCost, LoadPartyData);
+            recruitForm.ShowDialog(this);
+        }
+
+        private void lstParty_SelectedIndexChanged(object? sender, EventArgs e)
+        {
+            if (lstParty.SelectedItem == null)
+            {
+                btnInspect.Enabled = false;
+                btnInspect.Text = "Inspect";
+            }
+            else
+            {
+                string item = lstParty.SelectedItem.ToString() ?? string.Empty;
+                string name = item.Split(" - ")[0];
+                btnInspect.Enabled = true;
+                btnInspect.Text = $"Inspect {name}";
+            }
+        }
+
+        private void btnInspect_Click(object? sender, EventArgs e)
+        {
+            if (lstParty.SelectedItem == null) return;
+            string item = lstParty.SelectedItem.ToString() ?? string.Empty;
+            string name = item.Split(" - ")[0];
+
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using MySqlCommand cmd = new MySqlCommand("SELECT current_hp, max_hp, mana, strength, dex, intelligence, action_speed FROM characters WHERE account_id=@id AND name=@name", conn);
+            cmd.Parameters.AddWithValue("@id", _userId);
+            cmd.Parameters.AddWithValue("@name", name);
+            using MySqlDataReader reader = cmd.ExecuteReader();
+            if (reader.Read())
+            {
+                int hp = reader.GetInt32("current_hp");
+                int maxHp = reader.GetInt32("max_hp");
+                int mana = reader.GetInt32("mana");
+                int str = reader.GetInt32("strength");
+                int dex = reader.GetInt32("dex");
+                int intel = reader.GetInt32("intelligence");
+                int speed = reader.GetInt32("action_speed");
+                MessageBox.Show($"{name}\nHP: {hp}/{maxHp}\nMana: {mana}\nSTR: {str}\nDEX: {dex}\nINT: {intel}\nSpeed: {speed}", $"Inspect {name}");
+            }
         }
     }
 }

--- a/WinFormsApp2/RecruitCandidate.cs
+++ b/WinFormsApp2/RecruitCandidate.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace WinFormsApp2
+{
+    public class RecruitCandidate
+    {
+        public string Name { get; set; } = string.Empty;
+        public int Strength { get; set; }
+        public int Dexterity { get; set; }
+        public int Intelligence { get; set; }
+        public int ActionSpeed { get; set; } = 1;
+        public int MaxHp => 10 + 5 * Strength;
+        public int Mana => 10 + 5 * Intelligence;
+
+        public static RecruitCandidate Generate(Random rng, int index)
+        {
+            var candidate = new RecruitCandidate
+            {
+                Name = $"Recruit {index + 1}",
+                Strength = 5,
+                Dexterity = 5,
+                Intelligence = 5
+            };
+            for (int i = 0; i < 10; i++)
+            {
+                int stat = rng.Next(3);
+                if (stat == 0) candidate.Strength++;
+                else if (stat == 1) candidate.Dexterity++;
+                else candidate.Intelligence++;
+            }
+            return candidate;
+        }
+    }
+}

--- a/WinFormsApp2/RecruitForm.Designer.cs
+++ b/WinFormsApp2/RecruitForm.Designer.cs
@@ -1,0 +1,57 @@
+using System.Windows.Forms;
+using System.Drawing;
+
+namespace WinFormsApp2
+{
+    partial class RecruitForm
+    {
+        private System.ComponentModel.IContainer? components = null;
+        private ListBox lstCandidates;
+        private Button btnView;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            lstCandidates = new ListBox();
+            btnView = new Button();
+            SuspendLayout();
+            //
+            // lstCandidates
+            //
+            lstCandidates.FormattingEnabled = true;
+            lstCandidates.ItemHeight = 15;
+            lstCandidates.Location = new Point(12, 12);
+            lstCandidates.Name = "lstCandidates";
+            lstCandidates.Size = new Size(200, 94);
+            //
+            // btnView
+            //
+            btnView.Enabled = false;
+            btnView.Location = new Point(12, 112);
+            btnView.Name = "btnView";
+            btnView.Size = new Size(200, 23);
+            btnView.Text = "View Hero";
+            btnView.UseVisualStyleBackColor = true;
+            btnView.Click += btnView_Click;
+            //
+            // RecruitForm
+            //
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(224, 147);
+            Controls.Add(btnView);
+            Controls.Add(lstCandidates);
+            Name = "RecruitForm";
+            Text = "Recruit Candidates";
+            ResumeLayout(false);
+        }
+    }
+}

--- a/WinFormsApp2/RecruitForm.cs
+++ b/WinFormsApp2/RecruitForm.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace WinFormsApp2
+{
+    public partial class RecruitForm : Form
+    {
+        private readonly List<RecruitCandidate> _candidates;
+        private readonly int _userId;
+        private readonly int _searchCost;
+        private readonly Action _onHire;
+
+        public RecruitForm(int userId, List<RecruitCandidate> candidates, int searchCost, Action onHire)
+        {
+            _userId = userId;
+            _candidates = candidates;
+            _searchCost = searchCost;
+            _onHire = onHire;
+            InitializeComponent();
+            foreach (var c in _candidates)
+            {
+                lstCandidates.Items.Add(c.Name);
+            }
+            lstCandidates.SelectedIndexChanged += (s, e) =>
+            {
+                btnView.Enabled = lstCandidates.SelectedIndex >= 0;
+            };
+        }
+
+        private void btnView_Click(object? sender, EventArgs e)
+        {
+            if (lstCandidates.SelectedIndex < 0) return;
+            var candidate = _candidates[lstCandidates.SelectedIndex];
+            using var view = new HeroViewForm(_userId, candidate, _searchCost);
+            if (view.ShowDialog(this) == DialogResult.OK)
+            {
+                int index = lstCandidates.SelectedIndex;
+                _candidates.RemoveAt(index);
+                lstCandidates.Items.RemoveAt(index);
+                _onHire();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add dynamic recruit search costing based on level and party size
- Show recruit candidates with randomized stats and allow custom stat allocation
- Enable inspecting existing party members from the party list

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68969cb457a4833399f0c599552fec59