### PR TITLE
Default item text color to black

### DIFF
--- a/WinFormsApp2/Item.cs
+++ b/WinFormsApp2/Item.cs
@@ -14,7 +14,7 @@ namespace WinFormsApp2
         public Dictionary<string, int> FlatBonuses { get; } = new();
         public Dictionary<string, int> PercentBonuses { get; } = new();
         public int TotalPoints { get; set; }
-        public Color NameColor { get; set; } = Color.White;
+        public Color NameColor { get; set; } = Color.Black;
         public List<Color>? RainbowColors { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- ensure new items render with black text by default

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bb7c5f2048333b770af1240551b7c