### PR TITLE
Persist inventory and revamp combat UI

### DIFF
--- a/WinFormsApp2/BattleForm.Designer.cs
+++ b/WinFormsApp2/BattleForm.Designer.cs
@@ -6,8 +6,8 @@ namespace WinFormsApp2
     partial class BattleForm
     {
         private System.ComponentModel.IContainer? components = null;
-        private Label lblPlayer;
-        private Label lblNpc;
+        private FlowLayoutPanel pnlPlayers;
+        private FlowLayoutPanel pnlEnemies;
         private ListBox lstLog;
 
         protected override void Dispose(bool disposing)
@@ -21,40 +21,32 @@ namespace WinFormsApp2
 
         private void InitializeComponent()
         {
-            lblPlayer = new Label();
-            lblNpc = new Label();
+            pnlPlayers = new FlowLayoutPanel();
+            pnlEnemies = new FlowLayoutPanel();
             lstLog = new ListBox();
             SuspendLayout();
-            // lblPlayer
-            lblPlayer.AutoSize = true;
-            lblPlayer.Location = new Point(12, 9);
-            lblPlayer.Name = "lblPlayer";
-            lblPlayer.Size = new Size(38, 15);
-            lblPlayer.Text = "Player";
-            // lblNpc
-            lblNpc.AutoSize = true;
-            lblNpc.Location = new Point(12, 34);
-            lblNpc.Name = "lblNpc";
-            lblNpc.Size = new Size(31, 15);
-            lblNpc.Text = "NPC";
+            // pnlPlayers
+            pnlPlayers.Location = new Point(12, 12);
+            pnlPlayers.Size = new Size(200, 120);
+            // pnlEnemies
+            pnlEnemies.Location = new Point(276, 12);
+            pnlEnemies.Size = new Size(200, 120);
             // lstLog
             lstLog.FormattingEnabled = true;
             lstLog.ItemHeight = 15;
-            lstLog.Location = new Point(12, 60);
-            lstLog.Name = "lstLog";
-            lstLog.Size = new Size(260, 184);
+            lstLog.Location = new Point(12, 138);
+            lstLog.Size = new Size(464, 154);
             // BattleForm
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(284, 261);
+            ClientSize = new Size(488, 304);
             Controls.Add(lstLog);
-            Controls.Add(lblNpc);
-            Controls.Add(lblPlayer);
+            Controls.Add(pnlEnemies);
+            Controls.Add(pnlPlayers);
             Name = "BattleForm";
             Text = "Battle";
             Load += BattleForm_Load;
             ResumeLayout(false);
-            PerformLayout();
         }
     }
 }

--- a/WinFormsApp2/BattleSummaryForm.cs
+++ b/WinFormsApp2/BattleSummaryForm.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace WinFormsApp2
+{
+    public class BattleSummaryForm : Form
+    {
+        private readonly ListBox _list = new ListBox();
+        public BattleSummaryForm(IEnumerable<dynamic> players, IEnumerable<dynamic> enemies)
+        {
+            Text = "Battle Summary";
+            Width = 400;
+            Height = 300;
+            _list.Dock = DockStyle.Fill;
+            Controls.Add(_list);
+            foreach (var p in players)
+            {
+                _list.Items.Add($"{p.Name} - Damage Done: {p.DamageDone}, Damage Taken: {p.DamageTaken}");
+            }
+            foreach (var e in enemies)
+            {
+                _list.Items.Add($"{e.Name} - Damage Done: {e.DamageDone}, Damage Taken: {e.DamageTaken}");
+            }
+        }
+    }
+}

