### PR TITLE
Add world map travel scaffolding with nodes and persistence

### DIFF
--- a/WinFormsApp2/NavigationWindow.Designer.cs
+++ b/WinFormsApp2/NavigationWindow.Designer.cs
@@ -43,6 +43,11 @@
             tabControl1 = new TabControl();
             tabPage1 = new TabPage();
             Travel = new TabPage();
+            lstActivities = new ListBox();
+            lstConnections = new ListBox();
+            btnBeginTravel = new Button();
+            travelProgressBar = new ProgressBar();
+            lblTravelInfo = new Label();
             ((System.ComponentModel.ISupportInitialize)pictureBox1).BeginInit();
             tabControl1.SuspendLayout();
             SuspendLayout();
@@ -65,6 +70,8 @@
             nodeRiverVillage.Size = new Size(14, 13);
             nodeRiverVillage.TabIndex = 1;
             nodeRiverVillage.TabStop = true;
+            nodeRiverVillage.AutoCheck = false;
+            nodeRiverVillage.Enabled = false;
             nodeRiverVillage.UseVisualStyleBackColor = false;
             // 
             // nodeMounttown
@@ -76,6 +83,8 @@
             nodeMounttown.Size = new Size(14, 13);
             nodeMounttown.TabIndex = 2;
             nodeMounttown.TabStop = true;
+            nodeMounttown.AutoCheck = false;
+            nodeMounttown.Enabled = false;
             nodeMounttown.UseVisualStyleBackColor = false;
             // 
             // nodeDesert
@@ -87,6 +96,8 @@
             nodeDesert.Size = new Size(14, 13);
             nodeDesert.TabIndex = 3;
             nodeDesert.TabStop = true;
+            nodeDesert.AutoCheck = false;
+            nodeDesert.Enabled = false;
             nodeDesert.UseVisualStyleBackColor = false;
             // 
             // nodeDarkSpire
@@ -98,6 +109,8 @@
             nodeDarkSpire.Size = new Size(14, 13);
             nodeDarkSpire.TabIndex = 4;
             nodeDarkSpire.TabStop = true;
+            nodeDarkSpire.AutoCheck = false;
+            nodeDarkSpire.Enabled = false;
             nodeDarkSpire.UseVisualStyleBackColor = false;
             // 
             // nodeSouthernIsland
@@ -109,6 +122,8 @@
             nodeSouthernIsland.Size = new Size(14, 13);
             nodeSouthernIsland.TabIndex = 5;
             nodeSouthernIsland.TabStop = true;
+            nodeSouthernIsland.AutoCheck = false;
+            nodeSouthernIsland.Enabled = false;
             nodeSouthernIsland.UseVisualStyleBackColor = false;
             // 
             // nodeMountain
@@ -120,6 +135,8 @@
             nodeMountain.Size = new Size(14, 13);
             nodeMountain.TabIndex = 6;
             nodeMountain.TabStop = true;
+            nodeMountain.AutoCheck = false;
+            nodeMountain.Enabled = false;
             nodeMountain.UseVisualStyleBackColor = false;
             // 
             // nodeForestPlains
@@ -131,6 +148,8 @@
             nodeForestPlains.Size = new Size(14, 13);
             nodeForestPlains.TabIndex = 7;
             nodeForestPlains.TabStop = true;
+            nodeForestPlains.AutoCheck = false;
+            nodeForestPlains.Enabled = false;
             nodeForestPlains.UseVisualStyleBackColor = false;
             // 
             // nodeNorthernIsland
@@ -142,6 +161,8 @@
             nodeNorthernIsland.Size = new Size(14, 13);
             nodeNorthernIsland.TabIndex = 8;
             nodeNorthernIsland.TabStop = true;
+            nodeNorthernIsland.AutoCheck = false;
+            nodeNorthernIsland.Enabled = false;
             nodeNorthernIsland.UseVisualStyleBackColor = false;
             // 
             // nodeFarCliffs
