### PR TITLE
Ensure HP regen tick stability and balance enemy encounter levels

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -58,18 +58,24 @@ namespace WinFormsApp2
             }
 
             int totalLevel = _players.Sum(p => p.Level);
-            int targetLevel = (int)Math.Ceiling(totalLevel * 1.25);
+            int minLevel = (int)Math.Floor(totalLevel * 0.7);
+            int maxLevel = (int)Math.Ceiling(totalLevel * 1.2);
             int npcLevel = 0;
-            while (npcLevel < targetLevel)
+            while (npcLevel < minLevel)
             {
                 using var npcCmd = new MySqlCommand("SELECT name, level, current_hp, max_hp, strength, dex, action_speed, melee_defense, role, targeting_style FROM npcs ORDER BY RAND() LIMIT 1", conn);
                 using var r2 = npcCmd.ExecuteReader();
                 if (r2.Read())
                 {
+                    int level = r2.GetInt32("level");
+                    if (npcLevel + level > maxLevel)
+                    {
+                        continue;
+                    }
                     var npc = new Creature
                     {
                         Name = r2.GetString("name"),
-                        Level = r2.GetInt32("level"),
+                        Level = level,
                         CurrentHp = r2.GetInt32("current_hp"),
                         MaxHp = r2.GetInt32("max_hp"),
                         Strength = r2.GetInt32("strength"),
@@ -80,7 +86,7 @@ namespace WinFormsApp2
                         TargetingStyle = r2.GetString("targeting_style")
                     };
                     _npcs.Add(npc);
-                    npcLevel += npc.Level;
+                    npcLevel += level;
                 }
             }
         }

--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -164,10 +164,16 @@ namespace WinFormsApp2
         {
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using MySqlCommand cmd = new MySqlCommand("UPDATE characters SET current_hp = LEAST(max_hp, current_hp + CEILING(max_hp*0.05)) WHERE account_id=@id AND current_hp>0 AND current_hp<max_hp", conn);
+            using MySqlCommand cmd = new MySqlCommand("UPDATE characters SET current_hp = LEAST(max_hp, current_hp + GREATEST(10, CEILING(max_hp*0.05))) WHERE account_id=@id AND current_hp>0 AND current_hp<max_hp", conn);
             cmd.Parameters.AddWithValue("@id", _userId);
             cmd.ExecuteNonQuery();
+
+            int selectedIndex = lstParty.SelectedIndex;
             LoadPartyData();
+            if (selectedIndex >= 0 && selectedIndex < lstParty.Items.Count)
+            {
+                lstParty.SelectedIndex = selectedIndex;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Preserve party selection when regeneration ticks while keeping at least 10 HP per tick
- Match enemy party total levels to 70%-120% of the player party

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898045ac7848333be96cabba772be75