### PR TITLE
Add NPC table and battle system

### DIFF
--- a/WinFormsApp2/BattleForm.Designer.cs
+++ b/WinFormsApp2/BattleForm.Designer.cs
@@ -1,0 +1,60 @@
+using System.Windows.Forms;
+using System.Drawing;
+
+namespace WinFormsApp2
+{
+    partial class BattleForm
+    {
+        private System.ComponentModel.IContainer? components = null;
+        private Label lblPlayer;
+        private Label lblNpc;
+        private ListBox lstLog;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            lblPlayer = new Label();
+            lblNpc = new Label();
+            lstLog = new ListBox();
+            SuspendLayout();
+            // lblPlayer
+            lblPlayer.AutoSize = true;
+            lblPlayer.Location = new Point(12, 9);
+            lblPlayer.Name = "lblPlayer";
+            lblPlayer.Size = new Size(38, 15);
+            lblPlayer.Text = "Player";
+            // lblNpc
+            lblNpc.AutoSize = true;
+            lblNpc.Location = new Point(12, 34);
+            lblNpc.Name = "lblNpc";
+            lblNpc.Size = new Size(31, 15);
+            lblNpc.Text = "NPC";
+            // lstLog
+            lstLog.FormattingEnabled = true;
+            lstLog.ItemHeight = 15;
+            lstLog.Location = new Point(12, 60);
+            lstLog.Name = "lstLog";
+            lstLog.Size = new Size(260, 184);
+            // BattleForm
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(284, 261);
+            Controls.Add(lstLog);
+            Controls.Add(lblNpc);
+            Controls.Add(lblPlayer);
+            Name = "BattleForm";
+            Text = "Battle";
+            Load += BattleForm_Load;
+            ResumeLayout(false);
+            PerformLayout();
+        }
+    }
+}

