### PR TITLE
Prevent new hires from inheriting dead heroes' skills

### DIFF
--- a/WinFormsApp2/HeroViewForm.cs
+++ b/WinFormsApp2/HeroViewForm.cs
@@ -73,6 +73,17 @@ namespace WinFormsApp2
                 MessageBox.Show("Name must be 3-12 characters with no spaces");
                 return;
             }
+            using (MySqlCommand check = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@acc AND name=@name", conn))
+            {
+                check.Parameters.AddWithValue("@acc", _userId);
+                check.Parameters.AddWithValue("@name", name);
+                int exists = Convert.ToInt32(check.ExecuteScalar());
+                if (exists > 0)
+                {
+                    MessageBox.Show("A hero with that name already exists.");
+                    return;
+                }
+            }
             insert.Parameters.AddWithValue("@name", name);
             insert.Parameters.AddWithValue("@hp", hp);
             insert.Parameters.AddWithValue("@maxHp", hp);

--- a/WinFormsApp2/InventoryForm.cs
+++ b/WinFormsApp2/InventoryForm.cs
@@ -64,7 +64,7 @@ namespace WinFormsApp2
             {
                 using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
                 conn.Open();
-                using MySqlCommand cmd = new MySqlCommand("UPDATE characters SET current_hp = LEAST(max_hp, current_hp + @heal) WHERE account_id=@uid AND name=@name", conn);
+                using MySqlCommand cmd = new MySqlCommand("UPDATE characters SET current_hp = LEAST(max_hp, current_hp + @heal) WHERE account_id=@uid AND name=@name AND is_dead=0", conn);
                 cmd.Parameters.AddWithValue("@heal", ((HealingPotion)item).HealAmount);
                 cmd.Parameters.AddWithValue("@uid", _userId);
                 cmd.Parameters.AddWithValue("@name", _selectedTarget);
@@ -79,7 +79,7 @@ namespace WinFormsApp2
             cmbTarget.Items.Clear();
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using MySqlCommand cmd = new MySqlCommand("SELECT name FROM characters WHERE account_id=@id", conn);
+            using MySqlCommand cmd = new MySqlCommand("SELECT name FROM characters WHERE account_id=@id AND is_dead=0", conn);
             cmd.Parameters.AddWithValue("@id", _userId);
             using var r = cmd.ExecuteReader();
             while (r.Read())

--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -155,7 +155,7 @@ namespace WinFormsApp2
 
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using MySqlCommand cmd = new MySqlCommand("SELECT id FROM characters WHERE account_id=@id AND name=@name", conn);
+            using MySqlCommand cmd = new MySqlCommand("SELECT id FROM characters WHERE account_id=@id AND name=@name AND is_dead=0", conn);
             cmd.Parameters.AddWithValue("@id", _userId);
             cmd.Parameters.AddWithValue("@name", name);
             object? result = cmd.ExecuteScalar();


### PR DESCRIPTION
## Summary
- Ensure recruited heroes have unique names and block duplicates
- Only load living heroes when inspecting or using inventory items

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ba1da58d483339cf687918f1d778c