### PR TITLE
Add role-based targeting and group combat

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Forms;
 using MySql.Data.MySqlClient;
 
@@ -6,10 +8,10 @@ namespace WinFormsApp2
 {
     public partial class BattleForm : Form
     {
-        private readonly Creature _player = new();
-        private readonly Creature _npc = new();
-        private readonly System.Windows.Forms.Timer _playerTimer = new();
-        private readonly System.Windows.Forms.Timer _npcTimer = new();
+        private readonly List<Creature> _players = new();
+        private readonly List<Creature> _npcs = new();
+        private readonly Dictionary<Creature, Timer> _timers = new();
+        private readonly Random _rng = new();
         private readonly int _userId;
 
         public BattleForm(int userId)
@@ -24,35 +26,52 @@ namespace WinFormsApp2
             using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
 
-            using var cmd = new MySqlCommand("SELECT name, current_hp, max_hp, strength, dex, action_speed, melee_defense FROM characters WHERE account_id=@id LIMIT 1", conn);
+            using var cmd = new MySqlCommand("SELECT name, level, current_hp, max_hp, strength, dex, action_speed, melee_defense, role, targeting_style FROM characters WHERE account_id=@id", conn);
             cmd.Parameters.AddWithValue("@id", _userId);
             using (var r = cmd.ExecuteReader())
             {
-                if (r.Read())
+                while (r.Read())
                 {
-                    _player.Name = r.GetString("name");
-                    _player.CurrentHp = r.GetInt32("current_hp");
-                    _player.MaxHp = r.GetInt32("max_hp");
-                    _player.Strength = r.GetInt32("strength");
-                    _player.Dex = r.GetInt32("dex");
-                    _player.ActionSpeed = r.GetInt32("action_speed");
-                    _player.MeleeDefense = r.GetInt32("melee_defense");
+                    _players.Add(new Creature
+                    {
+                        Name = r.GetString("name"),
+                        Level = r.GetInt32("level"),
+                        CurrentHp = r.GetInt32("current_hp"),
+                        MaxHp = r.GetInt32("max_hp"),
+                        Strength = r.GetInt32("strength"),
+                        Dex = r.GetInt32("dex"),
+                        ActionSpeed = r.GetInt32("action_speed"),
+                        MeleeDefense = r.GetInt32("melee_defense"),
+                        Role = r.GetString("role"),
+                        TargetingStyle = r.GetString("targeting_style")
+                    });
                 }
             }
 
-            using var npcCmd = new MySqlCommand("SELECT name, level, current_hp, max_hp, strength, dex, action_speed, melee_defense FROM npcs ORDER BY RAND() LIMIT 1", conn);
-            using (var r2 = npcCmd.ExecuteReader())
+            int totalLevel = _players.Sum(p => p.Level);
+            int targetLevel = (int)Math.Ceiling(totalLevel * 1.25);
+            int npcLevel = 0;
+            while (npcLevel < targetLevel)
             {
+                using var npcCmd = new MySqlCommand("SELECT name, level, current_hp, max_hp, strength, dex, action_speed, melee_defense, role, targeting_style FROM npcs ORDER BY RAND() LIMIT 1", conn);
+                using var r2 = npcCmd.ExecuteReader();
                 if (r2.Read())
                 {
-                    _npc.Name = r2.GetString("name");
-                    _npc.Level = r2.GetInt32("level");
-                    _npc.CurrentHp = r2.GetInt32("current_hp");
-                    _npc.MaxHp = r2.GetInt32("max_hp");
-                    _npc.Strength = r2.GetInt32("strength");
-                    _npc.Dex = r2.GetInt32("dex");
-                    _npc.ActionSpeed = r2.GetInt32("action_speed");
-                    _npc.MeleeDefense = r2.GetInt32("melee_defense");
+                    var npc = new Creature
+                    {
+                        Name = r2.GetString("name"),
+                        Level = r2.GetInt32("level"),
+                        CurrentHp = r2.GetInt32("current_hp"),
+                        MaxHp = r2.GetInt32("max_hp"),
+                        Strength = r2.GetInt32("strength"),
+                        Dex = r2.GetInt32("dex"),
+                        ActionSpeed = r2.GetInt32("action_speed"),
+                        MeleeDefense = r2.GetInt32("melee_defense"),
+                        Role = r2.GetString("role"),
+                        TargetingStyle = r2.GetString("targeting_style")
+                    };
+                    _npcs.Add(npc);
+                    npcLevel += npc.Level;
                 }
             }
         }
@@ -65,50 +84,150 @@ namespace WinFormsApp2
 
         private void UpdateLabels()
         {
-            lblPlayer.Text = $"{_player.Name}: {_player.CurrentHp}/{_player.MaxHp} HP";
-            lblNpc.Text = $"{_npc.Name}: {_npc.CurrentHp}/{_npc.MaxHp} HP";
+            lblPlayer.Text = string.Join("\n", _players.Select(p => $"{p.Name}: {p.CurrentHp}/{p.MaxHp} HP"));
+            lblNpc.Text = string.Join("\n", _npcs.Select(n => $"{n.Name}: {n.CurrentHp}/{n.MaxHp} HP"));
         }
 
         private void StartTimers()
         {
-            _playerTimer.Interval = (int)(3000 / (_player.ActionSpeed + _player.Dex / 25.0));
-            _npcTimer.Interval = (int)(3000 / (_npc.ActionSpeed + _npc.Dex / 25.0));
-            _playerTimer.Tick += PlayerAction;
-            _npcTimer.Tick += NpcAction;
-            _playerTimer.Start();
-            _npcTimer.Start();
+            foreach (var p in _players)
+            {
+                var t = new Timer();
+                t.Interval = (int)(3000 / (p.ActionSpeed + p.Dex / 25.0));
+                t.Tick += (s, e) => Act(p, _players, _npcs);
+                t.Start();
+                _timers[p] = t;
+            }
+            foreach (var n in _npcs)
+            {
+                var t = new Timer();
+                t.Interval = (int)(3000 / (n.ActionSpeed + n.Dex / 25.0));
+                t.Tick += (s, e) => Act(n, _npcs, _players);
+                t.Start();
+                _timers[n] = t;
+            }
         }
 
-        private void PlayerAction(object? sender, EventArgs e)
+        private void Act(Creature actor, List<Creature> allies, List<Creature> opponents)
         {
-            int dmg = Math.Max(1, _player.Strength - _npc.MeleeDefense);
-            _npc.CurrentHp -= dmg;
-            lstLog.Items.Add($"{_player.Name} hits {_npc.Name} for {dmg} damage!");
+            if (actor.CurrentHp <= 0) return;
+            if (actor.HealCooldown > 0) actor.HealCooldown--;
+
+            Creature? target;
+            if (actor.Role == "Healer" && actor.HealCooldown == 0)
+            {
+                target = ChooseHealerTarget(actor, allies);
+                if (target != null && target.CurrentHp < target.MaxHp)
+                {
+                    int heal = Math.Max(1, actor.Strength);
+                    target.CurrentHp = Math.Min(target.MaxHp, target.CurrentHp + heal);
+                    lstLog.Items.Add($"{actor.Name} heals {target.Name} for {heal}!");
+                    actor.CurrentTarget = target;
+                    actor.HealCooldown = 3;
+                    CheckEnd();
+                    return;
+                }
+            }
+
+            target = ChooseOpponent(actor, opponents, allies);
+            if (target == null) return;
+
+            int dmg = Math.Max(1, actor.Strength - target.MeleeDefense);
+            target.CurrentHp -= dmg;
+            lstLog.Items.Add($"{actor.Name} hits {target.Name} for {dmg} damage!");
+            target.Threat[actor] = target.Threat.GetValueOrDefault(actor) + dmg;
+            target.CurrentTarget = actor;
+            actor.CurrentTarget = target;
             CheckEnd();
         }
 
-        private void NpcAction(object? sender, EventArgs e)
+        private Creature? ChooseHealerTarget(Creature actor, List<Creature> allies)
         {
-            int dmg = Math.Max(1, _npc.Strength - _player.MeleeDefense);
-            _player.CurrentHp -= dmg;
-            lstLog.Items.Add($"{_npc.Name} hits {_player.Name} for {dmg} damage!");
-            CheckEnd();
+            var injured = allies.Where(a => a.CurrentHp < a.MaxHp).ToList();
+            if (!injured.Any()) return null;
+            switch (actor.TargetingStyle)
+            {
+                case "prioritize lowest health ally":
+                    return injured.OrderBy(a => (double)a.CurrentHp / a.MaxHp).First();
+                case "prioritize different allies each turn":
+                    actor.LastHealedIndex = (actor.LastHealedIndex + 1) % injured.Count;
+                    return injured[actor.LastHealedIndex];
+                case "prioritize self":
+                    return actor.CurrentHp < actor.MaxHp ? actor : injured.First();
+                default:
+                    return injured.First();
+            }
+        }
+
+        private Creature? ChooseOpponent(Creature actor, List<Creature> opponents, List<Creature> allies)
+        {
+            var alive = opponents.Where(o => o.CurrentHp > 0).ToList();
+            if (!alive.Any()) return null;
+            switch (actor.Role)
+            {
+                case "Tank":
+                    switch (actor.TargetingStyle)
+                    {
+                        case "prioritize strongest foe":
+                            return alive.OrderByDescending(o => o.Strength).First();
+                        case "prioritize weakest foe":
+                            return alive.OrderBy(o => o.Strength).First();
+                        case "prioritize targets that arent attack you":
+                            var notOnMe = alive.Where(o => o.CurrentTarget != actor).ToList();
+                            return notOnMe.Any() ? notOnMe[_rng.Next(notOnMe.Count)] : alive[_rng.Next(alive.Count)];
+                        default:
+                            return alive[_rng.Next(alive.Count)];
+                    }
+                case "DPS":
+                    switch (actor.TargetingStyle)
+                    {
+                        case "prioritize target of the strongest tank":
+                            var tank = allies.Where(a => a.Role == "Tank").OrderByDescending(a => a.Strength).FirstOrDefault();
+                            if (tank?.CurrentTarget != null) return tank.CurrentTarget;
+                            break;
+                        case "prioritize targets attacking you":
+                            var atkMe = alive.Where(o => o.CurrentTarget == actor).ToList();
+                            if (atkMe.Any()) return atkMe[_rng.Next(atkMe.Count)];
+                            break;
+                        case "prioritize targets that attack non-tanks":
+                            var atkNonTank = alive.Where(o => o.CurrentTarget != null && o.CurrentTarget.Role != "Tank").ToList();
+                            if (atkNonTank.Any()) return atkNonTank[_rng.Next(atkNonTank.Count)];
+                            break;
+                    }
+                    return alive[_rng.Next(alive.Count)];
+                default:
+                    return alive[_rng.Next(alive.Count)];
+            }
         }
 
         private void CheckEnd()
         {
             UpdateLabels();
-            if (_player.CurrentHp <= 0 || _npc.CurrentHp <= 0)
+            if (_players.All(p => p.CurrentHp <= 0) || _npcs.All(n => n.CurrentHp <= 0))
             {
-                _playerTimer.Stop();
-                _npcTimer.Stop();
-                string winner = _player.CurrentHp > 0 ? _player.Name : _npc.Name;
-                lstLog.Items.Add($"{winner} wins!");
-                if (_player.CurrentHp > 0)
+                foreach (var t in _timers.Values) t.Stop();
+                bool playersWin = _players.Any(p => p.CurrentHp > 0);
+                lstLog.Items.Add(playersWin ? "Players win!" : "NPCs win!");
+                if (playersWin)
                 {
-                    AwardExperience();
+                    AwardExperience(_npcs.Sum(n => n.Level));
                 }
             }
+        }
+
+        private void AwardExperience(int totalEnemyLevels)
+        {
+            using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            int partySize = _players.Count;
+            if (partySize <= 0) return;
+            int expGain = totalEnemyLevels * 20;
+            int expPer = expGain / partySize;
+            using var updateCmd = new MySqlCommand("UPDATE characters SET experience_points = experience_points + @exp WHERE account_id=@id", conn);
+            updateCmd.Parameters.AddWithValue("@exp", expPer);
+            updateCmd.Parameters.AddWithValue("@id", _userId);
+            updateCmd.ExecuteNonQuery();
+            lstLog.Items.Add($"Each party member gains {expPer} EXP!");
         }
 
         private class Creature
@@ -121,34 +240,12 @@ namespace WinFormsApp2
             public int ActionSpeed { get; set; }
             public int MeleeDefense { get; set; }
             public int Level { get; set; }
-        }
-
-        private void AwardExperience()
-        {
-            using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
-            conn.Open();
-
-            int partySize;
-            using (var countCmd = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@id", conn))
-            {
-                countCmd.Parameters.AddWithValue("@id", _userId);
-                partySize = Convert.ToInt32(countCmd.ExecuteScalar());
-            }
-
-            if (partySize <= 0) return;
-
-            int totalEnemyLevels = _npc.Level;
-            int expGain = totalEnemyLevels * 20;
-            int expPer = expGain / partySize;
-
-            using (var updateCmd = new MySqlCommand("UPDATE characters SET experience_points = experience_points + @exp WHERE account_id=@id", conn))
-            {
-                updateCmd.Parameters.AddWithValue("@exp", expPer);
-                updateCmd.Parameters.AddWithValue("@id", _userId);
-                updateCmd.ExecuteNonQuery();
-            }
-
-            lstLog.Items.Add($"Each party member gains {expPer} EXP!");
+            public string Role { get; set; } = "DPS";
+            public string TargetingStyle { get; set; } = "no priorities";
+            public Creature? CurrentTarget { get; set; }
+            public Dictionary<Creature, int> Threat { get; } = new();
+            public int LastHealedIndex { get; set; } = -1;
+            public int HealCooldown { get; set; }
         }
     }
 }

