### PR TITLE
Fix HireMultiplayerPartyWindow designer namespace and partial declaration

### DIFF
--- a/WinFormsApp2/HireMultiplayerPartyWindow.Designer.cs
+++ b/WinFormsApp2/HireMultiplayerPartyWindow.Designer.cs
@@ -1,4 +1,7 @@
-﻿namespace BattleLands
+using System.Windows.Forms;
+using System.Drawing;
+
+namespace WinFormsApp2
 {
     partial class HireMultiplayerPartyWindow
     {

--- a/WinFormsApp2/HireMultiplayerPartyWindow.cs
+++ b/WinFormsApp2/HireMultiplayerPartyWindow.cs
@@ -25,7 +25,7 @@ namespace WinFormsApp2
         public override string ToString() => Name;
     }
 
-    public class HireMultiplayerPartyWindow : Form
+    public partial class HireMultiplayerPartyWindow : Form
     {
         private readonly ListBox _partyList = new();
         private readonly ListBox _memberList = new();


### PR DESCRIPTION
## Summary
- align HireMultiplayerPartyWindow.Designer with project namespace and include required using directives
- mark HireMultiplayerPartyWindow class partial so designer integrates

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afac71d57483338f1bcc37480a2d13