@@ -153,6 +174,8 @@
             nodeFarCliffs.Size = new Size(14, 13);
             nodeFarCliffs.TabIndex = 9;
             nodeFarCliffs.TabStop = true;
+            nodeFarCliffs.AutoCheck = false;
+            nodeFarCliffs.Enabled = false;
             nodeFarCliffs.UseVisualStyleBackColor = false;
             // 
             // nodeSmallVillage
@@ -164,6 +187,8 @@
             nodeSmallVillage.Size = new Size(14, 13);
             nodeSmallVillage.TabIndex = 10;
             nodeSmallVillage.TabStop = true;
+            nodeSmallVillage.AutoCheck = false;
+            nodeSmallVillage.Enabled = false;
             nodeSmallVillage.UseVisualStyleBackColor = false;
             // 
             // nodeForestValley
@@ -175,6 +200,8 @@
             nodeForestValley.Size = new Size(14, 13);
             nodeForestValley.TabIndex = 11;
             nodeForestValley.TabStop = true;
+            nodeForestValley.AutoCheck = false;
+            nodeForestValley.Enabled = false;
             nodeForestValley.UseVisualStyleBackColor = false;
             // 
             // tabControl1
@@ -188,7 +215,8 @@
             tabControl1.TabIndex = 12;
             // 
             // tabPage1
-            // 
+            //
+            tabPage1.Controls.Add(lstActivities);
             tabPage1.Location = new Point(4, 24);
             tabPage1.Name = "tabPage1";
             tabPage1.Padding = new Padding(3);
@@ -196,9 +224,23 @@
             tabPage1.TabIndex = 0;
             tabPage1.Text = "Activities";
             tabPage1.UseVisualStyleBackColor = true;
+            //
+            // lstActivities
+            //
+            lstActivities.Dock = DockStyle.Fill;
+            lstActivities.FormattingEnabled = true;
+            lstActivities.ItemHeight = 15;
+            lstActivities.Location = new Point(3, 3);
+            lstActivities.Name = "lstActivities";
+            lstActivities.Size = new Size(425, 583);
+            lstActivities.TabIndex = 0;
             // 
             // Travel
-            // 
+            //
+            Travel.Controls.Add(lblTravelInfo);
+            Travel.Controls.Add(travelProgressBar);
+            Travel.Controls.Add(btnBeginTravel);
+            Travel.Controls.Add(lstConnections);
             Travel.Location = new Point(4, 24);
             Travel.Name = "Travel";
             Travel.Padding = new Padding(3);
@@ -206,6 +248,40 @@
             Travel.TabIndex = 1;
             Travel.Text = "Travel";
             Travel.UseVisualStyleBackColor = true;
+            //
+            // lstConnections
+            //
+            lstConnections.FormattingEnabled = true;
+            lstConnections.ItemHeight = 15;
+            lstConnections.Location = new Point(6, 6);
+            lstConnections.Name = "lstConnections";
+            lstConnections.Size = new Size(417, 199);
+            lstConnections.TabIndex = 0;
+            //
+            // btnBeginTravel
+            //
+            btnBeginTravel.Location = new Point(6, 211);
+            btnBeginTravel.Name = "btnBeginTravel";
+            btnBeginTravel.Size = new Size(150, 23);
+            btnBeginTravel.TabIndex = 1;
+            btnBeginTravel.Text = "Begin Travel";
+            btnBeginTravel.UseVisualStyleBackColor = true;
+            btnBeginTravel.Click += btnBeginTravel_Click;
+            //
+            // travelProgressBar
+            //
+            travelProgressBar.Location = new Point(6, 240);
+            travelProgressBar.Name = "travelProgressBar";
+            travelProgressBar.Size = new Size(417, 23);
+            travelProgressBar.TabIndex = 2;
+            //
+            // lblTravelInfo
+            //
+            lblTravelInfo.AutoSize = true;
+            lblTravelInfo.Location = new Point(6, 266);
+            lblTravelInfo.Name = "lblTravelInfo";
+            lblTravelInfo.Size = new Size(0, 15);
+            lblTravelInfo.TabIndex = 3;
             // 
             // NavigationWindow
             // 
