### PR TITLE
Add starting gold and party ability framework

### DIFF
--- a/WinFormsApp2/Ability.cs
+++ b/WinFormsApp2/Ability.cs
@@ -1,0 +1,10 @@
+namespace WinFormsApp2
+{
+    public class Ability
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public int Cost { get; set; }
+    }
+}

--- a/WinFormsApp2/AbilityService.cs
+++ b/WinFormsApp2/AbilityService.cs
@@ -1,0 +1,37 @@
+using MySql.Data.MySqlClient;
+using System.Collections.Generic;
+
+namespace WinFormsApp2
+{
+    public static class AbilityService
+    {
+        public static List<Ability> GetShopAbilities(int characterId, MySqlConnection conn)
+        {
+            using var cmd = new MySqlCommand(@"SELECT a.id, a.name, a.description, a.cost
+                                               FROM abilities a
+                                               WHERE a.id NOT IN (SELECT ability_id FROM character_abilities WHERE character_id=@cid)", conn);
+            cmd.Parameters.AddWithValue("@cid", characterId);
+            using var reader = cmd.ExecuteReader();
+            var list = new List<Ability>();
+            while (reader.Read())
+            {
+                list.Add(new Ability
+                {
+                    Id = reader.GetInt32("id"),
+                    Name = reader.GetString("name"),
+                    Description = reader.GetString("description"),
+                    Cost = reader.GetInt32("cost")
+                });
+            }
+            return list;
+        }
+
+        public static void PurchaseAbility(int characterId, int abilityId, MySqlConnection conn)
+        {
+            using var cmd = new MySqlCommand("INSERT INTO character_abilities(character_id, ability_id) VALUES(@c,@a)", conn);
+            cmd.Parameters.AddWithValue("@c", characterId);
+            cmd.Parameters.AddWithValue("@a", abilityId);
+            cmd.ExecuteNonQuery();
+        }
+    }
+}

--- a/WinFormsApp2/HeroInspectForm.cs
+++ b/WinFormsApp2/HeroInspectForm.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Windows.Forms;
+using MySql.Data.MySqlClient;
+
+namespace WinFormsApp2
+{
+    public class HeroInspectForm : Form
+    {
+        private readonly int _userId;
+        private readonly int _characterId;
+        private Label lblStats = new Label();
+        private Button btnLevelUp = new Button();
+
+        public HeroInspectForm(int userId, int characterId)
+        {
+            _userId = userId;
+            _characterId = characterId;
+            Text = "Hero Details";
+            Width = 300;
+            Height = 250;
+
+            lblStats.Left = 10;
+            lblStats.Top = 10;
+            lblStats.Width = 260;
+            lblStats.Height = 150;
+            Controls.Add(lblStats);
+
+            btnLevelUp.Text = "Level Up";
+            btnLevelUp.Left = 10;
+            btnLevelUp.Top = 170;
+            btnLevelUp.Click += BtnLevelUp_Click;
+            Controls.Add(btnLevelUp);
+
+            Load += HeroInspectForm_Load;
+        }
+
+        private void HeroInspectForm_Load(object? sender, EventArgs e)
+        {
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using MySqlCommand cmd = new MySqlCommand("SELECT name, level, experience_points, strength, dex, intelligence, current_hp, max_hp FROM characters WHERE id=@cid AND account_id=@uid", conn);
+            cmd.Parameters.AddWithValue("@cid", _characterId);
+            cmd.Parameters.AddWithValue("@uid", _userId);
+            using MySqlDataReader reader = cmd.ExecuteReader();
+            if (reader.Read())
+            {
+                string name = reader.GetString("name");
+                int level = reader.GetInt32("level");
+                int exp = reader.GetInt32("experience_points");
+                int str = reader.GetInt32("strength");
+                int dex = reader.GetInt32("dex");
+                int intel = reader.GetInt32("intelligence");
+                int hp = reader.GetInt32("current_hp");
+                int maxHp = reader.GetInt32("max_hp");
+                lblStats.Text = $"{name}\nLevel: {level}\nEXP: {exp}/{level * 100}\nHP: {hp}/{maxHp}\nSTR: {str}\nDEX: {dex}\nINT: {intel}";
+                btnLevelUp.Enabled = exp >= level * 100;
+            }
+        }
+
+        private void BtnLevelUp_Click(object? sender, EventArgs e)
+        {
+            using var form = new LevelUpForm(_userId, _characterId);
+            form.ShowDialog(this);
+            HeroInspectForm_Load(null, EventArgs.Empty);
+        }
+    }
+}

--- a/WinFormsApp2/HeroViewForm.cs
+++ b/WinFormsApp2/HeroViewForm.cs
@@ -65,7 +65,7 @@ namespace WinFormsApp2
             updateGold.Parameters.AddWithValue("@id", _userId);
             updateGold.ExecuteNonQuery();
 
-            using MySqlCommand insert = new MySqlCommand("INSERT INTO characters(account_id, name, current_hp, max_hp, mana, experience_points, action_speed, strength, dex, intelligence, melee_defense, magic_defense) VALUES(@acc,@name,@hp,@maxHp,@mana,0,@speed,@str,@dex,@int,0,0)", conn);
+            using MySqlCommand insert = new MySqlCommand("INSERT INTO characters(account_id, name, current_hp, max_hp, mana, experience_points, action_speed, strength, dex, intelligence, melee_defense, magic_defense, level, skill_points) VALUES(@acc,@name,@hp,@maxHp,@mana,0,@speed,@str,@dex,@int,0,0,1,0)", conn);
             insert.Parameters.AddWithValue("@acc", _userId);
             insert.Parameters.AddWithValue("@name", _candidate.Name);
             insert.Parameters.AddWithValue("@hp", hp);

--- a/WinFormsApp2/LevelUpForm.cs
+++ b/WinFormsApp2/LevelUpForm.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+using MySql.Data.MySqlClient;
+
+namespace WinFormsApp2
+{
+    public class LevelUpForm : Form
+    {
+        private readonly int _userId;
+        private readonly int _characterId;
+        private NumericUpDown numStr = new NumericUpDown();
+        private NumericUpDown numDex = new NumericUpDown();
+        private NumericUpDown numInt = new NumericUpDown();
+        private Label lblPoints = new Label();
+        private Label lblGold = new Label();
+        private ListBox lstAbilities = new ListBox();
+        private Button btnBuy = new Button();
+        private Button btnSave = new Button();
+
+        private int _baseStr;
+        private int _baseDex;
+        private int _baseInt;
+        private int _availablePoints;
+        private int _playerGold;
+        private List<Ability> _abilities = new List<Ability>();
+
+        public LevelUpForm(int userId, int characterId)
+        {
+            _userId = userId;
+            _characterId = characterId;
+            Text = "Level Up";
+            Width = 400;
+            Height = 300;
+
+            var lblStr = new Label { Text = "STR", Left = 10, Top = 10, Width = 40 };
+            numStr.Left = 60; numStr.Top = 8; numStr.Width = 60;
+            numStr.Minimum = 0; numStr.Maximum = 999;
+            numStr.ValueChanged += StatsChanged;
+
+            var lblDex = new Label { Text = "DEX", Left = 10, Top = 40, Width = 40 };
+            numDex.Left = 60; numDex.Top = 38; numDex.Width = 60;
+            numDex.Minimum = 0; numDex.Maximum = 999;
+            numDex.ValueChanged += StatsChanged;
+
+            var lblInt = new Label { Text = "INT", Left = 10, Top = 70, Width = 40 };
+            numInt.Left = 60; numInt.Top = 68; numInt.Width = 60;
+            numInt.Minimum = 0; numInt.Maximum = 999;
+            numInt.ValueChanged += StatsChanged;
+
+            lblPoints.Left = 10; lblPoints.Top = 100; lblPoints.Width = 200;
+            lblGold.Left = 220; lblGold.Top = 10; lblGold.Width = 150;
+            lstAbilities.Left = 220; lstAbilities.Top = 40; lstAbilities.Width = 150; lstAbilities.Height = 120;
+            btnBuy.Text = "Buy"; btnBuy.Left = 220; btnBuy.Top = 170; btnBuy.Click += BtnBuy_Click;
+            btnSave.Text = "Save"; btnSave.Left = 10; btnSave.Top = 130; btnSave.Click += BtnSave_Click;
+
+            Controls.AddRange(new Control[] { lblStr, numStr, lblDex, numDex, lblInt, numInt, lblPoints, lblGold, lstAbilities, btnBuy, btnSave });
+            Load += LevelUpForm_Load;
+        }
+
+        private void LevelUpForm_Load(object? sender, EventArgs e)
+        {
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+
+            using (MySqlCommand update = new MySqlCommand("UPDATE characters SET level=level+1, skill_points=skill_points+5 WHERE id=@cid", conn))
+            {
+                update.Parameters.AddWithValue("@cid", _characterId);
+                update.ExecuteNonQuery();
+            }
+
+            using (MySqlCommand cmd = new MySqlCommand("SELECT strength, dex, intelligence, skill_points FROM characters WHERE id=@cid", conn))
+            {
+                cmd.Parameters.AddWithValue("@cid", _characterId);
+                using MySqlDataReader reader = cmd.ExecuteReader();
+                if (reader.Read())
+                {
+                    _baseStr = reader.GetInt32("strength");
+                    _baseDex = reader.GetInt32("dex");
+                    _baseInt = reader.GetInt32("intelligence");
+                    _availablePoints = reader.GetInt32("skill_points");
+                    numStr.Value = _baseStr;
+                    numDex.Value = _baseDex;
+                    numInt.Value = _baseInt;
+                    lblPoints.Text = $"Points: {_availablePoints}";
+                }
+            }
+
+            using (MySqlCommand goldCmd = new MySqlCommand("SELECT gold FROM users WHERE id=@id", conn))
+            {
+                goldCmd.Parameters.AddWithValue("@id", _userId);
+                _playerGold = Convert.ToInt32(goldCmd.ExecuteScalar());
+                lblGold.Text = $"Gold: {_playerGold}";
+            }
+
+            _abilities = AbilityService.GetShopAbilities(_characterId, conn);
+            lstAbilities.Items.Clear();
+            foreach (var a in _abilities)
+            {
+                lstAbilities.Items.Add($"{a.Name} ({a.Cost})");
+            }
+        }
+
+        private void StatsChanged(object? sender, EventArgs e)
+        {
+            int spent = (int)((numStr.Value - _baseStr) + (numDex.Value - _baseDex) + (numInt.Value - _baseInt));
+            if (spent > _availablePoints)
+            {
+                var control = (NumericUpDown)sender!;
+                control.Value -= spent - _availablePoints;
+                spent = _availablePoints;
+            }
+            lblPoints.Text = $"Points: {_availablePoints - spent}";
+        }
+
+        private void BtnBuy_Click(object? sender, EventArgs e)
+        {
+            if (lstAbilities.SelectedIndex < 0) return;
+            var ability = _abilities[lstAbilities.SelectedIndex];
+            if (_playerGold < ability.Cost)
+            {
+                MessageBox.Show("Not enough gold.");
+                return;
+            }
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using (MySqlCommand goldCmd = new MySqlCommand("UPDATE users SET gold=gold-@cost WHERE id=@id", conn))
+            {
+                goldCmd.Parameters.AddWithValue("@cost", ability.Cost);
+                goldCmd.Parameters.AddWithValue("@id", _userId);
+                goldCmd.ExecuteNonQuery();
+            }
+            AbilityService.PurchaseAbility(_characterId, ability.Id, conn);
+            _playerGold -= ability.Cost;
+            lblGold.Text = $"Gold: {_playerGold}";
+            _abilities = AbilityService.GetShopAbilities(_characterId, conn);
+            lstAbilities.Items.Clear();
+            foreach (var a in _abilities)
+            {
+                lstAbilities.Items.Add($"{a.Name} ({a.Cost})");
+            }
+        }
+
+        private void BtnSave_Click(object? sender, EventArgs e)
+        {
+            int newStr = (int)numStr.Value;
+            int newDex = (int)numDex.Value;
+            int newInt = (int)numInt.Value;
+            int spent = (newStr - _baseStr) + (newDex - _baseDex) + (newInt - _baseInt);
+            int remaining = _availablePoints - spent;
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using MySqlCommand cmd = new MySqlCommand("UPDATE characters SET strength=@s, dex=@d, intelligence=@i, skill_points=@sp WHERE id=@cid", conn)
+            {
+                cmd.Parameters.AddWithValue("@s", newStr);
+                cmd.Parameters.AddWithValue("@d", newDex);
+                cmd.Parameters.AddWithValue("@i", newInt);
+                cmd.Parameters.AddWithValue("@sp", remaining);
+                cmd.Parameters.AddWithValue("@cid", _characterId);
+                cmd.ExecuteNonQuery();
+            }
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+    }
+}

--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -109,20 +109,15 @@ namespace WinFormsApp2
 
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using MySqlCommand cmd = new MySqlCommand("SELECT current_hp, max_hp, mana, strength, dex, intelligence, action_speed FROM characters WHERE account_id=@id AND name=@name", conn);
+            using MySqlCommand cmd = new MySqlCommand("SELECT id FROM characters WHERE account_id=@id AND name=@name", conn);
             cmd.Parameters.AddWithValue("@id", _userId);
             cmd.Parameters.AddWithValue("@name", name);
-            using MySqlDataReader reader = cmd.ExecuteReader();
-            if (reader.Read())
+            object? result = cmd.ExecuteScalar();
+            if (result != null)
             {
-                int hp = reader.GetInt32("current_hp");
-                int maxHp = reader.GetInt32("max_hp");
-                int mana = reader.GetInt32("mana");
-                int str = reader.GetInt32("strength");
-                int dex = reader.GetInt32("dex");
-                int intel = reader.GetInt32("intelligence");
-                int speed = reader.GetInt32("action_speed");
-                MessageBox.Show($"{name}\nHP: {hp}/{maxHp}\nMana: {mana}\nSTR: {str}\nDEX: {dex}\nINT: {intel}\nSpeed: {speed}", $"Inspect {name}");
+                int charId = Convert.ToInt32(result);
+                using var inspect = new HeroInspectForm(_userId, charId);
+                inspect.ShowDialog(this);
             }
         }
 

--- a/WinFormsApp2/RegisterForm.cs
+++ b/WinFormsApp2/RegisterForm.cs
@@ -31,7 +31,7 @@ namespace WinFormsApp2
                 return;
             }
 
