### PR TITLE
Display ability point cost in level-up window

### DIFF
--- a/WinFormsApp2/Ability.cs
+++ b/WinFormsApp2/Ability.cs
@@ -6,6 +6,7 @@ namespace WinFormsApp2
         public string Name { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
         public int Cost { get; set; }
+        public int PointCost { get; set; }
         public int Cooldown { get; set; }
         public int Slot { get; set; }
         public int Priority { get; set; }

--- a/WinFormsApp2/AbilityService.cs
+++ b/WinFormsApp2/AbilityService.cs
@@ -16,20 +16,26 @@ namespace WinFormsApp2
             var list = new List<Ability>();
             while (reader.Read())
             {
+                int manaCost = reader.GetInt32("cost");
                 list.Add(new Ability
                 {
                     Id = reader.GetInt32("id"),
                     Name = reader.GetString("name"),
                     Description = reader.GetString("description"),
-                    Cost = reader.GetInt32("cost"),
-                    Cooldown = reader.GetInt32("cooldown")
+                    Cost = manaCost,
+                    Cooldown = reader.GetInt32("cooldown"),
+                    PointCost = Math.Max(1, manaCost / 10)
                 });
             }
             return list;
         }
 
-        public static void PurchaseAbility(int characterId, int abilityId, MySqlConnection conn)
+        public static void PurchaseAbility(int characterId, int abilityId, int cost, MySqlConnection conn)
         {
+            using var spend = new MySqlCommand("UPDATE characters SET skill_points=skill_points-@c WHERE id=@cid", conn);
+            spend.Parameters.AddWithValue("@c", cost);
+            spend.Parameters.AddWithValue("@cid", characterId);
+            spend.ExecuteNonQuery();
             using var cmd = new MySqlCommand("INSERT INTO character_abilities(character_id, ability_id) VALUES(@c,@a)", conn);
             cmd.Parameters.AddWithValue("@c", characterId);
             cmd.Parameters.AddWithValue("@a", abilityId);
@@ -47,13 +53,15 @@ namespace WinFormsApp2
             var list = new List<Ability>();
             while (reader.Read())
             {
+                int manaCost = reader.GetInt32("cost");
                 list.Add(new Ability
                 {
                     Id = reader.GetInt32("id"),
                     Name = reader.GetString("name"),
                     Description = reader.GetString("description"),
-                    Cost = reader.GetInt32("cost"),
-                    Cooldown = reader.GetInt32("cooldown")
+                    Cost = manaCost,
+                    Cooldown = reader.GetInt32("cooldown"),
+                    PointCost = Math.Max(1, manaCost / 10)
                 });
             }
             return list;
@@ -70,6 +78,7 @@ namespace WinFormsApp2
             var list = new List<Ability>();
             while (reader.Read())
             {
+                int manaCost = reader.IsDBNull(reader.GetOrdinal("cost")) ? 0 : reader.GetInt32("cost");
                 var ability = new Ability
                 {
                     Slot = reader.GetInt32("slot"),
@@ -77,8 +86,9 @@ namespace WinFormsApp2
                     Id = reader.IsDBNull(reader.GetOrdinal("id")) ? 0 : reader.GetInt32("id"),
                     Name = reader.IsDBNull(reader.GetOrdinal("name")) ? "-basic attack-" : reader.GetString("name"),
                     Description = reader.IsDBNull(reader.GetOrdinal("description")) ? string.Empty : reader.GetString("description"),
-                    Cost = reader.IsDBNull(reader.GetOrdinal("cost")) ? 0 : reader.GetInt32("cost"),
-                    Cooldown = reader.IsDBNull(reader.GetOrdinal("cooldown")) ? 0 : reader.GetInt32("cooldown")
+                    Cost = manaCost,
+                    Cooldown = reader.IsDBNull(reader.GetOrdinal("cooldown")) ? 0 : reader.GetInt32("cooldown"),
+                    PointCost = Math.Max(1, manaCost / 10)
                 };
                 list.Add(ability);
             }

--- a/WinFormsApp2/LevelUpForm.cs
+++ b/WinFormsApp2/LevelUpForm.cs
@@ -79,6 +79,8 @@ namespace WinFormsApp2
                 lstAbilities.Items.Add(a.Name);
             }
             rtbAbility.Clear();
+            btnBuy.Text = "Buy";
+            btnBuy.Enabled = false;
             _passives = PassiveService.GetAvailablePassives(_characterId, conn);
             lstPassives.Items.Clear();
             foreach (var p in _passives)
@@ -109,9 +111,16 @@ namespace WinFormsApp2
                 MessageBox.Show("Not enough mana.");
                 return;
             }
+            if (_availablePoints < ability.PointCost)
+            {
+                MessageBox.Show("Not enough points.");
+                return;
+            }
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            AbilityService.PurchaseAbility(_characterId, ability.Id, conn);
+            AbilityService.PurchaseAbility(_characterId, ability.Id, ability.PointCost, conn);
+            _availablePoints -= ability.PointCost;
+            lblPoints.Text = $"Points: {_availablePoints}";
             _abilities = AbilityService.GetShopAbilities(_characterId, conn);
             lstAbilities.Items.Clear();
             foreach (var a in _abilities)
@@ -119,6 +128,8 @@ namespace WinFormsApp2
                 lstAbilities.Items.Add(a.Name);
             }
             rtbAbility.Clear();
+            btnBuy.Text = "Buy";
+            btnBuy.Enabled = false;
         }
 
         private void BtnBuyPassive_Click(object? sender, EventArgs e)
@@ -149,10 +160,14 @@ namespace WinFormsApp2
             if (lstAbilities.SelectedIndex < 0)
             {
                 rtbAbility.Clear();
+                btnBuy.Text = "Buy";
+                btnBuy.Enabled = false;
                 return;
             }
             var ability = _abilities[lstAbilities.SelectedIndex];
-            rtbAbility.Text = $"{ability.Description}\nCooldown: {ability.Cooldown}s\nMana Cost: {ability.Cost}";
+            rtbAbility.Text = $"{ability.Description}\nCooldown: {ability.Cooldown}s\nMana Cost: {ability.Cost}\nPoint Cost: {ability.PointCost}";
+            btnBuy.Text = $"Buy ({ability.PointCost} pt{(ability.PointCost > 1 ? "s" : string.Empty)})";
+            btnBuy.Enabled = ability.PointCost <= _availablePoints;
         }
 
         private void LstAbilities_MouseMove(object? sender, MouseEventArgs e)


### PR DESCRIPTION
## Summary
- show ability point cost on the level-up buy button
- deduct skill points when purchasing abilities and disable buying when insufficient

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8529fb1c8333850f2a4baf4f86ad