### PR TITLE
Initialize battle log control to prevent null reference

### DIFF
--- a/WinFormsApp2/BattleForm.Designer.cs
+++ b/WinFormsApp2/BattleForm.Designer.cs
@@ -23,6 +23,7 @@ namespace WinFormsApp2
         {
             pnlPlayers = new FlowLayoutPanel();
             pnlEnemies = new FlowLayoutPanel();
+            rtbLog = new RichTextBox();
             SuspendLayout();
             // 
             // pnlPlayers


### PR DESCRIPTION
## Summary
- Fix NullReferenceException in `BattleForm` by instantiating `rtbLog`

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_689bcb1b08d08333a124a4bdfdb9c283