@@ -250,5 +326,10 @@
         private TabControl tabControl1;
         private TabPage tabPage1;
         private TabPage Travel;
+        private ListBox lstActivities;
+        private ListBox lstConnections;
+        private Button btnBeginTravel;
+        private ProgressBar travelProgressBar;
+        private Label lblTravelInfo;
     }
 }

--- a/WinFormsApp2/NavigationWindow.cs
+++ b/WinFormsApp2/NavigationWindow.cs
@@ -12,9 +12,81 @@ namespace WinFormsApp2
 {
     public partial class NavigationWindow : Form
     {
-        public NavigationWindow()
+        private readonly int _accountId;
+        private readonly int _partySize;
+        private bool _hasBlessing;
+        private string _currentNode = "nodeMounttown";
+        private readonly TravelManager _travelManager;
+
+        private class ConnectionItem
         {
+            public string Id { get; }
+            private readonly string _display;
+            public ConnectionItem(string id, string display)
+            {
+                Id = id;
+                _display = display;
+            }
+            public override string ToString() => _display;
+        }
+
+        public NavigationWindow(int accountId, int partySize, bool hasBlessing)
+        {
+            _accountId = accountId;
+            _partySize = partySize;
+            _hasBlessing = hasBlessing;
             InitializeComponent();
+            _travelManager = new TravelManager(_accountId);
+            _travelManager.ProgressChanged += TravelManager_ProgressChanged;
+            _travelManager.TravelCompleted += TravelManager_TravelCompleted;
+            LoadNode(_currentNode);
+            _travelManager.Resume();
+        }
+
+        public NavigationWindow() : this(0, 0, false) { }
+
+        private void LoadNode(string id)
+        {
+            _currentNode = id;
+            foreach (var rb in Controls.OfType<RadioButton>())
+            {
+                rb.Checked = rb.Name == id;
+            }
+            var node = WorldMapService.GetNode(id);
+            lstActivities.Items.Clear();
+            foreach (var act in node.Activities)
+            {
+                lstActivities.Items.Add(act);
+            }
+            lstConnections.Items.Clear();
+            foreach (var (dest, days) in WorldMapService.GetConnections(id))
+            {
+                lstConnections.Items.Add(new ConnectionItem(dest.Id, $"{dest.Name} - {days} day(s)"));
+            }
+            travelProgressBar.Value = 0;
+            lblTravelInfo.Text = string.Empty;
+        }
+
+        private void btnBeginTravel_Click(object? sender, EventArgs e)
+        {
+            if (lstConnections.SelectedItem is ConnectionItem item)
+            {
+                _travelManager.StartTravel(_currentNode, item.Id, _partySize, _hasBlessing);
+                lblTravelInfo.Text = $"Traveling to {item.ToString()}";
+            }
+        }
+
+        private void TravelManager_ProgressChanged(int percent)
+        {
+            if (percent < 0) percent = 0;
+            if (percent > 100) percent = 100;
+            travelProgressBar.Value = percent;
+        }
+
+        private void TravelManager_TravelCompleted(string nodeId)
+        {
+            LoadNode(nodeId);
+            lblTravelInfo.Text = "Arrived.";
         }
     }
 }

--- a/WinFormsApp2/NotificationForm.cs
+++ b/WinFormsApp2/NotificationForm.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace WinFormsApp2
+{
+    /// <summary>
+    /// Simple expandable notification list. Entries can be removed
+    /// individually.
+    /// </summary>
+    public class NotificationForm : Form
+    {
+        private readonly ListBox _list = new ListBox();
+        private readonly Button _remove = new Button();
+
+        public NotificationForm()
+        {
+            Text = "Notifications";
+            Width = 300;
+            Height = 400;
+            _list.Dock = DockStyle.Fill;
+            _remove.Text = "Remove";
+            _remove.Dock = DockStyle.Bottom;
+            _remove.Click += (s, e) => { if (_list.SelectedIndex >= 0) _list.Items.RemoveAt(_list.SelectedIndex); };
+            Controls.Add(_list);
+            Controls.Add(_remove);
+        }
+
+        public void LoadNotifications(IEnumerable<string> notes)
+        {
+            _list.Items.Clear();
+            foreach (var n in notes) _list.Items.Add(n);
+        }
+    }
+}