--- a/WinFormsApp2/HeroInspectForm.cs
+++ b/WinFormsApp2/HeroInspectForm.cs
@@ -10,6 +10,8 @@ namespace WinFormsApp2
         private readonly int _characterId;
         private Label lblStats = new Label();
         private Button btnLevelUp = new Button();
+        private ComboBox cmbRole = new ComboBox();
+        private ComboBox cmbTarget = new ComboBox();
 
         public HeroInspectForm(int userId, int characterId)
         {
@@ -17,7 +19,7 @@ namespace WinFormsApp2
             _characterId = characterId;
             Text = "Hero Details";
             Width = 300;
-            Height = 250;
+            Height = 260;
 
             lblStats.Left = 10;
             lblStats.Top = 10;
@@ -25,9 +27,22 @@ namespace WinFormsApp2
             lblStats.Height = 150;
             Controls.Add(lblStats);
 
+            cmbRole.Left = 10;
+            cmbRole.Top = 170;
+            cmbRole.Width = 120;
+            cmbRole.Items.AddRange(new[] { "Tank", "Healer", "DPS" });
+            cmbRole.SelectedIndexChanged += CmbRole_SelectedIndexChanged;
+            Controls.Add(cmbRole);
+
+            cmbTarget.Left = 150;
+            cmbTarget.Top = 170;
+            cmbTarget.Width = 140;
+            cmbTarget.SelectedIndexChanged += CmbTarget_SelectedIndexChanged;
+            Controls.Add(cmbTarget);
+
             btnLevelUp.Text = "Level Up";
             btnLevelUp.Left = 10;
-            btnLevelUp.Top = 170;
+            btnLevelUp.Top = 200;
             btnLevelUp.Click += BtnLevelUp_Click;
             Controls.Add(btnLevelUp);
 
@@ -38,7 +53,7 @@ namespace WinFormsApp2
         {
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using MySqlCommand cmd = new MySqlCommand("SELECT name, level, experience_points, strength, dex, intelligence, current_hp, max_hp FROM characters WHERE id=@cid AND account_id=@uid", conn);
+            using MySqlCommand cmd = new MySqlCommand("SELECT name, level, experience_points, strength, dex, intelligence, current_hp, max_hp, role, targeting_style FROM characters WHERE id=@cid AND account_id=@uid", conn);
             cmd.Parameters.AddWithValue("@cid", _characterId);
             cmd.Parameters.AddWithValue("@uid", _userId);
             using MySqlDataReader reader = cmd.ExecuteReader();
@@ -55,6 +70,12 @@ namespace WinFormsApp2
                 int nextExp = ExperienceHelper.GetNextLevelRequirement(level);
                 lblStats.Text = $"{name}\nLevel: {level}\nEXP: {exp}/{nextExp}\nHP: {hp}/{maxHp}\nSTR: {str}\nDEX: {dex}\nINT: {intel}";
                 btnLevelUp.Enabled = exp >= nextExp;
+
+                string role = reader.GetString("role");
+                string targeting = reader.GetString("targeting_style");
+                cmbRole.SelectedItem = role;
+                LoadTargetOptions(role);
+                cmbTarget.SelectedItem = targeting;
             }
         }
 