-            using MySqlCommand insert = new MySqlCommand("INSERT INTO Users (Username, PasswordHash) VALUES (@u, @p)", conn);
+            using MySqlCommand insert = new MySqlCommand("INSERT INTO Users (Username, PasswordHash, Gold) VALUES (@u, @p, 300)", conn);
             insert.Parameters.AddWithValue("@u", txtUsername.Text);
             insert.Parameters.AddWithValue("@p", Form1.HashPassword(txtPassword.Text));
             insert.ExecuteNonQuery();

--- a/abilities.sql
+++ b/abilities.sql
@@ -1,0 +1,21 @@
+-- MySQL script to create ability tables and seed data
+USE accounts;
+
+CREATE TABLE IF NOT EXISTS abilities (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    description TEXT,
+    cost INT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS character_abilities (
+    character_id INT NOT NULL,
+    ability_id INT NOT NULL,
+    PRIMARY KEY(character_id, ability_id),
+    FOREIGN KEY (character_id) REFERENCES characters(id),
+    FOREIGN KEY (ability_id) REFERENCES abilities(id)
+);
+
+INSERT INTO abilities (name, description, cost) VALUES
+('Fireball', 'Deal fire damage to a single enemy.', 50),
+('Heal', 'Restore a small amount of HP to an ally.', 30);

--- a/accounts.sql
+++ b/accounts.sql
@@ -7,6 +7,6 @@ USE accounts;
 CREATE TABLE IF NOT EXISTS users (
     id INT AUTO_INCREMENT PRIMARY KEY,
     username VARCHAR(255) NOT NULL UNIQUE,
-    password VARCHAR(255) NOT NULL,
-    gold INT NOT NULL DEFAULT 0
+    passwordhash VARCHAR(255) NOT NULL,
+    gold INT NOT NULL DEFAULT 300
 );

--- a/characters.sql
+++ b/characters.sql
@@ -17,5 +17,7 @@ CREATE TABLE IF NOT EXISTS characters (
     intelligence INT NOT NULL,
     melee_defense INT NOT NULL,
     magic_defense INT NOT NULL,
+    level INT NOT NULL DEFAULT 1,
+    skill_points INT NOT NULL DEFAULT 0,
     FOREIGN KEY (account_id) REFERENCES users(id)
 );


### PR DESCRIPTION
## Summary
- default new accounts to 300 gold
- add level and skill point columns to characters with level-up UI
- introduce flexible ability framework with SQL tables and shop

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897cf84a870833385f4b6086f0a6b5a