### PR TITLE
Remove hired-out heroes from active party

### DIFF
--- a/WinFormsApp2/ArenaForm.cs
+++ b/WinFormsApp2/ArenaForm.cs
@@ -83,7 +83,7 @@ namespace WinFormsApp2
             conn.Open();
             if (_deposited)
             {
-                using var partyCountCmd = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0", conn);
+                using var partyCountCmd = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn);
                 partyCountCmd.Parameters.AddWithValue("@id", _userId);
                 int partyCount = Convert.ToInt32(partyCountCmd.ExecuteScalar());
                 using var arenaCountCmd = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=1", conn);
@@ -104,7 +104,7 @@ namespace WinFormsApp2
             }
             else
             {
-                using var chk = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0", conn);
+                using var chk = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn);
                 chk.Parameters.AddWithValue("@id", _userId);
                 if (Convert.ToInt32(chk.ExecuteScalar()) == 0)
                 {
@@ -114,7 +114,7 @@ namespace WinFormsApp2
                 using var ins = new MySqlCommand("INSERT INTO arena_teams(account_id,wins) VALUES(@id,0) ON DUPLICATE KEY UPDATE wins=wins", conn);
                 ins.Parameters.AddWithValue("@id", _userId);
                 ins.ExecuteNonQuery();
-                using var upd = new MySqlCommand("UPDATE characters SET in_arena=1 WHERE account_id=@id AND is_dead=0 AND in_arena=0", conn);
+                using var upd = new MySqlCommand("UPDATE characters SET in_arena=1 WHERE account_id=@id AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn);
                 upd.Parameters.AddWithValue("@id", _userId);
                 upd.ExecuteNonQuery();
                 _deposited = true;
@@ -188,7 +188,7 @@ namespace WinFormsApp2
                 using var del = new MySqlCommand("DELETE FROM arena_teams WHERE account_id=@id", conn);
                 del.Parameters.AddWithValue("@id", team.AccountId);
                 del.ExecuteNonQuery();
-                using var kill = new MySqlCommand("UPDATE characters SET is_dead=1, in_graveyard=1, in_arena=0, current_hp=0, death_time=NOW(), cause_of_death='Arena defeat' WHERE account_id=@id AND is_dead=0", conn);
+                using var kill = new MySqlCommand("UPDATE characters SET is_dead=1, in_graveyard=1, in_arena=0, in_tavern=0, current_hp=0, death_time=NOW(), cause_of_death='Arena defeat' WHERE account_id=@id AND is_dead=0", conn);
                 kill.Parameters.AddWithValue("@id", team.AccountId);
                 kill.ExecuteNonQuery();
                 using var winCmd = new MySqlCommand("UPDATE arena_teams SET wins=wins+1 WHERE account_id=@id", conn);

--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -68,8 +68,8 @@ namespace WinFormsApp2
             conn.Open();
 
             string playerQuery = _arenaBattle
-                ? "SELECT id, name, level, current_hp, max_hp, mana, strength, dex, intelligence, action_speed, melee_defense, magic_defense, role, targeting_style FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=1"
-                : "SELECT id, name, level, current_hp, max_hp, mana, strength, dex, intelligence, action_speed, melee_defense, magic_defense, role, targeting_style FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0";
+                ? "SELECT id, name, level, current_hp, max_hp, mana, strength, dex, intelligence, action_speed, melee_defense, magic_defense, role, targeting_style FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=1 AND in_tavern=0"
+                : "SELECT id, name, level, current_hp, max_hp, mana, strength, dex, intelligence, action_speed, melee_defense, magic_defense, role, targeting_style FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0 AND in_tavern=0";
             using var cmd = new MySqlCommand(playerQuery, conn);
             cmd.Parameters.AddWithValue("@id", _userId);
 
@@ -254,7 +254,7 @@ namespace WinFormsApp2
             }
             _opponentAccountId = oppId;
             InventoryService.Load(oppId);
-            using var cmd = new MySqlCommand("SELECT id, name, level, current_hp, max_hp, mana, strength, dex, intelligence, action_speed, melee_defense, magic_defense, role, targeting_style FROM characters WHERE account_id=@aid AND is_dead=0 AND in_arena=1", conn);
+            using var cmd = new MySqlCommand("SELECT id, name, level, current_hp, max_hp, mana, strength, dex, intelligence, action_speed, melee_defense, magic_defense, role, targeting_style FROM characters WHERE account_id=@aid AND is_dead=0 AND in_arena=1 AND in_tavern=0", conn);
             cmd.Parameters.AddWithValue("@aid", oppId);
             var npcIds = new Dictionary<Creature, int>();
             using (var r = cmd.ExecuteReader())
@@ -987,7 +987,7 @@ namespace WinFormsApp2
             if (partySize <= 0) return;
             int expGain = totalEnemyLevels * 10;
             int expPer = expGain / partySize;
-            using var updateCmd = new MySqlCommand("UPDATE characters SET experience_points = experience_points + @exp WHERE account_id=@id AND is_dead=0 AND in_arena=@arena", conn);
+            using var updateCmd = new MySqlCommand("UPDATE characters SET experience_points = experience_points + @exp WHERE account_id=@id AND is_dead=0 AND in_arena=@arena AND in_tavern=0", conn);
             updateCmd.Parameters.AddWithValue("@exp", expPer);
             updateCmd.Parameters.AddWithValue("@id", _userId);
             updateCmd.Parameters.AddWithValue("@arena", _arenaBattle ? 1 : 0);
@@ -1148,7 +1148,7 @@ namespace WinFormsApp2
                 }
                 string cause = _deathCauses.GetValueOrDefault(p.Name, "Unknown");
                 DialogResult res = MessageBox.Show($"Send {p.Name}'s body to the nearest graveyard?", "Graveyard", MessageBoxButtons.YesNo);
