### PR TITLE
Prevent armor from unequipping main hand weapon

### DIFF
--- a/WinFormsApp2/InventoryService.cs
+++ b/WinFormsApp2/InventoryService.cs
@@ -196,12 +196,15 @@ namespace WinFormsApp2
             else
             {
                 _equipment[character][slot] = item;
-                var other = slot == EquipmentSlot.LeftHand ? EquipmentSlot.RightHand : EquipmentSlot.LeftHand;
-                if (_equipment[character].TryGetValue(other, out var otherItem) && otherItem is Weapon w2 && w2.TwoHanded)
+                if (slot == EquipmentSlot.LeftHand || slot == EquipmentSlot.RightHand)
                 {
-                    AddItem(otherItem);
-                    _equipment[character][other] = null;
-                    SaveEquipment(character, other, null);
+                    var other = slot == EquipmentSlot.LeftHand ? EquipmentSlot.RightHand : EquipmentSlot.LeftHand;
+                    if (_equipment[character].TryGetValue(other, out var otherItem) && otherItem is Weapon w2 && w2.TwoHanded)
+                    {
+                        AddItem(otherItem);
+                        _equipment[character][other] = null;
+                        SaveEquipment(character, other, null);
+                    }
                 }
                 SaveEquipment(character, slot, item);
             }


### PR DESCRIPTION
## Summary
- avoid clearing main-hand weapon when equipping non-hand armor

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68af6090e6a88333bb41e7675afe4508