### PR TITLE
Show party power and expand enemy encounters

### DIFF
--- a/WinFormsApp2/RPGForm.Designer.cs
+++ b/WinFormsApp2/RPGForm.Designer.cs
@@ -18,6 +18,7 @@ namespace WinFormsApp2
         private Button btnNavigate;
         private Label lblGold;
         private Label lblTotalExp;
+        private Label partyPowerLabel;
         private TabControl tabSocial;
         private TabPage tabChat;
         private TabPage tabFriends;
@@ -57,6 +58,7 @@ namespace WinFormsApp2
             btnNavigate = new Button();
             lblGold = new Label();
             lblTotalExp = new Label();
+            partyPowerLabel = new Label();
             tabSocial = new TabControl();
             tabChat = new TabPage();
             txtChatDisplay = new TextBox();
@@ -157,13 +159,22 @@ namespace WinFormsApp2
             lblGold.Text = "Gold:";
             // 
             // lblTotalExp
-            // 
+            //
             lblTotalExp.AutoSize = true;
             lblTotalExp.Location = new Point(567, 45);
             lblTotalExp.Name = "lblTotalExp";
             lblTotalExp.Size = new Size(60, 15);
             lblTotalExp.TabIndex = 1;
             lblTotalExp.Text = "Party EXP:";
+            //
+            // partyPowerLabel
+            //
+            partyPowerLabel.AutoSize = true;
+            partyPowerLabel.Location = new Point(567, 74);
+            partyPowerLabel.Name = "partyPowerLabel";
+            partyPowerLabel.Size = new Size(82, 15);
+            partyPowerLabel.TabIndex = 10;
+            partyPowerLabel.Text = "Party Power:";
             // 
             // tabSocial
             // 
@@ -288,6 +299,7 @@ namespace WinFormsApp2
             ClientSize = new Size(684, 626);
             Controls.Add(tabSocial);
             Controls.Add(lblTotalExp);
+            Controls.Add(partyPowerLabel);
             Controls.Add(lblGold);
             Controls.Add(btnLogs);
             Controls.Add(btnInventory);


### PR DESCRIPTION
## Summary
- Compute party power from levels, equipment value, and learned skills and show it on the main RPG screen
- Display party power beside arena team names and in tooltips for challengers
- Spawn encounters with a strong foe and 1–2 weaker allies to increase multi-enemy fights

## Testing
- ⚠️ `dotnet build` *(dotnet not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68af671d2b048333b8cfde873215d15f