--- a/WinFormsApp2/QuestLogForm.cs
+++ b/WinFormsApp2/QuestLogForm.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace WinFormsApp2
+{
+    /// <summary>
+    /// Displays active quests with ability to abandon entries.
+    /// </summary>
+    public class QuestLogForm : Form
+    {
+        private readonly ListBox _list = new ListBox();
+        private readonly Button _abandon = new Button();
+
+        public QuestLogForm()
+        {
+            Text = "Quest Log";
+            Width = 300;
+            Height = 400;
+            _list.Dock = DockStyle.Fill;
+            _abandon.Text = "Abandon";
+            _abandon.Dock = DockStyle.Bottom;
+            _abandon.Click += (s, e) => { if (_list.SelectedIndex >= 0) _list.Items.RemoveAt(_list.SelectedIndex); };
+            Controls.Add(_list);
+            Controls.Add(_abandon);
+        }
+
+        public void LoadQuests(IEnumerable<string> quests)
+        {
+            _list.Items.Clear();
+            foreach (var q in quests) _list.Items.Add(q);
+        }
+    }
+}

--- a/WinFormsApp2/TravelLogService.cs
+++ b/WinFormsApp2/TravelLogService.cs
@@ -1,0 +1,30 @@
+using System;
+using MySql.Data.MySqlClient;
+
+namespace WinFormsApp2
+{
+    /// <summary>
+    /// Persists travel logs for later review.
+    /// </summary>
+    public static class TravelLogService
+    {
+        public static void LogJourney(int accountId, string fromNode, string toNode, int originalDays, int finalDays, int cost, bool fasterTravel)
+        {
+            using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using var cmd = new MySqlCommand(
+                "INSERT INTO travel_logs(account_id,from_node,to_node,start_time,end_time,original_days,travel_days,cost_gold,faster_travel_applied)"+
+                " VALUES(@a,@f,@t,@s,@e,@o,@d,@c,@fast)", conn);
+            cmd.Parameters.AddWithValue("@a", accountId);
+            cmd.Parameters.AddWithValue("@f", fromNode);
+            cmd.Parameters.AddWithValue("@t", toNode);
+            cmd.Parameters.AddWithValue("@s", DateTime.UtcNow.AddSeconds(-finalDays * 60));
+            cmd.Parameters.AddWithValue("@e", DateTime.UtcNow);
+            cmd.Parameters.AddWithValue("@o", originalDays);
+            cmd.Parameters.AddWithValue("@d", finalDays);
+            cmd.Parameters.AddWithValue("@c", cost);
+            cmd.Parameters.AddWithValue("@fast", fasterTravel);
+            cmd.ExecuteNonQuery();
+        }
+    }
+}

