### PR TITLE
Move battle flow to world map and improve recruiting

### DIFF
--- a/WinFormsApp2/BattleForm.Designer.cs
+++ b/WinFormsApp2/BattleForm.Designer.cs
@@ -39,6 +39,9 @@ namespace WinFormsApp2
             pnlPlayers.Name = "pnlPlayers";
             pnlPlayers.Size = new Size(252, 398);
             pnlPlayers.TabIndex = 2;
+            pnlPlayers.AutoScroll = true;
+            pnlPlayers.FlowDirection = FlowDirection.TopDown;
+            pnlPlayers.WrapContents = false;
             // 
             // pnlEnemies
             // 
@@ -47,6 +50,9 @@ namespace WinFormsApp2
             pnlEnemies.Name = "pnlEnemies";
             pnlEnemies.Size = new Size(264, 398);
             pnlEnemies.TabIndex = 1;
+            pnlEnemies.AutoScroll = true;
+            pnlEnemies.FlowDirection = FlowDirection.TopDown;
+            pnlEnemies.WrapContents = false;
             // 
             // lstLog
             //

--- a/WinFormsApp2/HeroViewForm.cs
+++ b/WinFormsApp2/HeroViewForm.cs
@@ -59,6 +59,18 @@ namespace WinFormsApp2
 
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
+
+            using (var countCmd = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@id AND is_dead=0", conn))
+            {
+                countCmd.Parameters.AddWithValue("@id", _userId);
+                int partyCount = Convert.ToInt32(countCmd.ExecuteScalar());
+                if (partyCount >= 5)
+                {
+                    MessageBox.Show("Party is full. Release a member before hiring.");
+                    return;
+                }
+            }
+
             using MySqlCommand goldCmd = new MySqlCommand("SELECT gold FROM users WHERE id=@id", conn);
             goldCmd.Parameters.AddWithValue("@id", _userId);
             int gold = Convert.ToInt32(goldCmd.ExecuteScalar());

--- a/WinFormsApp2/NavigationWindow.Designer.cs
+++ b/WinFormsApp2/NavigationWindow.Designer.cs
@@ -287,7 +287,7 @@
             btnFindEnemies.Name = "btnFindEnemies";
             btnFindEnemies.Size = new Size(150, 23);
             btnFindEnemies.TabIndex = 3;
-            btnFindEnemies.Text = "Find Enemies";
+            btnFindEnemies.Text = "Search for Enemies";
             btnFindEnemies.UseVisualStyleBackColor = true;
             // 
             // btnTavern

--- a/WinFormsApp2/RPGForm.Designer.cs
+++ b/WinFormsApp2/RPGForm.Designer.cs
@@ -13,7 +13,6 @@ namespace WinFormsApp2
         private FlowLayoutPanel pnlParty;
         private Button btnInspect;
         private Button btnFire;
-        private Button btnBattle;
         private Button btnInventory;
         private Button btnLogs;
         private Button btnNavigate;
@@ -53,7 +52,6 @@ namespace WinFormsApp2
             pnlParty = new FlowLayoutPanel();
             btnInspect = new Button();
             btnFire = new Button();
-            btnBattle = new Button();
             btnInventory = new Button();
             btnLogs = new Button();
             btnNavigate = new Button();
@@ -93,6 +91,7 @@ namespace WinFormsApp2
             pnlParty.Size = new Size(260, 154);
             pnlParty.FlowDirection = FlowDirection.TopDown;
             pnlParty.WrapContents = false;
+            pnlParty.AutoScroll = true;
             // 
             // btnInspect
             //
@@ -114,14 +113,6 @@ namespace WinFormsApp2
             btnFire.UseVisualStyleBackColor = true;
             btnFire.Click += btnFire_Click;
             //
-            // btnBattle
-            //
-            btnBattle.Location = new Point(12, 230);
-            btnBattle.Name = "btnBattle";
-            btnBattle.Size = new Size(260, 23);
-            btnBattle.Text = "Find Battle";
-            btnBattle.UseVisualStyleBackColor = true;
-            btnBattle.Click += btnBattle_Click;
             //
             // btnInventory
             //
@@ -268,7 +259,6 @@ namespace WinFormsApp2
             Controls.Add(lblGold);
             Controls.Add(btnLogs);
             Controls.Add(btnInventory);
-            Controls.Add(btnBattle);
             Controls.Add(btnFire);
             Controls.Add(btnInspect);
             Controls.Add(btnNavigate);

--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -90,7 +90,6 @@ namespace WinFormsApp2
             lblGold.Text = $"Gold: {_playerGold}";
             btnInspect.Enabled = false;
             btnInspect.Text = "Inspect";
-            btnBattle.Enabled = lstParty.Items.Count > 0;
         }
 
         private void lstParty_SelectedIndexChanged(object? sender, EventArgs e)
@@ -221,12 +220,6 @@ namespace WinFormsApp2
 
             MessageBox.Show($"{name} has been dismissed. You receive {refund} gold.");
             LoadPartyData();
-        }
-
-        private void btnBattle_Click(object? sender, EventArgs e)
-        {
-            using var battle = new BattleForm(_userId);
-            battle.ShowDialog(this);
         }
 
         private void btnLogs_Click(object? sender, EventArgs e)

--- a/WinFormsApp2/RecruitForm.cs
+++ b/WinFormsApp2/RecruitForm.cs
@@ -8,14 +8,14 @@ namespace WinFormsApp2
     {
         private readonly List<RecruitCandidate> _candidates;
         private readonly int _userId;
-        private readonly int _searchCost;
+        private readonly Func<int> _getSearchCost;
         private readonly Action _onHire;
 
-        public RecruitForm(int userId, List<RecruitCandidate> candidates, int searchCost, Action onHire)
+        public RecruitForm(int userId, List<RecruitCandidate> candidates, Func<int> getSearchCost, Action onHire)
         {
             _userId = userId;
             _candidates = candidates;
-            _searchCost = searchCost;
+            _getSearchCost = getSearchCost;
             _onHire = onHire;
             InitializeComponent();
             foreach (var c in _candidates)
@@ -32,7 +32,7 @@ namespace WinFormsApp2
         {
             if (lstCandidates.SelectedIndex < 0) return;
             var candidate = _candidates[lstCandidates.SelectedIndex];
-            using var view = new HeroViewForm(_userId, candidate, _searchCost);
+            using var view = new HeroViewForm(_userId, candidate, _getSearchCost());
             if (view.ShowDialog(this) == DialogResult.OK)
             {
                 int index = lstCandidates.SelectedIndex;


### PR DESCRIPTION
## Summary
- Relocate enemy search to world map activities
- Disable tavern recruiting when party reaches five and refresh costs after each hire
- Prepare UI panels to scroll for larger parties

## Testing
- `dotnet build WinFormsApp2/BattleLands.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7ec916f483338e2a146d45f67cb8