### PR TITLE
Use owned passives when loading battle data

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -96,10 +96,8 @@ namespace WinFormsApp2
                 {
                     kv.Key.Abilities.Add(new Ability { Id = 0, Name = "-basic attack-", Priority = 1, Cost = 0, Slot = 1 });
                 }
-                foreach (var p in PassiveService.GetCharacterPassives(kv.Value, conn))
-                {
-                    kv.Key.Passives[p.Key] = p.Value;
-                }
+                foreach (var p in PassiveService.GetOwnedPassives(kv.Value, conn))
+                    kv.Key.Passives[p.Name] = p.Level;
             }
 
             int totalLevel = _players.Sum(p => p.Level);


### PR DESCRIPTION
## Summary
- load passives in battle form using `GetOwnedPassives`
- store passive name and level in creature dictionary

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad123846b88333a04e6f74c78ed6f3