### PR TITLE
Ensure battles end on DoT and prompt to send dead allies only once

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -337,6 +337,7 @@ namespace WinFormsApp2
                         }
                     }
                 }
+                CheckEnd();
             };
             _progressTimer.Start();
         }
@@ -729,6 +730,7 @@ namespace WinFormsApp2
             if (_players.All(p => p.CurrentHp <= 0) || _npcs.All(n => n.CurrentHp <= 0))
             {
                 foreach (var t in _timers.Values) t.Stop();
+                _progressTimer.Stop();
                 bool playersWin = _players.Any(p => p.CurrentHp > 0);
                 string lootSummary = string.Empty;
                 AppendLog(playersWin ? "Players win!" : "NPCs win!", playersWin);


### PR DESCRIPTION
## Summary
- Stop progress timer when the battle concludes to prevent repeated graveyard prompts
- (From earlier) Call `CheckEnd()` after periodic effects so battles finish when damage-over-time kills the last combatant

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build WinFormsApp2/WinFormsApp2.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ad064b8e70833390ff102d2af3e6b1