### PR TITLE
Add ability slot system with priorities and battle summary flow

### DIFF
--- a/WinFormsApp2/Ability.cs
+++ b/WinFormsApp2/Ability.cs
@@ -6,5 +6,7 @@ namespace WinFormsApp2
         public string Name { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
         public int Cost { get; set; }
+        public int Slot { get; set; }
+        public int Priority { get; set; }
     }
 }

--- a/WinFormsApp2/AbilityService.cs
+++ b/WinFormsApp2/AbilityService.cs
@@ -1,4 +1,5 @@
 using MySql.Data.MySqlClient;
+using System;
 using System.Collections.Generic;
 
 namespace WinFormsApp2
@@ -31,6 +32,68 @@ namespace WinFormsApp2
             using var cmd = new MySqlCommand("INSERT INTO character_abilities(character_id, ability_id) VALUES(@c,@a)", conn);
             cmd.Parameters.AddWithValue("@c", characterId);
             cmd.Parameters.AddWithValue("@a", abilityId);
+            cmd.ExecuteNonQuery();
+        }
+
+        public static List<Ability> GetCharacterAbilities(int characterId, MySqlConnection conn)
+        {
+            using var cmd = new MySqlCommand(@"SELECT a.id, a.name, a.description, a.cost
+                                               FROM abilities a
+                                               JOIN character_abilities ca ON ca.ability_id = a.id
+                                               WHERE ca.character_id=@cid", conn);
+            cmd.Parameters.AddWithValue("@cid", characterId);
+            using var reader = cmd.ExecuteReader();
+            var list = new List<Ability>();
+            while (reader.Read())
+            {
+                list.Add(new Ability
+                {
+                    Id = reader.GetInt32("id"),
+                    Name = reader.GetString("name"),
+                    Description = reader.GetString("description"),
+                    Cost = reader.GetInt32("cost")
+                });
+            }
+            return list;
+        }
+
+        public static List<Ability> GetEquippedAbilities(int characterId, MySqlConnection conn)
+        {
+            using var cmd = new MySqlCommand(@"SELECT slot, priority, a.id, a.name, a.description, a.cost
+                                               FROM character_ability_slots s
+                                               LEFT JOIN abilities a ON s.ability_id = a.id
+                                               WHERE s.character_id=@cid", conn);
+            cmd.Parameters.AddWithValue("@cid", characterId);
+            using var reader = cmd.ExecuteReader();
+            var list = new List<Ability>();
+            while (reader.Read())
+            {
+                var ability = new Ability
+                {
+                    Slot = reader.GetInt32("slot"),
+                    Priority = reader.GetInt32("priority"),
+                    Id = reader.IsDBNull(reader.GetOrdinal("id")) ? 0 : reader.GetInt32("id"),
+                    Name = reader.IsDBNull(reader.GetOrdinal("name")) ? "-basic attack-" : reader.GetString("name"),
+                    Description = reader.IsDBNull(reader.GetOrdinal("description")) ? string.Empty : reader.GetString("description"),
+                    Cost = reader.IsDBNull(reader.GetOrdinal("cost")) ? 0 : reader.GetInt32("cost")
+                };
+                list.Add(ability);
+            }
+            return list;
+        }
+
+        public static void SetAbilitySlot(int characterId, int slot, int? abilityId, int priority, MySqlConnection conn)
+        {
+            using var cmd = new MySqlCommand(@"INSERT INTO character_ability_slots(character_id, slot, ability_id, priority)
+                                               VALUES(@c,@s,@a,@p)
+                                               ON DUPLICATE KEY UPDATE ability_id=@a, priority=@p", conn);
+            cmd.Parameters.AddWithValue("@c", characterId);
+            cmd.Parameters.AddWithValue("@s", slot);
+            if (abilityId.HasValue)
+                cmd.Parameters.AddWithValue("@a", abilityId.Value);
+            else
+                cmd.Parameters.AddWithValue("@a", DBNull.Value);
+            cmd.Parameters.AddWithValue("@p", priority);
             cmd.ExecuteNonQuery();
         }
     }

--- a/WinFormsApp2/BattleSummaryForm.cs
+++ b/WinFormsApp2/BattleSummaryForm.cs
@@ -6,14 +6,20 @@ namespace WinFormsApp2
     public class BattleSummaryForm : Form
     {
         private readonly ListBox _list = new();
+        private readonly Button _btnContinue = new();
 
         public BattleSummaryForm(IEnumerable<CombatantSummary> players, IEnumerable<CombatantSummary> enemies)
         {
             Text = "Battle Summary";
             Width = 400;
             Height = 300;
-            _list.Dock = DockStyle.Fill;
+            _list.Dock = DockStyle.Top;
+            _list.Height = 230;
             Controls.Add(_list);
+            _btnContinue.Text = "Continue";
+            _btnContinue.Dock = DockStyle.Bottom;
+            _btnContinue.Click += (s, e) => Close();
+            Controls.Add(_btnContinue);
             foreach (var p in players)
             {
                 _list.Items.Add($"{p.Name} - Damage Done: {p.DamageDone}, Damage Taken: {p.DamageTaken}");

--- a/abilities.sql
+++ b/abilities.sql
@@ -16,6 +16,16 @@ CREATE TABLE IF NOT EXISTS character_abilities (
     FOREIGN KEY (ability_id) REFERENCES abilities(id)
 );
 
+CREATE TABLE IF NOT EXISTS character_ability_slots (
+    character_id INT NOT NULL,
+    slot TINYINT NOT NULL,
+    ability_id INT NULL,
+    priority INT NOT NULL DEFAULT 1,
+    PRIMARY KEY(character_id, slot),
+    FOREIGN KEY (character_id) REFERENCES characters(id),
+    FOREIGN KEY (ability_id) REFERENCES abilities(id)
+);
+
 INSERT INTO abilities (name, description, cost) VALUES
 ('Fireball', 'Deal fire damage to a single enemy.', 50),
 ('Heal', 'Restore a small amount of HP to an ally.', 30);


### PR DESCRIPTION
## Summary
- add slot and priority fields to abilities with storage and services
- allow party members to assign abilities with priority in inspection screen
- update battle logic to use prioritized abilities costing mana
- add continue button to battle summary and auto close battle window

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898082fa93483339baa659157a6c749