@@ -63,6 +84,50 @@ namespace WinFormsApp2
             using var form = new LevelUpForm(_userId, _characterId);
             form.ShowDialog(this);
             HeroInspectForm_Load(null, EventArgs.Empty);
+        }
+
+        private void CmbRole_SelectedIndexChanged(object? sender, EventArgs e)
+        {
+            string role = cmbRole.SelectedItem?.ToString() ?? "DPS";
+            LoadTargetOptions(role);
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using MySqlCommand cmd = new MySqlCommand("UPDATE characters SET role=@r WHERE id=@cid", conn);
+            cmd.Parameters.AddWithValue("@r", role);
+            cmd.Parameters.AddWithValue("@cid", _characterId);
+            cmd.ExecuteNonQuery();
+        }
+
+        private void CmbTarget_SelectedIndexChanged(object? sender, EventArgs e)
+        {
+            string targeting = cmbTarget.SelectedItem?.ToString() ?? "no priorities";
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using MySqlCommand cmd = new MySqlCommand("UPDATE characters SET targeting_style=@t WHERE id=@cid", conn);
+            cmd.Parameters.AddWithValue("@t", targeting);
+            cmd.Parameters.AddWithValue("@cid", _characterId);
+            cmd.ExecuteNonQuery();
+        }
+
+        private void LoadTargetOptions(string role)
+        {
+            cmbTarget.Items.Clear();
+            switch (role)
+            {
+                case "Healer":
+                    cmbTarget.Items.AddRange(new[] { "prioritize lowest health ally", "prioritize different allies each turn", "prioritize self", "no priorities" });
+                    break;
+                case "Tank":
+                    cmbTarget.Items.AddRange(new[] { "prioritize strongest foe", "prioritize weakest foe", "prioritize targets that arent attack you", "no priorities" });
+                    break;
+                default: // DPS
+                    cmbTarget.Items.AddRange(new[] { "prioritize target of the strongest tank", "prioritize targets attacking you", "prioritize targets that attack non-tanks", "no priorities" });
+                    break;
+            }
+            if (cmbTarget.Items.Count > 0)
+            {
+                cmbTarget.SelectedIndex = 0;
+            }
         }
     }
 }