--- a/WinFormsApp2/TravelManager.cs
+++ b/WinFormsApp2/TravelManager.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Timers;
+using MySql.Data.MySqlClient;
+
+namespace WinFormsApp2
+{
+    /// <summary>
+    /// Handles travel timing, cost calculations and persistence. The manager
+    /// stores progress in the database so travel can resume if the application
+    /// closes.
+    /// </summary>
+    public class TravelManager
+    {
+        private readonly int _accountId;
+        private readonly Timer _timer = new Timer(1000);
+        private int _totalSeconds;
+        private int _elapsedSeconds;
+        private int _originalDays;
+        private int _travelCost;
+        private string? _fromNode;
+        private string? _toNode;
+        private readonly Random _rng = new Random();
+        private bool _fasterTravelApplied;
+
+        public event Action<int>? ProgressChanged;
+        public event Action<string>? TravelCompleted;
+
+        public TravelManager(int accountId)
+        {
+            _accountId = accountId;
+            _timer.Elapsed += Timer_Elapsed;
+        }
+
+        public void StartTravel(string fromNode, string toNode, int partySize, bool hasFasterTravel)
+        {
+            _fromNode = fromNode;
+            _toNode = toNode;
+            _originalDays = WorldMapService.GetNode(fromNode).Connections[toNode];
+            int days = _originalDays;
+            _fasterTravelApplied = hasFasterTravel && days > 1;
+            if (_fasterTravelApplied) days -= 1;
+            _totalSeconds = days * 60;
+            _elapsedSeconds = 0;
+            _timer.Start();
+            _travelCost = days * partySize * 5;
+            using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using var cmd = new MySqlCommand("UPDATE users SET gold = gold - @c WHERE id=@id", conn);
+            cmd.Parameters.AddWithValue("@c", _travelCost);
+            cmd.Parameters.AddWithValue("@id", _accountId);
+            cmd.ExecuteNonQuery();
+            SaveState();
+        }
+
+        private void Timer_Elapsed(object? sender, ElapsedEventArgs e)
+        {
+            _elapsedSeconds++;
+            ProgressChanged?.Invoke(_elapsedSeconds * 100 / Math.Max(1, _totalSeconds));
+            if (_elapsedSeconds % 30 == 0)
+            {
+                if (_rng.NextDouble() < 0.15)
+                {
+                    // TODO: trigger ambush battle
+                }
+            }
+            if (_elapsedSeconds >= _totalSeconds)
+            {
+                _timer.Stop();
+                CompleteTravel();
+            }
+            else
+            {
+                SaveState();
+            }
+        }
+
+        private void CompleteTravel()
+        {
+            if (_fromNode == null || _toNode == null) return;
+            using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using (var cmd = new MySqlCommand("REPLACE INTO travel_state(account_id,current_node,destination_node,start_time,arrival_time,progress_seconds,faster_travel,travel_cost) VALUES (@a,@curr,@dest,NULL,NULL,0,0,0)", conn))
+            {
+                cmd.Parameters.AddWithValue("@a", _accountId);
+                cmd.Parameters.AddWithValue("@curr", _toNode);
+                cmd.Parameters.AddWithValue("@dest", _toNode);
+                cmd.ExecuteNonQuery();
+            }
+            int finalDays = _totalSeconds / 60;
+            TravelLogService.LogJourney(_accountId, _fromNode, _toNode, _originalDays, finalDays, _travelCost, _fasterTravelApplied);
+            TravelCompleted?.Invoke(_toNode);
+        }
+
+        public void SaveState()
+        {
+            if (_fromNode == null || _toNode == null) return;
+            using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using var cmd = new MySqlCommand("REPLACE INTO travel_state(account_id,current_node,destination_node,start_time,arrival_time,progress_seconds,faster_travel,travel_cost) VALUES (@a,@curr,@dest,@start,@arr,@prog,@fast,@cost)", conn);
+            cmd.Parameters.AddWithValue("@a", _accountId);
+            cmd.Parameters.AddWithValue("@curr", _fromNode);
+            cmd.Parameters.AddWithValue("@dest", _toNode);
+            cmd.Parameters.AddWithValue("@start", DateTime.UtcNow);
+            cmd.Parameters.AddWithValue("@arr", DateTime.UtcNow.AddSeconds(_totalSeconds - _elapsedSeconds));
+            cmd.Parameters.AddWithValue("@prog", _elapsedSeconds);
+            cmd.Parameters.AddWithValue("@fast", _fasterTravelApplied);
+            cmd.Parameters.AddWithValue("@cost", _travelCost);
+            cmd.ExecuteNonQuery();
+        }
+
+        public void Resume()
+        {
+            using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using var cmd = new MySqlCommand("SELECT current_node,destination_node,progress_seconds,arrival_time,faster_travel,travel_cost FROM travel_state WHERE account_id=@a", conn);
+            cmd.Parameters.AddWithValue("@a", _accountId);
+            using var reader = cmd.ExecuteReader();
+            if (reader.Read())
+            {
+                _fromNode = reader.GetString("current_node");
+                _toNode = reader.GetString("destination_node");
+                _elapsedSeconds = reader.GetInt32("progress_seconds");
+                _fasterTravelApplied = reader.GetBoolean("faster_travel");
+                _travelCost = reader.GetInt32("travel_cost");
+                _originalDays = WorldMapService.GetNode(_fromNode).Connections[_toNode];
+                if (_fromNode == _toNode)
+                {
+                    // Not traveling
+                    _timer.Stop();
+                }
+                else
+                {
+                    int days = _originalDays;
+                    if (_fasterTravelApplied && days > 1) days -= 1;
+                    _totalSeconds = days * 60;
+                    _timer.Start();
+                }
+            }
+        }
+    }
+}