-                using (var deadCmd = new MySqlCommand("UPDATE characters SET is_dead=1, in_arena=0 WHERE account_id=@id AND name=@name", conn))
+                using (var deadCmd = new MySqlCommand("UPDATE characters SET is_dead=1, in_arena=0, in_tavern=0 WHERE account_id=@id AND name=@name", conn))
                 {
                     deadCmd.Parameters.AddWithValue("@id", _userId);
                     deadCmd.Parameters.AddWithValue("@name", p.Name);

--- a/WinFormsApp2/GraveyardForm.cs
+++ b/WinFormsApp2/GraveyardForm.cs
@@ -89,7 +89,7 @@ namespace WinFormsApp2
             pay.Parameters.AddWithValue("@c", cost);
             pay.Parameters.AddWithValue("@id", _userId);
             pay.ExecuteNonQuery();
-            using var res = new MySqlCommand("UPDATE characters SET is_dead=0, in_graveyard=0, in_arena=0, current_hp=max_hp, cause_of_death=NULL, death_time=NULL WHERE id=@cid", conn);
+            using var res = new MySqlCommand("UPDATE characters SET is_dead=0, in_graveyard=0, in_arena=0, in_tavern=0, current_hp=max_hp, cause_of_death=NULL, death_time=NULL WHERE id=@cid", conn);
             res.Parameters.AddWithValue("@cid", d.Id);
             res.ExecuteNonQuery();
             MessageBox.Show($"{d.Name} has been resurrected!");

--- a/WinFormsApp2/HeroViewForm.cs
+++ b/WinFormsApp2/HeroViewForm.cs
@@ -60,7 +60,7 @@ namespace WinFormsApp2
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
 
-            using (var countCmd = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0", conn))
+            using (var countCmd = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn))
             {
                 countCmd.Parameters.AddWithValue("@id", _userId);
                 int partyCount = Convert.ToInt32(countCmd.ExecuteScalar());

--- a/WinFormsApp2/InventoryForm.cs
+++ b/WinFormsApp2/InventoryForm.cs
@@ -98,7 +98,7 @@ namespace WinFormsApp2
             {
                 using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
                 conn.Open();
-                using MySqlCommand cmd = new MySqlCommand("UPDATE characters SET current_hp = LEAST(max_hp, current_hp + @heal) WHERE account_id=@uid AND name=@name AND is_dead=0 AND in_arena=0", conn);
+                using MySqlCommand cmd = new MySqlCommand("UPDATE characters SET current_hp = LEAST(max_hp, current_hp + @heal) WHERE account_id=@uid AND name=@name AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn);
                 cmd.Parameters.AddWithValue("@heal", ((HealingPotion)item).HealAmount);
                 cmd.Parameters.AddWithValue("@uid", _userId);
                 cmd.Parameters.AddWithValue("@name", _selectedTarget);
@@ -113,7 +113,7 @@ namespace WinFormsApp2
             cmbTarget.Items.Clear();
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using MySqlCommand cmd = new MySqlCommand("SELECT name FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0", conn);
+            using MySqlCommand cmd = new MySqlCommand("SELECT name FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn);
             cmd.Parameters.AddWithValue("@id", _userId);
             using var r = cmd.ExecuteReader();
             while (r.Read())

--- a/WinFormsApp2/NavigationWindow.cs
+++ b/WinFormsApp2/NavigationWindow.cs
@@ -259,7 +259,7 @@ namespace WinFormsApp2
         {
             using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using var cmd = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0", conn);
+            using var cmd = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn);
             cmd.Parameters.AddWithValue("@id", _accountId);
             _partySize = Convert.ToInt32(cmd.ExecuteScalar());
         }

--- a/WinFormsApp2/PartyHireService.cs
+++ b/WinFormsApp2/PartyHireService.cs
@@ -99,7 +99,7 @@ namespace WinFormsApp2.Multiplayer
             var members = new List<HireableMember>();
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using MySqlCommand cmd = new MySqlCommand("SELECT name,strength,dex,intelligence,experience_points FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0", conn);
+            using MySqlCommand cmd = new MySqlCommand("SELECT name,strength,dex,intelligence,experience_points FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn);
             cmd.Parameters.AddWithValue("@id", ownerId);
             using var reader = cmd.ExecuteReader();
             while (reader.Read())
@@ -114,6 +114,12 @@ namespace WinFormsApp2.Multiplayer
                 });
             }
             if (members.Count == 0) return false;
+
+            using (var upd = new MySqlCommand("UPDATE characters SET in_tavern=1 WHERE account_id=@id AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn))
+            {
+                upd.Parameters.AddWithValue("@id", ownerId);
+                upd.ExecuteNonQuery();
+            }
             var party = new HireableParty
             {
                 OwnerId = ownerId,
@@ -166,10 +172,15 @@ namespace WinFormsApp2.Multiplayer
             list.Remove(existing);
             SaveState();
             int gold = existing.GoldEarned;
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using (var upd = new MySqlCommand("UPDATE characters SET in_tavern=0 WHERE account_id=@id", conn))
+            {
+                upd.Parameters.AddWithValue("@id", ownerId);
+                upd.ExecuteNonQuery();
+            }
             if (gold > 0)
             {
-                using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
-                conn.Open();
                 using MySqlCommand add = new MySqlCommand("UPDATE users SET gold = gold + @g WHERE id=@id", conn);
                 add.Parameters.AddWithValue("@g", gold);
                 add.Parameters.AddWithValue("@id", ownerId);

--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -39,7 +39,7 @@ namespace WinFormsApp2
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
 
-            using MySqlCommand cmd = new MySqlCommand("SELECT name, experience_points, level, current_hp, max_hp, mana, intelligence FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0", conn);
+            using MySqlCommand cmd = new MySqlCommand("SELECT name, experience_points, level, current_hp, max_hp, mana, intelligence FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn);
             cmd.Parameters.AddWithValue("@id", _userId);
             using MySqlDataReader reader = cmd.ExecuteReader();
             lstParty.Items.Clear();
@@ -90,7 +90,7 @@ namespace WinFormsApp2
 
             lblTotalExp.Text = $"Party EXP: {totalExp}";
             int totalSkills = 0;
-            using (var skillCmd = new MySqlCommand("SELECT COUNT(*) FROM character_abilities ca JOIN characters c ON ca.character_id=c.id WHERE c.account_id=@id AND c.is_dead=0 AND in_arena=0", conn))
+            using (var skillCmd = new MySqlCommand("SELECT COUNT(*) FROM character_abilities ca JOIN characters c ON ca.character_id=c.id WHERE c.account_id=@id AND c.is_dead=0 AND in_arena=0 AND in_tavern=0", conn))
             {
                 skillCmd.Parameters.AddWithValue("@id", _userId);
                 object? sres = skillCmd.ExecuteScalar();
@@ -136,7 +136,7 @@ namespace WinFormsApp2
 
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using MySqlCommand cmd = new MySqlCommand("SELECT id FROM characters WHERE account_id=@id AND name=@name AND is_dead=0 AND in_arena=0", conn);
+            using MySqlCommand cmd = new MySqlCommand("SELECT id FROM characters WHERE account_id=@id AND name=@name AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn);
             cmd.Parameters.AddWithValue("@id", _userId);
             cmd.Parameters.AddWithValue("@name", name);
             object? result = cmd.ExecuteScalar();
@@ -184,7 +184,7 @@ namespace WinFormsApp2
 
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using MySqlCommand cmd = new MySqlCommand("SELECT id, level FROM characters WHERE account_id=@id AND name=@name AND is_dead=0 AND in_arena=0", conn);
+            using MySqlCommand cmd = new MySqlCommand("SELECT id, level FROM characters WHERE account_id=@id AND name=@name AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn);
             cmd.Parameters.AddWithValue("@id", _userId);
             cmd.Parameters.AddWithValue("@name", name);
             using var reader = cmd.ExecuteReader();
@@ -281,7 +281,7 @@ namespace WinFormsApp2
                 "UPDATE characters SET " +
                 "current_hp = LEAST(max_hp, current_hp + 5 + CEILING(max_hp*0.05)), " +
                 "mana = LEAST(10 + 5*intelligence, mana + 5 + CEILING((10 + 5*intelligence)*0.05)) " +
-                "WHERE account_id=@id AND is_dead=0 AND in_arena=0 AND current_hp>0 AND (current_hp < max_hp OR mana < (10 + 5*intelligence))",
+                "WHERE account_id=@id AND is_dead=0 AND in_arena=0 AND in_tavern=0 AND current_hp>0 AND (current_hp < max_hp OR mana < (10 + 5*intelligence))",
                 conn);
             cmd.Parameters.AddWithValue("@id", _userId);
             cmd.ExecuteNonQuery();

--- a/WinFormsApp2/TavernForm.cs
+++ b/WinFormsApp2/TavernForm.cs
@@ -102,7 +102,7 @@ namespace WinFormsApp2
             int totalLevel = 0;
             using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using var cmd = new MySqlCommand("SELECT level FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0", conn);
+            using var cmd = new MySqlCommand("SELECT level FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn);
             cmd.Parameters.AddWithValue("@id", _accountId);
             using var reader = cmd.ExecuteReader();
             while (reader.Read())

--- a/characters.sql
+++ b/characters.sql
@@ -19,5 +19,6 @@ CREATE TABLE IF NOT EXISTS characters (
     magic_defense INT NOT NULL,
     level INT NOT NULL DEFAULT 1,
     skill_points INT NOT NULL DEFAULT 0,
+    in_tavern TINYINT NOT NULL DEFAULT 0,
     FOREIGN KEY (account_id) REFERENCES users(id)
 );

--- a/update_characters_tavern.sql
+++ b/update_characters_tavern.sql
@@ -1,0 +1,4 @@
+USE accounts;
+
+ALTER TABLE characters
+    ADD COLUMN in_tavern TINYINT NOT NULL DEFAULT 0;


### PR DESCRIPTION
## Summary
- mark characters deposited for hire as in_tavern
- hide in_tavern heroes from party queries and battles
- add SQL migration for in_tavern column

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln -p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_68afb8ccc4b883338381dfbd7acef627