--- a/add_more_spells.sql
+++ b/add_more_spells.sql
@@ -1,0 +1,12 @@
+USE accounts;
+INSERT INTO abilities (name, description, cost) VALUES
+('Ice Lance', 'Deal ice damage to a single enemy.', 40),
+('Lightning Bolt', 'Strike an enemy with lightning.', 45),
+('Shield Bash', 'Stun a foe briefly.', 30),
+('Rejuvenate', 'Heal an ally over time.', 35),
+('Stone Skin', 'Increase an ally\'s defense.', 25),
+('Arcane Blast', 'Area damage to all enemies.', 60),
+('Poison Arrow', 'Deal poison damage over time.', 30),
+('Cleanse', 'Remove negative effects from an ally.', 20),
+('Berserk', 'Increase own damage for a short time.', 50),
+('Drain Life', 'Steal health from an enemy.', 55);

--- a/update_characters_targeting.sql
+++ b/update_characters_targeting.sql
@@ -1,0 +1,3 @@
+USE accounts;
+ALTER TABLE characters ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'DPS';
+ALTER TABLE characters ADD COLUMN targeting_style VARCHAR(50) NOT NULL DEFAULT 'no priorities';

--- a/update_npcs_targeting.sql
+++ b/update_npcs_targeting.sql
@@ -1,0 +1,3 @@
+USE accounts;
+ALTER TABLE npcs ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'DPS';
+ALTER TABLE npcs ADD COLUMN targeting_style VARCHAR(50) NOT NULL DEFAULT 'no priorities';


### PR DESCRIPTION
## Summary
- add role and targeting dropdowns to hero inspection
- rebuild battle form to support parties, role-driven priorities, and threat
- create SQL migrations for character/NPC targeting fields and extra spells

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897d6e0b5c88333890ef450f2ff5462