### PR TITLE
Show recruit search cost and add travel ambush

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -17,6 +17,7 @@ namespace WinFormsApp2
         private readonly int _userId;
         private readonly System.Windows.Forms.Timer _progressTimer = new System.Windows.Forms.Timer();
         private readonly Dictionary<string, string> _deathCauses = new();
+        private readonly bool _wildEncounter;
 
         private class LogEntry
         {
@@ -37,9 +38,10 @@ namespace WinFormsApp2
             lstLog.SelectedIndex = lstLog.Items.Count - 1;
         }
 
-        public BattleForm(int userId)
+        public BattleForm(int userId, bool wildEncounter = false)
         {
             _userId = userId;
+            _wildEncounter = wildEncounter;
             InitializeComponent();
             LoadData();
         }
@@ -102,8 +104,18 @@ namespace WinFormsApp2
             }
 
             int totalLevel = _players.Sum(p => p.Level);
-            int minLevel = Math.Max(1, (int)Math.Ceiling(totalLevel * 1.0));
-            int maxLevel = Math.Max(minLevel, (int)Math.Ceiling(totalLevel * 1.4));
+            int minLevel;
+            int maxLevel;
+            if (_wildEncounter)
+            {
+                minLevel = Math.Max(1, (int)Math.Ceiling(totalLevel * 0.8));
+                maxLevel = Math.Max(minLevel, (int)Math.Ceiling(totalLevel * 1.0));
+            }
+            else
+            {
+                minLevel = Math.Max(1, (int)Math.Ceiling(totalLevel * 1.0));
+                maxLevel = Math.Max(minLevel, (int)Math.Ceiling(totalLevel * 1.4));
+            }
             int npcLevel = 0;
             while (_npcs.Count == 0 || npcLevel < minLevel)
             {

--- a/WinFormsApp2/NavigationWindow.cs
+++ b/WinFormsApp2/NavigationWindow.cs
@@ -42,6 +42,7 @@ namespace WinFormsApp2
             _travelManager = new TravelManager(_accountId);
             _travelManager.ProgressChanged += TravelManager_ProgressChanged;
             _travelManager.TravelCompleted += TravelManager_TravelCompleted;
+            _travelManager.AmbushEncounter += TravelManager_AmbushEncounter;
             _currentNode = GetCurrentNode();
             LoadNode(_currentNode);
             lstConnections.SelectedIndexChanged += LstConnections_SelectedIndexChanged;
@@ -201,6 +202,16 @@ namespace WinFormsApp2
             using var cmd = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@id AND is_dead=0", conn);
             cmd.Parameters.AddWithValue("@id", _accountId);
             _partySize = Convert.ToInt32(cmd.ExecuteScalar());
+        }
+
+        private void TravelManager_AmbushEncounter()
+        {
+            lblTravelInfo.Text = "Ambushed by wild enemies!";
+            using var battle = new BattleForm(_accountId, true);
+            battle.ShowDialog(this);
+            _refresh();
+            UpdatePartySize();
+            _travelManager.ResumeAfterEncounter();
         }
     }
 }