--- a/WinFormsApp2/Form1.cs
+++ b/WinFormsApp2/Form1.cs
@@ -24,6 +24,7 @@ namespace WinFormsApp2
             if (result != null)
             {
                 int userId = Convert.ToInt32(result);
+                InventoryService.Load(userId);
                 RPGForm rpg = new RPGForm(userId);
                 rpg.FormClosed += (s, args) => this.Close();
                 rpg.Show();

--- a/WinFormsApp2/HeroInspectForm.cs
+++ b/WinFormsApp2/HeroInspectForm.cs
@@ -115,6 +115,7 @@ namespace WinFormsApp2
                 int maxHp = reader.GetInt32("max_hp");
                 int nextExp = ExperienceHelper.GetNextLevelRequirement(level);
                 lblStats.Text = $"{name}\nLevel: {level}\nEXP: {exp}/{nextExp}\nHP: {hp}/{maxHp}\nSTR: {str}\nDEX: {dex}\nINT: {intel}";
+                ShowPredictions(str, dex, intel);
                 btnLevelUp.Enabled = exp >= nextExp;
 
                 string role = reader.GetString("role");
@@ -124,6 +125,27 @@ namespace WinFormsApp2
                 cmbTarget.SelectedItem = targeting;
                 LoadEquipment();
             }
+        }
+
+        private void ShowPredictions(int str, int dex, int intel)
+        {
+            var weapon = InventoryService.GetEquippedItem(_characterName, EquipmentSlot.LeftHand) as Weapon
+                ?? InventoryService.GetEquippedItem(_characterName, EquipmentSlot.RightHand) as Weapon;
+            double statTotal = str;
+            double min = 0.8, max = 1.2, critBonus = 0, speed = 1 + dex / 25.0;
+            if (weapon != null)
+            {
+                statTotal = str * weapon.StrScaling + dex * weapon.DexScaling + intel * weapon.IntScaling;
+                min = weapon.MinMultiplier;
+                max = weapon.MaxMultiplier;
+                critBonus = weapon.CritChanceBonus;
+                speed *= (1 + weapon.AttackSpeedMod);
+            }
+            double minD = Math.Max(1, statTotal * min);
+            double maxD = Math.Max(1, statTotal * max);
+            double crit = Math.Min(1.0, 0.05 + dex / 5 * 0.01 + critBonus);
+            double atkRate = speed / 3.0;
+            lblStats.Text += $"\nDamage: {minD:F1}-{maxD:F1}\nCrit Chance: {crit:P0}\nAttack Rate: {atkRate:F2}/s";
         }
 
         private void BtnLevelUp_Click(object? sender, EventArgs e)

