### PR TITLE
Add loot pool system and fix battle progress bar overflow

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -408,7 +408,7 @@ namespace WinFormsApp2
                                 {
                                     _deathCauses[c.Name] = $"{c.Name} succumbed to {eff.Kind}.";
                                 }
-                                c.HpBar.Value = Math.Max(0, c.CurrentHp);
+                                c.HpBar.Value = Math.Min(c.HpBar.Maximum, Math.Max(0, c.CurrentHp));
                                 eff.TimeUntilTickMs += eff.TickIntervalMs;
                             }
                         }
@@ -533,13 +533,13 @@ namespace WinFormsApp2
                     if (ability.Name == "Drain Life")
                     {
                         actor.CurrentHp = Math.Min(actor.MaxHp, actor.CurrentHp + spellDamage);
-                        actor.HpBar.Value = Math.Max(0, actor.CurrentHp);
+                        actor.HpBar.Value = Math.Min(actor.HpBar.Maximum, Math.Max(0, actor.CurrentHp));
                         AppendLog($"{actor.Name} absorbs {spellDamage} health!", actorIsPlayer, true);
                     }
 
                     actor.DamageDone += spellDamage;
                     target.DamageTaken += spellDamage;
-                    target.HpBar.Value = Math.Max(0, target.CurrentHp);
+                    target.HpBar.Value = Math.Min(target.HpBar.Maximum, Math.Max(0, target.CurrentHp));
                     actor.AttackBar.Value = actor.AttackInterval;
                     target.Threat[actor] = target.Threat.GetValueOrDefault(actor) + spellDamage;
                     target.CurrentTarget = actor;
@@ -587,7 +587,7 @@ namespace WinFormsApp2
             AppendLog(attackLog, _players.Contains(actor));
             actor.DamageDone += dmg;
             target.DamageTaken += dmg;
-            target.HpBar.Value = Math.Max(0, target.CurrentHp);
+            target.HpBar.Value = Math.Min(target.HpBar.Maximum, Math.Max(0, target.CurrentHp));
             actor.AttackBar.Value = actor.AttackInterval;
             target.Threat[actor] = target.Threat.GetValueOrDefault(actor) + dmg;
             target.CurrentTarget = actor;