--- a/WinFormsApp2/WorldMapService.cs
+++ b/WinFormsApp2/WorldMapService.cs
@@ -16,13 +16,13 @@ namespace WinFormsApp2
         {
             Nodes = new Dictionary<string, WorldMapNode>();
 
-            var nodeMountain = new WorldMapNode("nodeMountain", "Mountain", "Towering peaks home to dangerous beasts.");
+            var nodeMountain = new WorldMapNode("nodeMountain", "Mountain", "Towering peaks home to dangerous beasts. Enemies around Lv10-15 with rare threats at Lv30+.");
             nodeMountain.Connections["nodeMounttown"] = 2;
             nodeMountain.Activities.Add("Search for enemies (Lv 10-15)");
             nodeMountain.Activities.Add("Search for powerful enemies (Lv 30+)");
             Nodes[nodeMountain.Id] = nodeMountain;
 
-            var nodeMounttown = new WorldMapNode("nodeMounttown", "Mounttown", "A bustling town carved into the mountainside.");
+            var nodeMounttown = new WorldMapNode("nodeMounttown", "Mounttown", "A bustling town carved into the mountainside. Generally safe from wild enemies.");
             nodeMounttown.Connections["nodeMountain"] = 2;
             nodeMounttown.Connections["nodeDarkSpire"] = 1;
             nodeMounttown.Connections["nodeRiverVillage"] = 3;
@@ -32,7 +32,7 @@ namespace WinFormsApp2
             nodeMounttown.Activities.Add("Tavern (recruit Lv5 adventurers w/2 random passives)");
             Nodes[nodeMounttown.Id] = nodeMounttown;
 
-            var nodeDarkSpire = new WorldMapNode("nodeDarkSpire", "Dark Spire", "An ominous tower shrouded in eternal twilight.");
+            var nodeDarkSpire = new WorldMapNode("nodeDarkSpire", "Dark Spire", "An ominous tower shrouded in eternal twilight. Foes start around Lv1-5 and grow stronger each floor.");
             nodeDarkSpire.Connections["nodeMounttown"] = 1;
             nodeDarkSpire.Connections["nodeRiverVillage"] = 3;
             nodeDarkSpire.Connections["nodeForestValley"] = 3;
@@ -40,21 +40,21 @@ namespace WinFormsApp2
             nodeDarkSpire.Activities.Add("Track floors cleared and reward bonus (15-20% for Lv15-20 floor)");
             Nodes[nodeDarkSpire.Id] = nodeDarkSpire;
 
-            var nodeNorthernIsland = new WorldMapNode("nodeNorthernIsland", "Northern Island", "A remote island swept by cold winds.");
+            var nodeNorthernIsland = new WorldMapNode("nodeNorthernIsland", "Northern Island", "A remote island swept by cold winds. Home to formidable Lv50 foes.");
             nodeNorthernIsland.Connections["nodeDarkSpire"] = 3;
             nodeNorthernIsland.Connections["nodeForestValley"] = 4;
             nodeNorthernIsland.Activities.Add("Ancient Stone of Regret (reset stats to 5 for 150% hire value cost)");
             nodeNorthernIsland.Activities.Add("Search for strong enemies (Lv50)");
             Nodes[nodeNorthernIsland.Id] = nodeNorthernIsland;
 
-            var nodeSouthernIsland = new WorldMapNode("nodeSouthernIsland", "Southern Island", "A tropical haven dotted with fishing huts.");
+            var nodeSouthernIsland = new WorldMapNode("nodeSouthernIsland", "Southern Island", "A tropical haven dotted with fishing huts. Mostly peaceful with few hostile creatures.");
             nodeSouthernIsland.Connections["nodeSmallVillage"] = 10;
             nodeSouthernIsland.Activities.Add("Fisherman work: assign party member for N minutes → earns 5 gp/min");
             nodeSouthernIsland.Activities.Add("Tavern: hire hostile NPC mercenaries (no exp/level/equipment/resurrection)");
             nodeSouthernIsland.Activities.Add("Temple: blessing that reduces travel ≥2 days by 1 day");
             Nodes[nodeSouthernIsland.Id] = nodeSouthernIsland;
 
-            var nodeRiverVillage = new WorldMapNode("nodeRiverVillage", "River Village", "A prosperous settlement along winding rivers.");
+            var nodeRiverVillage = new WorldMapNode("nodeRiverVillage", "River Village", "A prosperous settlement along winding rivers. Nearby foes span a wide range of levels.");
             nodeRiverVillage.Connections["nodeSmallVillage"] = 1;
             nodeRiverVillage.Connections["nodeDarkSpire"] = 3;
             nodeRiverVillage.Connections["nodeMounttown"] = 3;
@@ -66,7 +66,7 @@ namespace WinFormsApp2
             nodeRiverVillage.Activities.Add("Wizard Tower: teleport to any node for cost");
             Nodes[nodeRiverVillage.Id] = nodeRiverVillage;
 
-            var nodeSmallVillage = new WorldMapNode("nodeSmallVillage", "Small Village", "A quaint village surrounded by whispering woods.");
+            var nodeSmallVillage = new WorldMapNode("nodeSmallVillage", "Small Village", "A quaint village surrounded by whispering woods. Local enemies range from Lv1-10.");
             nodeSmallVillage.Connections["nodeSouthernIsland"] = 10;
             nodeSmallVillage.Connections["nodeRiverVillage"] = 1;
             nodeSmallVillage.Activities.Add("Shop");
@@ -74,14 +74,14 @@ namespace WinFormsApp2
             nodeSmallVillage.Activities.Add("Search the woods (Lv1-10 enemies)");
             Nodes[nodeSmallVillage.Id] = nodeSmallVillage;
 
-            var nodeDesert = new WorldMapNode("nodeDesert", "Desert", "An endless expanse of scorching sands.");
+            var nodeDesert = new WorldMapNode("nodeDesert", "Desert", "An endless expanse of scorching sands. Rare encounters reach around Lv50.");
             nodeDesert.Connections["nodeForestValley"] = 4;
             nodeDesert.Connections["nodeFarCliffs"] = 5;
             nodeDesert.Connections["nodeForestPlains"] = 5;
             nodeDesert.Activities.Add("Wander the desert: spend 1 day, chance to encounter Lv50 giant worm raid boss");
             Nodes[nodeDesert.Id] = nodeDesert;
 
-            var nodeForestValley = new WorldMapNode("nodeForestValley", "Forest Valley", "A lush valley teeming with hidden wildlife.");
+            var nodeForestValley = new WorldMapNode("nodeForestValley", "Forest Valley", "A lush valley teeming with hidden wildlife. Expect enemies around Lv10-20 with occasional Lv30-40 threats and rare Lv50 raids.");
             nodeForestValley.Connections["nodeDarkSpire"] = 3;
             nodeForestValley.Connections["nodeRiverVillage"] = 4;
             nodeForestValley.Connections["nodeForestPlains"] = 3;
@@ -90,7 +90,7 @@ namespace WinFormsApp2
             nodeForestValley.Activities.Add("Search for powerful enemies (Lv30-40, 15% chance Lv50 raid boss)");
             Nodes[nodeForestValley.Id] = nodeForestValley;
 
-            var nodeForestPlains = new WorldMapNode("nodeForestPlains", "Forest Plains", "Open plains where the forest meets the sky.");
+            var nodeForestPlains = new WorldMapNode("nodeForestPlains", "Forest Plains", "Open plains where the forest meets the sky. Enemies generally Lv15-25 with rare Lv50 raid bosses.");
             nodeForestPlains.Connections["nodeFarCliffs"] = 1;
             nodeForestPlains.Connections["nodeDesert"] = 5;
             nodeForestPlains.Connections["nodeForestValley"] = 3;
@@ -99,7 +99,7 @@ namespace WinFormsApp2
             nodeForestPlains.Activities.Add("Search for powerful enemies (Lv50 raid boss)");
             Nodes[nodeForestPlains.Id] = nodeForestPlains;
 
-            var nodeFarCliffs = new WorldMapNode("nodeFarCliffs", "Far Cliffs", "Sheer cliffs that overlook the restless sea.");
+            var nodeFarCliffs = new WorldMapNode("nodeFarCliffs", "Far Cliffs", "Sheer cliffs that overlook the restless sea. Local foes range around Lv5-15.");
             nodeFarCliffs.Connections["nodeForestPlains"] = 1;
             nodeFarCliffs.Connections["nodeDesert"] = 5;
             nodeFarCliffs.Activities.Add("Ancient Altar: does nothing unless holding 'Orb of Unknowable Evil'");


### PR DESCRIPTION
## Summary
- Display recruit search cost on tavern button
- Add random ambush encounters while traveling
- Document enemy levels in world map node descriptions

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae55778d248333ace1a539517a2224