### PR TITLE
Expose ArenaForm controls to designer

### DIFF
--- a/WinFormsApp2/ArenaForm.Designer.cs
+++ b/WinFormsApp2/ArenaForm.Designer.cs
@@ -1,0 +1,76 @@
+using System.Windows.Forms;
+using System.Drawing;
+
+namespace WinFormsApp2
+{
+    partial class ArenaForm
+    {
+        private System.ComponentModel.IContainer? components = null;
+        private ListBox _lstTeams;
+        private Button _btnChallenge;
+        private Button _btnDeposit;
+        private Label _lblStatus;
+        private ToolTip _tip;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && components != null)
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            components = new System.ComponentModel.Container();
+            _lblStatus = new Label();
+            _lstTeams = new ListBox();
+            _btnChallenge = new Button();
+            _btnDeposit = new Button();
+            _tip = new ToolTip(components);
+            SuspendLayout();
+            // 
+            // _lblStatus
+            // 
+            _lblStatus.AutoSize = true;
+            _lblStatus.Location = new Point(10, 10);
+            // 
+            // _lstTeams
+            // 
+            _lstTeams.Location = new Point(10, 40);
+            _lstTeams.Size = new Size(260, 140);
+            _lstTeams.SelectedIndexChanged += LstTeams_SelectedIndexChanged;
+            _lstTeams.MouseMove += LstTeams_MouseMove;
+            // 
+            // _btnChallenge
+            // 
+            _btnChallenge.Location = new Point(30, 190);
+            _btnChallenge.Size = new Size(100, 23);
+            _btnChallenge.Text = "Challenge";
+            _btnChallenge.Click += BtnChallenge_Click;
+            // 
+            // _btnDeposit
+            // 
+            _btnDeposit.Location = new Point(150, 190);
+            _btnDeposit.Size = new Size(100, 23);
+            _btnDeposit.Text = "Deposit";
+            _btnDeposit.Click += BtnDeposit_Click;
+            // 
+            // ArenaForm
+            // 
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(300, 260);
+            Controls.Add(_lblStatus);
+            Controls.Add(_lstTeams);
+            Controls.Add(_btnChallenge);
+            Controls.Add(_btnDeposit);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            StartPosition = FormStartPosition.CenterParent;
+            Text = "Battle Arena";
+            ResumeLayout(false);
+            PerformLayout();
+        }
+    }
+}

--- a/WinFormsApp2/ArenaForm.cs
+++ b/WinFormsApp2/ArenaForm.cs
@@ -6,37 +6,16 @@ using MySql.Data.MySqlClient;
 
 namespace WinFormsApp2
 {
-    public class ArenaForm : Form
+    public partial class ArenaForm : Form
     {
         private readonly int _userId;
         private int _wins;
-        private readonly ListBox _lstTeams;
-        private readonly Button _btnChallenge;
-        private readonly Button _btnDeposit;
-        private readonly Label _lblStatus;
-        private readonly ToolTip _tip = new();
         private bool _deposited;
 
         public ArenaForm(int userId)
         {
             _userId = userId;
-            Text = "Battle Arena";
-            Width = 300;
-            Height = 260;
-            FormBorderStyle = FormBorderStyle.FixedDialog;
-            StartPosition = FormStartPosition.CenterParent;
-
-            _lblStatus = new Label { Left = 10, Top = 10, AutoSize = true };
-            _lstTeams = new ListBox { Left = 10, Top = 40, Width = 260, Height = 140 };
-            _lstTeams.SelectedIndexChanged += (s, e) => UpdateButtons();
-            _lstTeams.MouseMove += LstTeams_MouseMove;
-
-            _btnChallenge = new Button { Text = "Challenge", Width = 100, Left = 30, Top = 190 };
-            _btnChallenge.Click += BtnChallenge_Click;
-            _btnDeposit = new Button { Text = "Deposit", Width = 100, Left = 150, Top = 190 };
-            _btnDeposit.Click += BtnDeposit_Click;
-
-            Controls.AddRange(new Control[] { _lblStatus, _lstTeams, _btnChallenge, _btnDeposit });
+            InitializeComponent();
             Load += ArenaForm_Load;
         }
 
@@ -95,6 +74,8 @@ namespace WinFormsApp2
         {
             _btnChallenge.Enabled = _lstTeams.SelectedItem != null && _lstTeams.Items.Count > 0;
         }
+
+        private void LstTeams_SelectedIndexChanged(object? sender, EventArgs e) => UpdateButtons();
 
         private void BtnDeposit_Click(object? sender, EventArgs e)
         {


### PR DESCRIPTION
## Summary
- Convert ArenaForm to a partial class and move control initialization into a designer file so all buttons and labels are editable in the WinForms designer
- Add selection change handler to update buttons when list box selection changes

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68afa608ace08333947867ced511dc48