@@ -846,8 +846,8 @@ namespace WinFormsApp2
 
         private void CheckEnd()
         {
-            foreach (var p in _players) p.HpBar.Value = Math.Max(0, p.CurrentHp);
-            foreach (var n in _npcs) n.HpBar.Value = Math.Max(0, n.CurrentHp);
+            foreach (var p in _players) p.HpBar.Value = Math.Min(p.HpBar.Maximum, Math.Max(0, p.CurrentHp));
+            foreach (var n in _npcs) n.HpBar.Value = Math.Min(n.HpBar.Maximum, Math.Max(0, n.CurrentHp));
             if (_players.All(p => p.CurrentHp <= 0) || _npcs.All(n => n.CurrentHp <= 0))
             {
                 foreach (var t in _timers.Values) t.Stop();
@@ -1027,16 +1027,16 @@ namespace WinFormsApp2
             var panel = new Panel { Width = 180, Height = 80 };
             var lbl = new Label { Text = c.Name, AutoSize = true };
             c.HpBar = CloneProgressBar(hpTemplate);
-            c.HpBar.Maximum = c.MaxHp;
-            c.HpBar.Value = c.CurrentHp;
+            c.HpBar.Maximum = Math.Max(1, c.MaxHp);
+            c.HpBar.Value = Math.Min(c.HpBar.Maximum, Math.Max(0, c.CurrentHp));
             c.HpBar.Location = new Point(0, 15);
             panel.Controls.Add(lbl);
             panel.Controls.Add(c.HpBar);
             if (c.MaxMana > 0)
             {
                 c.ManaBar = CloneProgressBar(manaTemplate);
-                c.ManaBar.Maximum = c.MaxMana;
-                c.ManaBar.Value = c.Mana;
+                c.ManaBar.Maximum = Math.Max(1, c.MaxMana);
+                c.ManaBar.Value = Math.Min(c.ManaBar.Maximum, Math.Max(0, c.Mana));
                 c.ManaBar.Location = new Point(0, 35);
                 panel.Controls.Add(c.ManaBar);
                 c.AttackBar = CloneProgressBar(attackTemplate);

--- a/WinFormsApp2/LootPool.cs
+++ b/WinFormsApp2/LootPool.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WinFormsApp2
+{
+    /// <summary>
+    /// Provides a global loot pool that is shared between shops and enemy drops.
+    /// Items are grouped into broad level brackets and shop stock is generated
+    /// without overlap so each shop offers unique wares.
+    /// </summary>
+    public static class LootPool
+    {
+        private static readonly Random _rng = new();
+
+        // Pools keyed by (minLevel,maxLevel)
+        private static readonly Dictionary<(int Min, int Max), List<string>> _pools = new()
+        {
+            [(1,10)] = new List<string>
+            {
+                "Healing Potion",
+                "Dagger",
+                "Shortsword",
+                "Leather Armor",
+                "Leather Cap",
+                "Leather Boots",
+                "Cloth Robe"
+            },
+            [(11,20)] = new List<string>
+            {
+                "Bow",
+                "Staff",
+                "Wand",
+                "Longsword",
+                "Plate Armor",
+                "Rod",
+                "Mace"
+            },
+            [(21,40)] = new List<string>
+            {
+                "Greataxe",
+                "Scythe",
+                "Greatsword",
+                "Greatmaul"
+            }
+        };
+
+        private static readonly HashSet<string> _usedItems = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, List<Item>> _shopStocks = new();
+
+        private static List<string> GetPool(int level)
+        {
+            foreach (var kv in _pools)
+            {
+                if (level >= kv.Key.Min && level <= kv.Key.Max)
+                    return kv.Value;
+            }
+            return _pools.First().Value;
+        }
+
+        /// <summary>
+        /// Returns the stock for the given shop node. The stock is generated
+        /// once and cached so repeated visits show the same items. Items are
+        /// drawn from the global pool and are unique across shops.
+        /// </summary>
+        public static List<Item> GetShopStock(string nodeId)
+        {
+            if (_shopStocks.TryGetValue(nodeId, out var stock))
+                return stock;
+
+            int level = nodeId switch
+            {
+                "nodeSmallVillage" => 5,
+                "nodeMounttown" => 15,
+                "nodeRiverVillage" => 25,
+                _ => 5
+            };
+
+            var pool = GetPool(level);
+            var items = new List<Item>
+            {
+                // every shop sells at least one potion
+                new HealingPotion()
+            };
+
+            for (int i = items.Count; i < 5; i++)
+            {
+                var available = pool.Where(n => !_usedItems.Contains(n)).ToList();
+                if (available.Count == 0)
+                    available = pool; // allow reuse if pool exhausted
+                string name = available[_rng.Next(available.Count)];
+                _usedItems.Add(name);
+                Item? item = InventoryService.CreateItem(name);
+                if (item != null)
+                    items.Add(item);
+            }
+
+            _shopStocks[nodeId] = items;
+            return items;
+        }
+
+        /// <summary>
+        /// Returns a random item suitable for an enemy of the given level.
+        /// This does not affect shop stock and can return items already used
+        /// by shops.
+        /// </summary>
+        public static Item? GetEnemyLoot(int level)
+        {
+            var pool = GetPool(level);
+            if (pool.Count == 0)
+                return null;
+            string name = pool[_rng.Next(pool.Count)];
+            return InventoryService.CreateItem(name);
+        }
+    }
+}

--- a/WinFormsApp2/LootService.cs
+++ b/WinFormsApp2/LootService.cs
@@ -42,6 +42,15 @@ namespace WinFormsApp2
                 goldCmd.ExecuteNonQuery();
             }
             conn.Close();
+
+            // chance to drop additional loot from global pool
+            Item? bonusLoot = LootPool.GetEnemyLoot(avgLevel);
+            if (bonusLoot != null)
+            {
+                drops[bonusLoot.Name] = drops.GetValueOrDefault(bonusLoot.Name) + 1;
+                InventoryService.AddItem(bonusLoot);
+            }
+
             foreach (var kvp in drops.Where(k => k.Key != "gold"))
             {
                 for (int i = 0; i < kvp.Value; i++)

--- a/WinFormsApp2/NavigationWindow.cs
+++ b/WinFormsApp2/NavigationWindow.cs
@@ -149,7 +149,7 @@ namespace WinFormsApp2
 
         private void BtnShop_Click(object? sender, EventArgs e)
         {
-            using var shop = new ShopForm(_accountId);
+            using var shop = new ShopForm(_accountId, _currentNode);
             shop.ShowDialog(this);
             _refresh();
             UpdatePartySize();

--- a/WinFormsApp2/ShopForm.Designer.cs
+++ b/WinFormsApp2/ShopForm.Designer.cs
@@ -119,7 +119,7 @@ namespace WinFormsApp2
             Controls.Add(_lstShop);
             Name = "ShopForm";
             Text = "Shop";
-            Load += ShopForm_Load_2;
+            Load += ShopForm_Load;
             ResumeLayout(false);
             PerformLayout();
         }

--- a/WinFormsApp2/ShopForm.cs
+++ b/WinFormsApp2/ShopForm.cs
@@ -11,26 +11,14 @@ namespace WinFormsApp2
     {
         private readonly int _userId;
         private int _playerGold;
-        private readonly List<Item> _shopItems = new()
-        {
-            new HealingPotion(),
-            WeaponFactory.Create("dagger"),
-            WeaponFactory.Create("shortsword"),
-            WeaponFactory.Create("bow"),
-            WeaponFactory.Create("staff"),
-            WeaponFactory.Create("wand"),
-            ArmorFactory.Create("leatherarmor"),
-            ArmorFactory.Create("leathercap"),
-            ArmorFactory.Create("leatherboots"),
-            ArmorFactory.Create("clothrobe"),
-            ArmorFactory.Create("platearmor")
-        };
+        private readonly List<Item> _shopItems;
 
         private readonly ToolTip _tip = new();
 
-        public ShopForm(int userId)
+        public ShopForm(int userId, string nodeId)
         {
             _userId = userId;
+            _shopItems = LootPool.GetShopStock(nodeId);
             InitializeComponent();
             _btnBuy.Click += BtnBuy_Click;
             _btnSell.Click += BtnSell_Click;
@@ -231,14 +219,5 @@ namespace WinFormsApp2
             e.DrawFocusRectangle();
         }
 
-        private void ShopForm_Load_1(object sender, EventArgs e)
-        {
-
-        }
-
-        private void ShopForm_Load_2(object sender, EventArgs e)
-        {
-
-        }
     }
 }


### PR DESCRIPTION
## Summary
- introduce a global loot pool divided into level brackets for shops and enemies
- have shops draw unique stock from the loot pool based on location
- clamp HP/Mana progress bars to prevent rapid battle crash

## Testing
- `dotnet build WinFormsApp2/BattleLands.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6f0cc37c83339250d55c6c087bcb