### PR TITLE
Balance loot and progression systems

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -985,7 +985,7 @@ namespace WinFormsApp2
             conn.Open();
             int partySize = _players.Count;
             if (partySize <= 0) return;
-            int expGain = totalEnemyLevels * 20;
+            int expGain = totalEnemyLevels * 10;
             int expPer = expGain / partySize;
             using var updateCmd = new MySqlCommand("UPDATE characters SET experience_points = experience_points + @exp WHERE account_id=@id AND is_dead=0 AND in_arena=@arena", conn);
             updateCmd.Parameters.AddWithValue("@exp", expPer);

--- a/WinFormsApp2/LootPool.cs
+++ b/WinFormsApp2/LootPool.cs
@@ -83,7 +83,7 @@ namespace WinFormsApp2
                 new HealingPotion()
             };
 
-            for (int i = items.Count; i < 5; i++)
+            for (int i = items.Count; i < 15; i++)
             {
                 var available = pool.Where(n => !_usedItems.Contains(n)).ToList();
                 if (available.Count == 0)

--- a/WinFormsApp2/LootService.cs
+++ b/WinFormsApp2/LootService.cs
@@ -36,8 +36,10 @@ namespace WinFormsApp2
             int avgLevel = Math.Max(1, (int)Math.Round(npcs.Average(n => n.level)));
             if (drops.TryGetValue("gold", out int gold))
             {
+                int boostedGold = (int)Math.Round(gold * 1.5);
+                drops["gold"] = boostedGold;
                 using MySqlCommand goldCmd = new MySqlCommand("UPDATE users SET gold = gold + @g WHERE id=@id", conn);
-                goldCmd.Parameters.AddWithValue("@g", gold);
+                goldCmd.Parameters.AddWithValue("@g", boostedGold);
                 goldCmd.Parameters.AddWithValue("@id", userId);
                 goldCmd.ExecuteNonQuery();
             }


### PR DESCRIPTION
## Summary
- Halve party experience gain per battle
- Expand each shop's stock by ten additional items
- Boost gold drops from enemies by 50%

## Testing
- ⚠️ `dotnet build WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af9e60e3648333bd15a6b45484007c