--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Windows.Forms;
+using MySql.Data.MySqlClient;
+
+namespace WinFormsApp2
+{
+    public partial class BattleForm : Form
+    {
+        private readonly Creature _player = new();
+        private readonly Creature _npc = new();
+        private readonly Timer _playerTimer = new();
+        private readonly Timer _npcTimer = new();
+        private readonly int _userId;
+
+        public BattleForm(int userId)
+        {
+            _userId = userId;
+            InitializeComponent();
+            LoadData();
+        }
+
+        private void LoadData()
+        {
+            using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+
+            using var cmd = new MySqlCommand("SELECT name, current_hp, max_hp, strength, dex, action_speed, melee_defense FROM characters WHERE account_id=@id LIMIT 1", conn);
+            cmd.Parameters.AddWithValue("@id", _userId);
+            using (var r = cmd.ExecuteReader())
+            {
+                if (r.Read())
+                {
+                    _player.Name = r.GetString("name");
+                    _player.CurrentHp = r.GetInt32("current_hp");
+                    _player.MaxHp = r.GetInt32("max_hp");
+                    _player.Strength = r.GetInt32("strength");
+                    _player.Dex = r.GetInt32("dex");
+                    _player.ActionSpeed = r.GetInt32("action_speed");
+                    _player.MeleeDefense = r.GetInt32("melee_defense");
+                }
+            }
+
+            using var npcCmd = new MySqlCommand("SELECT name, current_hp, max_hp, strength, dex, action_speed, melee_defense FROM npcs ORDER BY RAND() LIMIT 1", conn);
+            using (var r2 = npcCmd.ExecuteReader())
+            {
+                if (r2.Read())
+                {
+                    _npc.Name = r2.GetString("name");
+                    _npc.CurrentHp = r2.GetInt32("current_hp");
+                    _npc.MaxHp = r2.GetInt32("max_hp");
+                    _npc.Strength = r2.GetInt32("strength");
+                    _npc.Dex = r2.GetInt32("dex");
+                    _npc.ActionSpeed = r2.GetInt32("action_speed");
+                    _npc.MeleeDefense = r2.GetInt32("melee_defense");
+                }
+            }
+        }
+
+        private void BattleForm_Load(object? sender, EventArgs e)
+        {
+            UpdateLabels();
+            StartTimers();
+        }
+
+        private void UpdateLabels()
+        {
+            lblPlayer.Text = $"{_player.Name}: {_player.CurrentHp}/{_player.MaxHp} HP";
+            lblNpc.Text = $"{_npc.Name}: {_npc.CurrentHp}/{_npc.MaxHp} HP";
+        }
+
+        private void StartTimers()
+        {
+            _playerTimer.Interval = (int)(3000 / (_player.ActionSpeed + _player.Dex / 25.0));
+            _npcTimer.Interval = (int)(3000 / (_npc.ActionSpeed + _npc.Dex / 25.0));
+            _playerTimer.Tick += PlayerAction;
+            _npcTimer.Tick += NpcAction;
+            _playerTimer.Start();
+            _npcTimer.Start();
+        }
+
+        private void PlayerAction(object? sender, EventArgs e)
+        {
+            int dmg = Math.Max(1, _player.Strength - _npc.MeleeDefense);
+            _npc.CurrentHp -= dmg;
+            lstLog.Items.Add($"{_player.Name} hits {_npc.Name} for {dmg} damage!");
+            CheckEnd();
+        }
+
+        private void NpcAction(object? sender, EventArgs e)
+        {
+            int dmg = Math.Max(1, _npc.Strength - _player.MeleeDefense);
+            _player.CurrentHp -= dmg;
+            lstLog.Items.Add($"{_npc.Name} hits {_player.Name} for {dmg} damage!");
+            CheckEnd();
+        }
+
+        private void CheckEnd()
+        {
+            UpdateLabels();
+            if (_player.CurrentHp <= 0 || _npc.CurrentHp <= 0)
+            {
+                _playerTimer.Stop();
+                _npcTimer.Stop();
+                string winner = _player.CurrentHp > 0 ? _player.Name : _npc.Name;
+                lstLog.Items.Add($"{winner} wins!");
+            }
+        }
+
+        private class Creature
+        {
+            public string Name { get; set; } = string.Empty;
+            public int MaxHp { get; set; }
+            public int CurrentHp { get; set; }
+            public int Strength { get; set; }
+            public int Dex { get; set; }
+            public int ActionSpeed { get; set; }
+            public int MeleeDefense { get; set; }
+        }
+    }
+}

--- a/WinFormsApp2/RPGForm.Designer.cs
+++ b/WinFormsApp2/RPGForm.Designer.cs
@@ -12,6 +12,7 @@ namespace WinFormsApp2
         private ListBox lstParty;
         private Button btnHire;
         private Button btnInspect;
+        private Button btnBattle;
         private Label lblGold;
         private Label lblTotalExp;
 
@@ -35,6 +36,7 @@ namespace WinFormsApp2
             lstParty = new ListBox();
             btnHire = new Button();
             btnInspect = new Button();
+            btnBattle = new Button();
             lblGold = new Label();
             lblTotalExp = new Label();
             SuspendLayout();
@@ -67,10 +69,19 @@ namespace WinFormsApp2
             btnInspect.UseVisualStyleBackColor = true;
             btnInspect.Click += btnInspect_Click;
             //
+            // btnBattle
+            //
+            btnBattle.Location = new Point(12, 230);
+            btnBattle.Name = "btnBattle";
+            btnBattle.Size = new Size(260, 23);
+            btnBattle.Text = "Find Battle";
+            btnBattle.UseVisualStyleBackColor = true;
+            btnBattle.Click += btnBattle_Click;
+            //
             // lblGold
             //
             lblGold.AutoSize = true;
-            lblGold.Location = new Point(12, 237);
+            lblGold.Location = new Point(12, 259);
             lblGold.Name = "lblGold";
             lblGold.Size = new Size(35, 15);
             lblGold.Text = "Gold:";
@@ -78,7 +89,7 @@ namespace WinFormsApp2
             // lblTotalExp
             //
             lblTotalExp.AutoSize = true;