--- a/WinFormsApp2/HeroViewForm.Designer.cs
+++ b/WinFormsApp2/HeroViewForm.Designer.cs
@@ -7,6 +7,7 @@ namespace WinFormsApp2
     {
         private System.ComponentModel.IContainer? components = null;
         private Label lblName;
+        private TextBox txtName;
         private Label lblStr;
         private Label lblDex;
         private Label lblInt;
@@ -28,6 +29,7 @@ namespace WinFormsApp2
         private void InitializeComponent()
         {
             lblName = new Label();
+            txtName = new TextBox();
             lblStr = new Label();
             lblDex = new Label();
             lblInt = new Label();
@@ -42,12 +44,15 @@ namespace WinFormsApp2
             SuspendLayout();
             //
             // lblName
-            //
             lblName.AutoSize = true;
             lblName.Location = new Point(12, 9);
             lblName.Name = "lblName";
-            lblName.Size = new Size(38, 15);
-            lblName.Text = "Name";
+            lblName.Size = new Size(39, 15);
+            lblName.Text = "Name:";
+
+            // txtName
+            txtName.Location = new Point(70, 6);
+            txtName.Size = new Size(120, 23);
             //
             // lblStr
             //
@@ -127,6 +132,7 @@ namespace WinFormsApp2
             Controls.Add(lblInt);
             Controls.Add(lblDex);
             Controls.Add(lblStr);
+            Controls.Add(txtName);
             Controls.Add(lblName);
             Name = "HeroViewForm";
             Text = "Hero";

--- a/WinFormsApp2/HeroViewForm.cs
+++ b/WinFormsApp2/HeroViewForm.cs
@@ -18,7 +18,7 @@ namespace WinFormsApp2
             _searchCost = searchCost;
             _hireCost = 10 + (int)Math.Ceiling(searchCost * 0.1);
             InitializeComponent();
-            lblName.Text = candidate.Name;
+            txtName.Text = candidate.Name;
             lblStr.Text = $"STR: {candidate.Strength}";
             lblDex.Text = $"DEX: {candidate.Dexterity}";
             lblInt.Text = $"INT: {candidate.Intelligence}";
@@ -67,7 +67,13 @@ namespace WinFormsApp2
 
             using MySqlCommand insert = new MySqlCommand("INSERT INTO characters(account_id, name, current_hp, max_hp, mana, experience_points, action_speed, strength, dex, intelligence, melee_defense, magic_defense, level, skill_points) VALUES(@acc,@name,@hp,@maxHp,@mana,0,@speed,@str,@dex,@int,0,0,1,0)", conn);
             insert.Parameters.AddWithValue("@acc", _userId);
-            insert.Parameters.AddWithValue("@name", _candidate.Name);
+            string name = txtName.Text.Trim();
+            if (name.Contains(' ') || name.Length < 3 || name.Length > 12)
+            {
+                MessageBox.Show("Name must be 3-12 characters with no spaces");
+                return;
+            }
+            insert.Parameters.AddWithValue("@name", name);
             insert.Parameters.AddWithValue("@hp", hp);
             insert.Parameters.AddWithValue("@maxHp", hp);
             insert.Parameters.AddWithValue("@mana", mana);

--- a/WinFormsApp2/InventoryForm.Designer.cs
+++ b/WinFormsApp2/InventoryForm.Designer.cs
@@ -9,6 +9,7 @@ namespace WinFormsApp2
         private ListBox lstItems;
         private Label lblDescription;
         private Button btnUse;
+        private ComboBox cmbTarget;
 
         protected override void Dispose(bool disposing)
         {
@@ -24,6 +25,7 @@ namespace WinFormsApp2
             lstItems = new ListBox();
             lblDescription = new Label();
             btnUse = new Button();
+            cmbTarget = new ComboBox();
             SuspendLayout();
             //
             // lstItems
@@ -40,18 +42,23 @@ namespace WinFormsApp2
             lblDescription.Size = new Size(200, 120);
             //
             // btnUse
-            //
-            btnUse.Location = new Point(168, 135);
+            btnUse.Location = new Point(168, 164);
             btnUse.Size = new Size(200, 23);
             btnUse.Text = "Use";
             btnUse.Enabled = false;
             btnUse.Click += btnUse_Click;
+
+            // cmbTarget
+            cmbTarget.Location = new Point(168, 135);
+            cmbTarget.Size = new Size(200, 23);
+            cmbTarget.SelectedIndexChanged += cmbTarget_SelectedIndexChanged;
             //
             // InventoryForm
             //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(380, 223);
+            Controls.Add(cmbTarget);
             Controls.Add(btnUse);
             Controls.Add(lblDescription);
             Controls.Add(lstItems);

--- a/WinFormsApp2/InventoryForm.cs
+++ b/WinFormsApp2/InventoryForm.cs
@@ -1,19 +1,25 @@
 using System;
 using System.Linq;
 using System.Windows.Forms;
+using MySql.Data.MySqlClient;
 
 namespace WinFormsApp2
 {
     public partial class InventoryForm : Form
     {
-        public InventoryForm()
+        private readonly int _userId;
+        private string? _selectedTarget;
+
+        public InventoryForm(int userId)
         {
+            _userId = userId;
             InitializeComponent();
         }
 
         private void InventoryForm_Load(object? sender, EventArgs e)
         {
             RefreshItems();
+            LoadTargets();
         }
 
         private void RefreshItems()
@@ -48,20 +54,47 @@ namespace WinFormsApp2
             else
             {
                 lblDescription.Text = item.Description;
-                btnUse.Enabled = item is HealingPotion;
+                btnUse.Enabled = item is HealingPotion && _selectedTarget != null;
             }
         }
 
         private void btnUse_Click(object? sender, EventArgs e)
         {
             var item = SelectedItem();
-            if (item == null) return;
+            if (item == null || _selectedTarget == null) return;
             if (item is HealingPotion)
             {
-                // use potion on first party member? For simplicity, remove from inventory.
+                using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+                conn.Open();
+                using MySqlCommand cmd = new MySqlCommand("UPDATE characters SET current_hp = LEAST(max_hp, current_hp + @heal) WHERE account_id=@uid AND name=@name", conn);
+                cmd.Parameters.AddWithValue("@heal", ((HealingPotion)item).HealAmount);
+                cmd.Parameters.AddWithValue("@uid", _userId);
+                cmd.Parameters.AddWithValue("@name", _selectedTarget);
+                cmd.ExecuteNonQuery();
                 InventoryService.RemoveItem(item);
                 RefreshItems();
             }
+        }
+
+        private void LoadTargets()
+        {
+            cmbTarget.Items.Clear();
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using MySqlCommand cmd = new MySqlCommand("SELECT name FROM characters WHERE account_id=@id", conn);
+            cmd.Parameters.AddWithValue("@id", _userId);
+            using var r = cmd.ExecuteReader();
+            while (r.Read())
+            {
+                cmbTarget.Items.Add(r.GetString("name"));
+            }
+        }
+
+        private void cmbTarget_SelectedIndexChanged(object? sender, EventArgs e)
+        {
+            _selectedTarget = cmbTarget.SelectedItem?.ToString();
+            var item = SelectedItem();
+            btnUse.Enabled = item is HealingPotion && _selectedTarget != null;
         }
     }
 }

--- a/WinFormsApp2/InventoryService.cs
+++ b/WinFormsApp2/InventoryService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using MySql.Data.MySqlClient;
 
 namespace WinFormsApp2
 {
@@ -13,15 +14,61 @@ namespace WinFormsApp2
     {
         private static readonly List<InventoryItem> _items = new();
         private static readonly Dictionary<string, Dictionary<EquipmentSlot, Item?>> _equipment = new();
-
-        static InventoryService()
-        {
-            // starting items
-            AddItem(new HealingPotion(), 3);
-            AddItem(WeaponFactory.Create("shortsword"));
-        }
+        private static int _userId;
+        private static bool _loaded;
 
         public static IReadOnlyList<InventoryItem> Items => _items;
+
+        public static void Load(int userId)
+        {
+            if (_loaded && _userId == userId) return;
+            _loaded = true;
+            _userId = userId;
+            _items.Clear();
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using MySqlCommand cmd = new MySqlCommand("SELECT item_name, quantity FROM user_items WHERE account_id=@id", conn);
+            cmd.Parameters.AddWithValue("@id", userId);
+            using (var r = cmd.ExecuteReader())
+            {
+                while (r.Read())
+                {
+                    string name = r.GetString("item_name");
+                    int qty = r.GetInt32("quantity");
+                    Item? item = CreateItem(name);
+                    if (item != null)
+                    {
+                        _items.Add(new InventoryItem { Item = item, Quantity = qty });
+                    }
+                }
+            }
+
+            using MySqlCommand eq = new MySqlCommand("SELECT character_name, slot, item_name FROM character_equipment WHERE account_id=@id", conn);
+            eq.Parameters.AddWithValue("@id", userId);
+            using var r2 = eq.ExecuteReader();
+            while (r2.Read())
+            {
+                string charName = r2.GetString("character_name");
+                string slot = r2.GetString("slot");
+                string itemName = r2.GetString("item_name");
+                Item? item = CreateItem(itemName);
+                if (item != null)
+                {
+                    if (!_equipment.ContainsKey(charName))
+                        _equipment[charName] = new Dictionary<EquipmentSlot, Item?>();
+                    _equipment[charName][Enum.Parse<EquipmentSlot>(slot)] = item;
+                }
+            }
+        }
+
+        private static Item? CreateItem(string name)
+        {
+            return name switch
+            {
+                "Healing Potion" => new HealingPotion(),
+                _ => WeaponFactory.Create(name.Replace(" ", "").ToLower())
+            };
+        }
 
         public static void AddItem(Item item, int qty = 1)
         {
@@ -34,6 +81,16 @@ namespace WinFormsApp2
             {
                 existing.Quantity += qty;
             }
+            if (_loaded)
+            {
+                using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+                conn.Open();
+                using MySqlCommand cmd = new MySqlCommand("INSERT INTO user_items(account_id,item_name,quantity) VALUES(@id,@name,@qty) ON DUPLICATE KEY UPDATE quantity=quantity+@qty", conn);
+                cmd.Parameters.AddWithValue("@id", _userId);
+                cmd.Parameters.AddWithValue("@name", item.Name);
+                cmd.Parameters.AddWithValue("@qty", qty);
+                cmd.ExecuteNonQuery();
+            }
         }
 
         public static void RemoveItem(Item item, int qty = 1)
@@ -44,6 +101,20 @@ namespace WinFormsApp2
             if (existing.Quantity <= 0)
             {
                 _items.Remove(existing);
+            }
+            if (_loaded)
+            {
+                using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+                conn.Open();
+                using MySqlCommand cmd = new MySqlCommand("UPDATE user_items SET quantity=quantity-@qty WHERE account_id=@id AND item_name=@name", conn);
+                cmd.Parameters.AddWithValue("@qty", qty);
+                cmd.Parameters.AddWithValue("@id", _userId);
+                cmd.Parameters.AddWithValue("@name", item.Name);
+                cmd.ExecuteNonQuery();
+                using MySqlCommand del = new MySqlCommand("DELETE FROM user_items WHERE account_id=@id AND item_name=@name AND quantity<=0", conn);
+                del.Parameters.AddWithValue("@id", _userId);
+                del.Parameters.AddWithValue("@name", item.Name);
+                del.ExecuteNonQuery();
             }
         }
 
@@ -77,6 +148,8 @@ namespace WinFormsApp2
                     AddItem(r);
                 _equipment[character][EquipmentSlot.LeftHand] = item;
                 _equipment[character][EquipmentSlot.RightHand] = item;
+                SaveEquipment(character, EquipmentSlot.LeftHand, item);
+                SaveEquipment(character, EquipmentSlot.RightHand, item);
             }
             else
             {
@@ -86,7 +159,9 @@ namespace WinFormsApp2
                 {
                     AddItem(otherItem);
                     _equipment[character][other] = null;
+                    SaveEquipment(character, other, null);
                 }
+                SaveEquipment(character, slot, item);
             }
         }
 
@@ -128,7 +203,32 @@ namespace WinFormsApp2
                 if (dict.TryGetValue(slot, out var item) && item != null)
                 {
                     dict[slot] = null;
+                    SaveEquipment(character, slot, null);
                 }
+            }
+        }
+
+        private static void SaveEquipment(string character, EquipmentSlot slot, Item? item)
+        {
+            if (!_loaded) return;
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            if (item == null)
+            {
+                using MySqlCommand cmd = new MySqlCommand("DELETE FROM character_equipment WHERE account_id=@id AND character_name=@c AND slot=@s", conn);
+                cmd.Parameters.AddWithValue("@id", _userId);
+                cmd.Parameters.AddWithValue("@c", character);
+                cmd.Parameters.AddWithValue("@s", slot.ToString());
+                cmd.ExecuteNonQuery();
+            }
+            else
+            {
+                using MySqlCommand cmd = new MySqlCommand("REPLACE INTO character_equipment(account_id,character_name,slot,item_name) VALUES(@id,@c,@s,@n)", conn);
+                cmd.Parameters.AddWithValue("@id", _userId);
+                cmd.Parameters.AddWithValue("@c", character);
+                cmd.Parameters.AddWithValue("@s", slot.ToString());
+                cmd.Parameters.AddWithValue("@n", item.Name);
+                cmd.ExecuteNonQuery();
             }
         }
     }

