### PR TITLE
Initialize NavigationWindow buttons to prevent null reference

### DIFF
--- a/WinFormsApp2/NavigationWindow.Designer.cs
+++ b/WinFormsApp2/NavigationWindow.Designer.cs
@@ -47,6 +47,9 @@
             btnShop = new Button();
             btnGraveyard = new Button();
             btnTavern = new Button();
+            btnFindEnemies = new Button();
+            btnArena = new Button();
+            btnTemple = new Button();
             lstConnections = new ListBox();
             rtbNodeDescription = new RichTextBox();
             btnBeginTravel = new Button();


### PR DESCRIPTION
## Summary
- Instantiate missing buttons in `NavigationWindow` to avoid `NullReferenceException`

## Testing
- `dotnet build WinFormsApp2/WinFormsApp2.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop/targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4e11e9948333a20858793d0e6637