--- a/WinFormsApp2/WorldMapNode.cs
+++ b/WinFormsApp2/WorldMapNode.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace WinFormsApp2
+{
+    /// <summary>
+    /// Represents a node on the world map. Nodes contain connections to other
+    /// nodes with associated travel time in days and a list of activities
+    /// available at that location.
+    /// </summary>
+    public class WorldMapNode
+    {
+        public string Id { get; }
+        public string Name { get; }
+        public Dictionary<string, int> Connections { get; } = new();
+        public List<string> Activities { get; } = new();
+
+        public WorldMapNode(string id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+    }
+}

--- a/WinFormsApp2/WorldMapService.cs
+++ b/WinFormsApp2/WorldMapService.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WinFormsApp2
+{
+    /// <summary>
+    /// Holds the static definition of all world map nodes and their
+    /// connections/activities. This allows the navigation UI and travel system
+    /// to query available destinations and actions.
+    /// </summary>
+    public static class WorldMapService
+    {
+        public static readonly Dictionary<string, WorldMapNode> Nodes;
+
+        static WorldMapService()
+        {
+            Nodes = new Dictionary<string, WorldMapNode>();
+
+            var nodeMountain = new WorldMapNode("nodeMountain", "Mountain");
+            nodeMountain.Connections["nodeMounttown"] = 2;
+            nodeMountain.Activities.Add("Search for enemies (Lv 10-15)");
+            nodeMountain.Activities.Add("Search for powerful enemies (Lv 30+)");
+            Nodes[nodeMountain.Id] = nodeMountain;
+
+            var nodeMounttown = new WorldMapNode("nodeMounttown", "Mounttown");
+            nodeMounttown.Connections["nodeMountain"] = 2;
+            nodeMounttown.Connections["nodeDarkSpire"] = 1;
+            nodeMounttown.Connections["nodeRiverVillage"] = 3;
+            nodeMounttown.Activities.Add("Shop");
+            nodeMounttown.Activities.Add("Temple (30 min +10% HP buff)");
+            nodeMounttown.Activities.Add("Graveyard (resurrect screen)");
+            nodeMounttown.Activities.Add("Tavern (recruit Lv5 adventurers w/2 random passives)");
+            Nodes[nodeMounttown.Id] = nodeMounttown;
+
+            var nodeDarkSpire = new WorldMapNode("nodeDarkSpire", "Dark Spire");
+            nodeDarkSpire.Connections["nodeMounttown"] = 1;
+            nodeDarkSpire.Connections["nodeRiverVillage"] = 3;
+            nodeDarkSpire.Connections["nodeForestValley"] = 3;
+            nodeDarkSpire.Activities.Add("Endless dungeon starting Lv1-5, +5 Lv per win");
+            nodeDarkSpire.Activities.Add("Track floors cleared and reward bonus (15-20% for Lv15-20 floor)");
+            Nodes[nodeDarkSpire.Id] = nodeDarkSpire;
+
+            var nodeNorthernIsland = new WorldMapNode("nodeNorthernIsland", "Northern Island");
+            nodeNorthernIsland.Connections["nodeDarkSpire"] = 3;
+            nodeNorthernIsland.Connections["nodeForestValley"] = 4;
+            nodeNorthernIsland.Activities.Add("Ancient Stone of Regret (reset stats to 5 for 150% hire value cost)");
+            nodeNorthernIsland.Activities.Add("Search for strong enemies (Lv50)");
+            Nodes[nodeNorthernIsland.Id] = nodeNorthernIsland;
+
+            var nodeSouthernIsland = new WorldMapNode("nodeSouthernIsland", "Southern Island");
+            nodeSouthernIsland.Connections["nodeSmallVillage"] = 10;
+            nodeSouthernIsland.Activities.Add("Fisherman work: assign party member for N minutes → earns 5 gp/min");
+            nodeSouthernIsland.Activities.Add("Tavern: hire hostile NPC mercenaries (no exp/level/equipment/resurrection)");
+            nodeSouthernIsland.Activities.Add("Temple: blessing that reduces travel ≥2 days by 1 day");
+            Nodes[nodeSouthernIsland.Id] = nodeSouthernIsland;
+
+            var nodeRiverVillage = new WorldMapNode("nodeRiverVillage", "River Village");
+            nodeRiverVillage.Connections["nodeSmallVillage"] = 1;
+            nodeRiverVillage.Connections["nodeDarkSpire"] = 3;
+            nodeRiverVillage.Connections["nodeMounttown"] = 3;
+            nodeRiverVillage.Connections["nodeDesert"] = 4;
+            nodeRiverVillage.Connections["nodeForestValley"] = 4;
+            nodeRiverVillage.Activities.Add("Battle Arena: leave party to fight other teams");
+            nodeRiverVillage.Activities.Add("Tavern: recruit magic specialists and take quests");
+            nodeRiverVillage.Activities.Add("Shop: strong/expensive items");
+            nodeRiverVillage.Activities.Add("Wizard Tower: teleport to any node for cost");
+            Nodes[nodeRiverVillage.Id] = nodeRiverVillage;
+
+            var nodeSmallVillage = new WorldMapNode("nodeSmallVillage", "Small Village");
+            nodeSmallVillage.Connections["nodeSouthernIsland"] = 10;
+            nodeSmallVillage.Connections["nodeRiverVillage"] = 1;
+            nodeSmallVillage.Activities.Add("Shop");
+            nodeSmallVillage.Activities.Add("Tavern (recruit DEX specialists)");
+            nodeSmallVillage.Activities.Add("Search the woods (Lv1-10 enemies)");
+            Nodes[nodeSmallVillage.Id] = nodeSmallVillage;
+
+            var nodeDesert = new WorldMapNode("nodeDesert", "Desert");
+            nodeDesert.Connections["nodeForestValley"] = 4;
+            nodeDesert.Connections["nodeFarCliffs"] = 5;
+            nodeDesert.Connections["nodeForestPlains"] = 5;
+            nodeDesert.Activities.Add("Wander the desert: spend 1 day, chance to encounter Lv50 giant worm raid boss");
+            Nodes[nodeDesert.Id] = nodeDesert;
+
+            var nodeForestValley = new WorldMapNode("nodeForestValley", "Forest Valley");
+            nodeForestValley.Connections["nodeDarkSpire"] = 3;
+            nodeForestValley.Connections["nodeRiverVillage"] = 4;
+            nodeForestValley.Connections["nodeForestPlains"] = 3;
+            nodeForestValley.Connections["nodeDesert"] = 4;
+            nodeForestValley.Activities.Add("Search for enemies (Lv10-20)");
+            nodeForestValley.Activities.Add("Search for powerful enemies (Lv30-40, 15% chance Lv50 raid boss)");
+            Nodes[nodeForestValley.Id] = nodeForestValley;
+
+            var nodeForestPlains = new WorldMapNode("nodeForestPlains", "Forest Plains");
+            nodeForestPlains.Connections["nodeFarCliffs"] = 1;
+            nodeForestPlains.Connections["nodeDesert"] = 5;
+            nodeForestPlains.Connections["nodeForestValley"] = 3;
+            nodeForestPlains.Activities.Add("Commune with nature (receive raid-boss quest)");
+            nodeForestPlains.Activities.Add("Search for enemies (Lv15-25)");
+            nodeForestPlains.Activities.Add("Search for powerful enemies (Lv50 raid boss)");
+            Nodes[nodeForestPlains.Id] = nodeForestPlains;
+
+            var nodeFarCliffs = new WorldMapNode("nodeFarCliffs", "Far Cliffs");
+            nodeFarCliffs.Connections["nodeForestPlains"] = 1;
+            nodeFarCliffs.Connections["nodeDesert"] = 5;
+            nodeFarCliffs.Activities.Add("Ancient Altar: does nothing unless holding 'Orb of Unknowable Evil'");
+            nodeFarCliffs.Activities.Add("Search for enemies (Lv5-15)");
+            Nodes[nodeFarCliffs.Id] = nodeFarCliffs;
+        }
+
+        public static WorldMapNode GetNode(string id) => Nodes[id];
+
+        public static IEnumerable<(WorldMapNode node, int days)> GetConnections(string id)
+        {
+            var source = GetNode(id);
+            foreach (var kv in source.Connections)
+            {
+                yield return (Nodes[kv.Key], kv.Value);
+            }
+        }
+    }
+}

--- a/world_map.sql
+++ b/world_map.sql
@@ -1,0 +1,66 @@
+CREATE TABLE IF NOT EXISTS nodes (
+    id VARCHAR(50) PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS node_connections (
+    from_node VARCHAR(50) NOT NULL,
+    to_node VARCHAR(50) NOT NULL,
+    travel_time_days INT NOT NULL,
+    PRIMARY KEY (from_node, to_node),
+    FOREIGN KEY (from_node) REFERENCES nodes(id),
+    FOREIGN KEY (to_node) REFERENCES nodes(id)
+);
+
+CREATE TABLE IF NOT EXISTS activities (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    node_id VARCHAR(50) NOT NULL,
+    activity_type VARCHAR(50),
+    description VARCHAR(255),
+    duration_seconds INT,
+    FOREIGN KEY (node_id) REFERENCES nodes(id)
+);
+
+CREATE TABLE IF NOT EXISTS travel_state (
+    account_id INT PRIMARY KEY,
+    current_node VARCHAR(50) NOT NULL,
+    destination_node VARCHAR(50) NOT NULL,
+    start_time DATETIME,
+    arrival_time DATETIME,
+    progress_seconds INT DEFAULT 0,
+    faster_travel TINYINT(1) DEFAULT 0,
+    travel_cost INT DEFAULT 0,
+    FOREIGN KEY (current_node) REFERENCES nodes(id),
+    FOREIGN KEY (destination_node) REFERENCES nodes(id)
+);
+
+CREATE TABLE IF NOT EXISTS travel_logs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    account_id INT,
+    from_node VARCHAR(50),
+    to_node VARCHAR(50),
+    start_time DATETIME,
+    end_time DATETIME,
+    original_days INT,
+    travel_days INT,
+    cost_gold INT,
+    faster_travel_applied TINYINT(1),
+    FOREIGN KEY (from_node) REFERENCES nodes(id),
+    FOREIGN KEY (to_node) REFERENCES nodes(id)
+);
+
+CREATE TABLE IF NOT EXISTS notifications (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    account_id INT,
+    created_at DATETIME,
+    message TEXT
+);
+
+CREATE TABLE IF NOT EXISTS quests (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    account_id INT,
+    description TEXT,
+    progress INT DEFAULT 0,
+    target INT DEFAULT 0,
+    completed TINYINT(1) DEFAULT 0
+);


### PR DESCRIPTION
## Summary
- define world-map nodes, connections, and activities for navigation
- add travel manager with cost, ambush checks, logging, and persistent state
- expand navigation window with read-only map nodes, activities, and travel progress
- introduce notification and quest log forms and SQL schema for travel/quests

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0527d4c88333a3f46ba06f921289