### PR TITLE
Make equipment stackable and show spell info in rich text box

### DIFF
--- a/WinFormsApp2/LevelUpForm.Designer.cs
+++ b/WinFormsApp2/LevelUpForm.Designer.cs
@@ -9,6 +9,7 @@ namespace WinFormsApp2
         private Label lblPoints;
         private Label lblGold;
         private ListBox lstAbilities;
+        private RichTextBox rtbAbility;
         private Button btnBuy;
         private Button btnSave;
         private ListBox lstPassives;
@@ -71,6 +72,17 @@ namespace WinFormsApp2
             lstAbilities.Name = "lstAbilities";
             lstAbilities.Size = new Size(213, 179);
             lstAbilities.TabIndex = 1;
+
+            // rtbAbility
+            //
+            rtbAbility = new RichTextBox();
+            rtbAbility.Location = new Point(180, 197);
+            rtbAbility.Margin = new Padding(4, 5, 4, 5);
+            rtbAbility.Name = "rtbAbility";
+            rtbAbility.ReadOnly = true;
+            rtbAbility.Size = new Size(213, 110);
+            rtbAbility.TabIndex = 13;
+            rtbAbility.Text = "";
             //
             // lstPassives
             //
@@ -84,7 +96,7 @@ namespace WinFormsApp2
             // 
             // btnBuy
             // 
-            btnBuy.Location = new Point(179, 197);
+            btnBuy.Location = new Point(179, 315);
             btnBuy.Margin = new Padding(4, 5, 4, 5);
             btnBuy.Name = "btnBuy";
             btnBuy.Size = new Size(214, 38);
@@ -168,10 +180,11 @@ namespace WinFormsApp2
             // 
             AutoScaleDimensions = new SizeF(10F, 25F);
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(630, 250);
+            ClientSize = new Size(630, 370);
             Controls.Add(btnBuyPassive);
             Controls.Add(lstPassives);
             Controls.Add(btnBuy);
+            Controls.Add(rtbAbility);
             Controls.Add(lstAbilities);
             Controls.Add(lblGold);
             Controls.Add(btnSave);

--- a/WinFormsApp2/LevelUpForm.cs
+++ b/WinFormsApp2/LevelUpForm.cs
@@ -29,6 +29,7 @@ namespace WinFormsApp2
             btnBuy.Click += BtnBuy_Click;
             btnBuyPassive.Click += BtnBuyPassive_Click;
             btnSave.Click += BtnSave_Click;
+            lstAbilities.SelectedIndexChanged += LstAbilities_SelectedIndexChanged;
             Load += LevelUpForm_Load;
         }
 
@@ -72,8 +73,9 @@ namespace WinFormsApp2
             lstAbilities.Items.Clear();
             foreach (var a in _abilities)
             {
-                lstAbilities.Items.Add($"{a.Name}: {a.Description} Cooldown: {a.Cooldown}s, Mana Cost: {a.Cost}");
+                lstAbilities.Items.Add(a.Name);
             }
+            rtbAbility.Clear();
             _passives = PassiveService.GetPassives(_characterId, conn);
             lstPassives.Items.Clear();
             foreach (var p in _passives)
@@ -111,8 +113,9 @@ namespace WinFormsApp2
             lstAbilities.Items.Clear();
             foreach (var a in _abilities)
             {
-                lstAbilities.Items.Add($"{a.Name}: {a.Description} Cooldown: {a.Cooldown}s, Mana Cost: {a.Cost}");
+                lstAbilities.Items.Add(a.Name);
             }
+            rtbAbility.Clear();
         }
 
         private void BtnBuyPassive_Click(object? sender, EventArgs e)
@@ -136,6 +139,17 @@ namespace WinFormsApp2
             {
                 lstPassives.Items.Add($"{p.Name} (Lv {p.Level}) - Cost: {p.Level + 1}\n{p.Description}");
             }
+        }
+
+        private void LstAbilities_SelectedIndexChanged(object? sender, EventArgs e)
+        {
+            if (lstAbilities.SelectedIndex < 0)
+            {
+                rtbAbility.Clear();
+                return;
+            }
+            var ability = _abilities[lstAbilities.SelectedIndex];
+            rtbAbility.Text = $"{ability.Description}\nCooldown: {ability.Cooldown}s\nMana Cost: {ability.Cost}";
         }
 
         private void BtnSave_Click(object? sender, EventArgs e)

--- a/WinFormsApp2/Weapon.cs
+++ b/WinFormsApp2/Weapon.cs
@@ -2,6 +2,10 @@ namespace WinFormsApp2
 {
     public class Weapon : Item
     {
+        public Weapon()
+        {
+            Stackable = true;
+        }
         public double StrScaling { get; init; }
         public double DexScaling { get; init; }
         public double IntScaling { get; init; }


### PR DESCRIPTION
## Summary
- Stack weapons by default so duplicate gear combines in inventory displays
- Show detailed ability descriptions in a dedicated RichTextBox when purchasing skills

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.csproj -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b839f330c8333aa15132dbf95fa07