### PR TITLE
Allow item properties to be modified after construction

### DIFF
--- a/WinFormsApp2/Item.cs
+++ b/WinFormsApp2/Item.cs
@@ -5,9 +5,9 @@ namespace WinFormsApp2
 {
     public abstract class Item
     {
-        public string Name { get; init; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
         public string Description { get; init; } = string.Empty;
-        public bool Stackable { get; init; }
+        public bool Stackable { get; set; }
         public EquipmentSlot? Slot { get; init; }
         public int Price { get; init; }
 


### PR DESCRIPTION
## Summary
- make `Item.Name` and `Item.Stackable` writable so they can be changed after creation

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bef0b89448333a5e25657fc21b813