### PR TITLE
Distribute battle EXP and refine leveling

### DIFF
--- a/WinFormsApp2/ExperienceHelper.cs
+++ b/WinFormsApp2/ExperienceHelper.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace WinFormsApp2
+{
+    public static class ExperienceHelper
+    {
+        // Returns the total experience required to reach the given level.
+        public static int GetExpForLevel(int level)
+        {
+            if (level <= 1) return 0;
+            return 10 * level * level - 10 * level + 55;
+        }
+
+        // Returns the total experience required to reach the next level.
+        public static int GetNextLevelRequirement(int currentLevel)
+        {
+            return GetExpForLevel(currentLevel + 1);
+        }
+    }
+}

--- a/WinFormsApp2/HeroInspectForm.cs
+++ b/WinFormsApp2/HeroInspectForm.cs
@@ -52,8 +52,9 @@ namespace WinFormsApp2
                 int intel = reader.GetInt32("intelligence");
                 int hp = reader.GetInt32("current_hp");
                 int maxHp = reader.GetInt32("max_hp");
-                lblStats.Text = $"{name}\nLevel: {level}\nEXP: {exp}/{level * 100}\nHP: {hp}/{maxHp}\nSTR: {str}\nDEX: {dex}\nINT: {intel}";
-                btnLevelUp.Enabled = exp >= level * 100;
+                int nextExp = ExperienceHelper.GetNextLevelRequirement(level);
+                lblStats.Text = $"{name}\nLevel: {level}\nEXP: {exp}/{nextExp}\nHP: {hp}/{maxHp}\nSTR: {str}\nDEX: {dex}\nINT: {intel}";
+                btnLevelUp.Enabled = exp >= nextExp;
             }
         }
 

--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -27,24 +27,27 @@ namespace WinFormsApp2
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
 
-            using MySqlCommand cmd = new MySqlCommand("SELECT name, experience_points FROM characters WHERE account_id=@id", conn);
+            using MySqlCommand cmd = new MySqlCommand("SELECT name, experience_points, level FROM characters WHERE account_id=@id", conn);
             cmd.Parameters.AddWithValue("@id", _userId);
             using MySqlDataReader reader = cmd.ExecuteReader();
             lstParty.Items.Clear();
             int totalExp = 0;
+            int totalLevel = 0;
             while (reader.Read())
             {
                 string name = reader.GetString("name");
                 int exp = reader.GetInt32("experience_points");
-                lstParty.Items.Add($"{name} - EXP {exp}");
+                int level = reader.GetInt32("level");
+                int nextExp = ExperienceHelper.GetNextLevelRequirement(level);
+                lstParty.Items.Add($"{name} - LVL {level} EXP {exp}/{nextExp}");
                 totalExp += exp;
+                totalLevel += level;
             }
             reader.Close();
 
             lblTotalExp.Text = $"Party EXP: {totalExp}";
 
-            int level = totalExp / 100 + 1;
-            _searchCost = 100 + level * 10 + lstParty.Items.Count * 20;
+            _searchCost = 100 + totalLevel * 10 + lstParty.Items.Count * 20;
 
             using MySqlCommand goldCmd = new MySqlCommand("SELECT gold FROM users WHERE id=@id", conn);
             goldCmd.Parameters.AddWithValue("@id", _userId);


### PR DESCRIPTION
## Summary
- Grant party-wide experience after victories based on enemy levels
- Track experience thresholds with new helper for scalable leveling
- Refresh UI to display progress toward next level and compute search costs from party levels

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897d3c74c94833385a9560f75d9d87f