### PR TITLE
Clamp gold after spending to prevent negative balances

### DIFF
--- a/WinFormsApp2/GraveyardForm.cs
+++ b/WinFormsApp2/GraveyardForm.cs
@@ -85,7 +85,7 @@ namespace WinFormsApp2
                 MessageBox.Show($"Need {cost} gold to resurrect.");
                 return;
             }
-            using var pay = new MySqlCommand("UPDATE users SET gold=gold-@c WHERE id=@id", conn);
+            using var pay = new MySqlCommand("UPDATE users SET gold=GREATEST(gold-@c,0) WHERE id=@id", conn);
             pay.Parameters.AddWithValue("@c", cost);
             pay.Parameters.AddWithValue("@id", _userId);
             pay.ExecuteNonQuery();

--- a/WinFormsApp2/HeroViewForm.cs
+++ b/WinFormsApp2/HeroViewForm.cs
@@ -79,7 +79,7 @@ namespace WinFormsApp2
                 MessageBox.Show("Not enough gold to hire this hero.");
                 return;
             }
-            using MySqlCommand updateGold = new MySqlCommand("UPDATE users SET gold=gold-@cost WHERE id=@id", conn);
+            using MySqlCommand updateGold = new MySqlCommand("UPDATE users SET gold=GREATEST(gold-@cost,0) WHERE id=@id", conn);
             updateGold.Parameters.AddWithValue("@cost", _hireCost);
             updateGold.Parameters.AddWithValue("@id", _userId);
             updateGold.ExecuteNonQuery();

--- a/WinFormsApp2/ShopForm.cs
+++ b/WinFormsApp2/ShopForm.cs
@@ -135,7 +135,7 @@ namespace WinFormsApp2
             }
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using MySqlCommand cmd = new MySqlCommand("UPDATE users SET gold = gold - @cost WHERE id=@id", conn);
+            using MySqlCommand cmd = new MySqlCommand("UPDATE users SET gold = GREATEST(gold - @cost, 0) WHERE id=@id", conn);
             cmd.Parameters.AddWithValue("@cost", proto.Price);
             cmd.Parameters.AddWithValue("@id", _userId);
             cmd.ExecuteNonQuery();

--- a/WinFormsApp2/TavernForm.cs
+++ b/WinFormsApp2/TavernForm.cs
@@ -67,7 +67,7 @@ namespace WinFormsApp2
                 return;
             }
 
-            using (var payCmd = new MySqlCommand("UPDATE users SET gold = gold - @cost WHERE id=@id", conn))
+            using (var payCmd = new MySqlCommand("UPDATE users SET gold = GREATEST(gold - @cost, 0) WHERE id=@id", conn))
             {
                 payCmd.Parameters.AddWithValue("@cost", _searchCost);
                 payCmd.Parameters.AddWithValue("@id", _accountId);

--- a/WinFormsApp2/TempleForm.cs
+++ b/WinFormsApp2/TempleForm.cs
@@ -36,7 +36,7 @@ namespace WinFormsApp2
                 MessageBox.Show("Not enough gold.");
                 return;
             }
-            using (var pay = new MySqlCommand("UPDATE users SET gold = gold - 100 WHERE id=@id", conn))
+            using (var pay = new MySqlCommand("UPDATE users SET gold = GREATEST(gold - 100, 0) WHERE id=@id", conn))
             {
                 pay.Parameters.AddWithValue("@id", _accountId);
                 pay.ExecuteNonQuery();

--- a/WinFormsApp2/TravelManager.cs
+++ b/WinFormsApp2/TravelManager.cs
@@ -56,7 +56,7 @@ namespace WinFormsApp2
             _travelCost = days * partySize * 5;
             using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using var cmd = new MySqlCommand("UPDATE users SET gold = gold - @c WHERE id=@id", conn);
+            using var cmd = new MySqlCommand("UPDATE users SET gold = GREATEST(gold - @c, 0) WHERE id=@id", conn);
             cmd.Parameters.AddWithValue("@c", _travelCost);
             cmd.Parameters.AddWithValue("@id", _accountId);
             cmd.ExecuteNonQuery();


### PR DESCRIPTION
## Summary
- Prevent negative gold after hiring heroes, resurrecting, traveling, shopping, searching for recruits, or buying temple blessings by clamping gold updates with `GREATEST(..., 0)`

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af65ca55f883338cfb4b65ef6fdcd6