### PR TITLE
Use read-only shop description box and add fire confirmation

### DIFF
--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -172,11 +172,38 @@ namespace WinFormsApp2
             }
         }
 
+        private bool ConfirmFire(string name)
+        {
+            using var confirm = new Form
+            {
+                Width = 300,
+                Height = 150,
+                FormBorderStyle = FormBorderStyle.FixedDialog,
+                Text = "Confirm Fire",
+                StartPosition = FormStartPosition.CenterParent
+            };
+
+            var lbl = new Label { Left = 10, Top = 10, Width = 260, Text = $"Type '{name}' to confirm firing:" };
+            var txt = new TextBox { Left = 10, Top = 40, Width = 260 };
+            var btn = new Button { Text = "Confirm", Left = 10, Top = 70, Width = 100, DialogResult = DialogResult.OK, Enabled = false };
+            btn.Click += (s, e) => confirm.Close();
+            txt.TextChanged += (s, e) => btn.Enabled = txt.Text == name;
+
+            confirm.Controls.Add(lbl);
+            confirm.Controls.Add(txt);
+            confirm.Controls.Add(btn);
+            confirm.AcceptButton = btn;
+
+            return confirm.ShowDialog(this) == DialogResult.OK;
+        }
+
         private void btnFire_Click(object? sender, EventArgs e)
         {
             if (lstParty.SelectedItem == null) return;
             string item = lstParty.SelectedItem.ToString() ?? string.Empty;
             string name = item.Split(" - ")[0];
+
+            if (!ConfirmFire(name)) return;
 
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();

--- a/WinFormsApp2/ShopForm.Designer.cs
+++ b/WinFormsApp2/ShopForm.Designer.cs
@@ -11,7 +11,6 @@ namespace WinFormsApp2
         private Button _btnBuy;
         private Button _btnSell;
         private Label _lblGold;
-        private Label _lblDescription;
 
         protected override void Dispose(bool disposing)
         {
@@ -29,7 +28,6 @@ namespace WinFormsApp2
             _btnBuy = new Button();
             _btnSell = new Button();
             _lblGold = new Label();
-            _lblDescription = new Label();
             label1 = new Label();
             label2 = new Label();
             shopDescBox = new RichTextBox();
@@ -75,16 +73,9 @@ namespace WinFormsApp2
             _lblGold.Size = new Size(35, 15);
             _lblGold.TabIndex = 0;
             _lblGold.Text = "Gold:";
-            // 
-            // _lblDescription
-            // 
-            _lblDescription.Location = new Point(10, 373);
-            _lblDescription.Name = "_lblDescription";
-            _lblDescription.Size = new Size(568, 40);
-            _lblDescription.TabIndex = 5;
-            // 
+            //
             // label1
-            // 
+            //
             label1.AutoSize = true;
             label1.Font = new Font("Segoe UI", 12F, FontStyle.Bold, GraphicsUnit.Point, 0);
             label1.Location = new Point(73, 1);
@@ -107,6 +98,8 @@ namespace WinFormsApp2
             // 
             shopDescBox.Location = new Point(10, 170);
             shopDescBox.Name = "shopDescBox";
+            shopDescBox.ReadOnly = true;
+            shopDescBox.BackColor = SystemColors.Window;
             shopDescBox.Size = new Size(570, 48);
             shopDescBox.TabIndex = 8;
             shopDescBox.Text = "";
@@ -119,7 +112,6 @@ namespace WinFormsApp2
             Controls.Add(shopDescBox);
             Controls.Add(label2);
             Controls.Add(label1);
-            Controls.Add(_lblDescription);
             Controls.Add(_lblGold);
             Controls.Add(_btnSell);
             Controls.Add(_btnBuy);

--- a/WinFormsApp2/ShopForm.cs
+++ b/WinFormsApp2/ShopForm.cs
@@ -85,18 +85,18 @@ namespace WinFormsApp2
         {
             int index = _lstShop.SelectedIndex;
             if (index >= 0 && index < _shopItems.Count)
-                _lblDescription.Text = DescribeItem(_shopItems[index]);
+                shopDescBox.Text = DescribeItem(_shopItems[index]);
             else
-                _lblDescription.Text = string.Empty;
+                shopDescBox.Text = string.Empty;
         }
 
         private void ShowInventoryDesc()
         {
             int index = _lstInventory.SelectedIndex;
             if (index >= 0 && index < InventoryService.Items.Count)
-                _lblDescription.Text = DescribeItem(InventoryService.Items[index].Item);
+                shopDescBox.Text = DescribeItem(InventoryService.Items[index].Item);
             else
-                _lblDescription.Text = string.Empty;
+                shopDescBox.Text = string.Empty;
         }
 
         private string DescribeItem(Item item)


### PR DESCRIPTION
## Summary
- Display selected item descriptions in a read-only `shopDescBox`
- Prompt for party member name confirmation before firing

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad178a1e5483338eabdc63a76b9b23