--- a/WinFormsApp2/RecruitCandidate.cs
+++ b/WinFormsApp2/RecruitCandidate.cs
@@ -14,9 +14,10 @@ namespace WinFormsApp2
 
         public static RecruitCandidate Generate(Random rng, int index)
         {
+            string[] names = { "Arin", "Belor", "Ciri", "Doran", "Elaine", "Faris", "Garen", "Hilda", "Iris", "Jorin" };
             var candidate = new RecruitCandidate
             {
-                Name = $"Recruit {index + 1}",
+                Name = names[rng.Next(names.Length)],
                 Strength = 5,
                 Dexterity = 5,
                 Intelligence = 5

--- a/WinFormsApp2/RegisterForm.cs
+++ b/WinFormsApp2/RegisterForm.cs
@@ -13,7 +13,19 @@ namespace WinFormsApp2
 
         private void btnRegister_Click(object? sender, EventArgs e)
         {
-            if (txtPassword.Text != txtConfirmPassword.Text)
+            string user = txtUsername.Text;
+            string pass = txtPassword.Text;
+            if (user.Contains(' ') || pass.Contains(' '))
+            {
+                MessageBox.Show("No spaces allowed in username or password");
+                return;
+            }
+            if (user.Length < 3 || user.Length > 12 || pass.Length < 3 || pass.Length > 12)
+            {
+                MessageBox.Show("Username and password must be 3-12 characters");
+                return;
+            }
+            if (pass != txtConfirmPassword.Text)
             {
                 MessageBox.Show("Passwords do not match");
                 return;
@@ -23,7 +35,7 @@ namespace WinFormsApp2
             conn.Open();
 
             using MySqlCommand check = new MySqlCommand("SELECT COUNT(1) FROM Users WHERE Username=@u", conn);
-            check.Parameters.AddWithValue("@u", txtUsername.Text);
+            check.Parameters.AddWithValue("@u", user);
             int exists = Convert.ToInt32(check.ExecuteScalar());
             if (exists > 0)
             {
@@ -32,8 +44,8 @@ namespace WinFormsApp2
             }
 
             using MySqlCommand insert = new MySqlCommand("INSERT INTO Users (Username, PasswordHash, Gold) VALUES (@u, @p, 300)", conn);
-            insert.Parameters.AddWithValue("@u", txtUsername.Text);
-            insert.Parameters.AddWithValue("@p", Form1.HashPassword(txtPassword.Text));
+            insert.Parameters.AddWithValue("@u", user);
+            insert.Parameters.AddWithValue("@p", Form1.HashPassword(pass));
             insert.ExecuteNonQuery();
 
             MessageBox.Show("Account created");

--- a/inventory_tables.sql
+++ b/inventory_tables.sql
@@ -1,0 +1,19 @@
+-- MySQL script to create tables for storing user inventory and equipment
+USE accounts;
+
+CREATE TABLE IF NOT EXISTS user_items (
+    account_id INT NOT NULL,
+    item_name VARCHAR(255) NOT NULL,
+    quantity INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (account_id, item_name),
+    FOREIGN KEY (account_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS character_equipment (
+    account_id INT NOT NULL,
+    character_name VARCHAR(255) NOT NULL,
+    slot VARCHAR(50) NOT NULL,
+    item_name VARCHAR(255) NOT NULL,
+    PRIMARY KEY (account_id, character_name, slot),
+    FOREIGN KEY (account_id) REFERENCES users(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- Persist inventory and equipment to MySQL and load per user
- Add damage predictions and attack stats to hero inspection
- Redesign battle view with progress bars and end-of-battle summary
- Provide SQL schema for inventory and equipment tables

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet build WinFormsApp2/WinFormsApp2.csproj -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897fba0643483338bf981fe7ee54dc3