### PR TITLE
Ensure battles end when damage-over-time kills last foe

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -337,6 +337,7 @@ namespace WinFormsApp2
                         }
                     }
                 }
+                CheckEnd();
             };
             _progressTimer.Start();
         }


### PR DESCRIPTION
## Summary
- Call `CheckEnd()` after processing periodic effects so battles conclude when DoT damage defeats a combatant

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad064b8e70833390ff102d2af3e6b1