-            lblTotalExp.Location = new Point(12, 262);
+            lblTotalExp.Location = new Point(12, 284);
             lblTotalExp.Name = "lblTotalExp";
             lblTotalExp.Size = new Size(69, 15);
             lblTotalExp.Text = "Party EXP:";
@@ -87,9 +98,10 @@ namespace WinFormsApp2
             //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(284, 291);
+            ClientSize = new Size(284, 321);
             Controls.Add(lblTotalExp);
             Controls.Add(lblGold);
+            Controls.Add(btnBattle);
             Controls.Add(btnInspect);
             Controls.Add(btnHire);
             Controls.Add(lstParty);

--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -125,5 +125,11 @@ namespace WinFormsApp2
                 MessageBox.Show($"{name}\nHP: {hp}/{maxHp}\nMana: {mana}\nSTR: {str}\nDEX: {dex}\nINT: {intel}\nSpeed: {speed}", $"Inspect {name}");
             }
         }
+
+        private void btnBattle_Click(object? sender, EventArgs e)
+        {
+            using var battle = new BattleForm(_userId);
+            battle.ShowDialog(this);
+        }
     }
 }

--- a/npcs.sql
+++ b/npcs.sql
@@ -1,0 +1,47 @@
+-- MySQL script to create the 'npcs' table and a procedure to generate random NPCs
+-- Assumes the 'accounts' database already exists
+
+USE accounts;
+
+CREATE TABLE IF NOT EXISTS npcs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    level INT NOT NULL,
+    current_hp INT NOT NULL,
+    max_hp INT NOT NULL,
+    mana INT NOT NULL,
+    action_speed INT NOT NULL,
+    strength INT NOT NULL,
+    dex INT NOT NULL,
+    intelligence INT NOT NULL,
+    melee_defense INT NOT NULL,
+    magic_defense INT NOT NULL
+);
+
+DELIMITER $$
+CREATE PROCEDURE GenerateNPC(IN npcName VARCHAR(255), IN npcLevel INT)
+BEGIN
+    INSERT INTO npcs (name, level, current_hp, max_hp, mana, action_speed, strength, dex, intelligence, melee_defense, magic_defense)
+    SELECT npcName,
+           npcLevel,
+           base_hp + npcLevel * 5,
+           base_hp + npcLevel * 5,
+           base_mana + npcLevel * 5,
+           1,
+           base_str + npcLevel,
+           base_dex + npcLevel,
+           base_int + npcLevel,
+           base_melee_def + npcLevel,
+           base_magic_def + npcLevel
+    FROM (
+        SELECT
+            FLOOR(RAND() * 20) + 30 AS base_hp,
+            FLOOR(RAND() * 20) + 30 AS base_mana,
+            FLOOR(RAND() * 5) + 5 AS base_str,
+            FLOOR(RAND() * 5) + 5 AS base_dex,
+            FLOOR(RAND() * 5) + 5 AS base_int,
+            FLOOR(RAND() * 5) + 5 AS base_melee_def,
+            FLOOR(RAND() * 5) + 5 AS base_magic_def
+    ) AS t;
+END$$
+DELIMITER ;

--- a/seed_npcs.sql
+++ b/seed_npcs.sql
@@ -1,0 +1,11 @@
+USE accounts;
+CALL GenerateNPC('Goblin Grunt',1);
+CALL GenerateNPC('Forest Wolf',2);
+CALL GenerateNPC('Bandit Scout',3);
+CALL GenerateNPC('Skeleton Warrior',4);
+CALL GenerateNPC('Orc Brute',5);
+CALL GenerateNPC('Dark Mage',6);
+CALL GenerateNPC('Troll Berserker',7);
+CALL GenerateNPC('Vampire Knight',8);
+CALL GenerateNPC('Dragon Whelp',9);
+CALL GenerateNPC('Ancient Dragon',10);


### PR DESCRIPTION
## Summary
- add `npcs` table and generator procedure for level-scaled random stats
- extend RPG form with a Find Battle button and launch basic real-time combat
- implement BattleForm real-time attack timers with dexterity-based action speed
- seed 10 level-scaled NPCs using the generation procedure

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896bb71b6cc833394c792fa3164baac