### PR TITLE
Add debug-mode DB connection option

### DIFF
--- a/WinFormsApp2/DatabaseConfig.cs
+++ b/WinFormsApp2/DatabaseConfig.cs
@@ -2,8 +2,11 @@ namespace WinFormsApp2
 {
     internal static class DatabaseConfig
     {
-        // Replace with your actual MySQL connection string
-        // Example: "Server=localhost;Database=DATABASE_NAME;User ID=USERNAME;Password=PASSWORD;"
-        public const string ConnectionString = "Server=localhost;Database=accounts;User ID=root;Password=;";
+        private const string Host = "76.134.86.9";
+        private const string Username = "userclient";
+        private const string Password = "123321";
+        public static bool DebugMode { get; set; }
+        public static string ConnectionString =>
+            $"Server={(DebugMode ? "127.0.0.1" : Host)};Database=accounts;User ID={Username};Password={Password};";
     }
 }

--- a/WinFormsApp2/Form1.Designer.cs
+++ b/WinFormsApp2/Form1.Designer.cs
@@ -15,6 +15,7 @@ namespace WinFormsApp2
         private Button btnCreateAccount = null!;
         private Label lblUsername = null!;
         private Label lblPassword = null!;
+        private CheckBox chkDebugMode = null!;
 
         /// <summary>
         ///  Clean up any resources being used.
@@ -43,6 +44,7 @@ namespace WinFormsApp2
             btnCreateAccount = new Button();
             lblUsername = new Label();
             lblPassword = new Label();
+            chkDebugMode = new CheckBox();
             SuspendLayout();
             // 
             // lblUsername
@@ -97,12 +99,23 @@ namespace WinFormsApp2
             btnCreateAccount.Text = "Create Account";
             btnCreateAccount.UseVisualStyleBackColor = true;
             btnCreateAccount.Click += btnCreateAccount_Click;
-            // 
+            //
+            // chkDebugMode
+            //
+            chkDebugMode.AutoSize = true;
+            chkDebugMode.Location = new Point(30, 179);
+            chkDebugMode.Name = "chkDebugMode";
+            chkDebugMode.Size = new Size(129, 19);
+            chkDebugMode.TabIndex = 6;
+            chkDebugMode.Text = "Enable debug mode";
+            chkDebugMode.UseVisualStyleBackColor = true;
+            //
             // Form1
-            // 
+            //
             AutoScaleDimensions = new SizeF(7F, 15F);
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(264, 211);
+            Controls.Add(chkDebugMode);
             Controls.Add(btnCreateAccount);
             Controls.Add(btnLogin);
             Controls.Add(txtPassword);

--- a/WinFormsApp2/Form1.cs
+++ b/WinFormsApp2/Form1.cs
@@ -15,6 +15,7 @@ namespace WinFormsApp2
 
         private void btnLogin_Click(object? sender, EventArgs e)
         {
+            DatabaseConfig.DebugMode = chkDebugMode.Checked;
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
             using MySqlCommand cmd = new MySqlCommand("SELECT id, nickname FROM Users WHERE Username=@u AND PasswordHash=@p", conn);


### PR DESCRIPTION
## Summary
- default DB connection now uses 76.134.86.9 with userclient/123321
- add "Enable debug mode" checkbox on login form
- debug mode routes DB connection to localhost

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.sln -clp:ErrorsOnly` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4a3592708333912d11f1f65cd763