### PR TITLE
Allow raid-size parties and refresh tavern lists

### DIFF
--- a/WinFormsApp2/ArenaForm.cs
+++ b/WinFormsApp2/ArenaForm.cs
@@ -89,7 +89,7 @@ namespace WinFormsApp2
                 using var arenaCountCmd = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=1", conn);
                 arenaCountCmd.Parameters.AddWithValue("@id", _userId);
                 int arenaCount = Convert.ToInt32(arenaCountCmd.ExecuteScalar());
-                if (partyCount + arenaCount > 5)
+                if (partyCount + arenaCount > 10)
                 {
                     MessageBox.Show("You need to make room to withdraw your party members.");
                     return;

--- a/WinFormsApp2/HeroViewForm.cs
+++ b/WinFormsApp2/HeroViewForm.cs
@@ -64,7 +64,7 @@ namespace WinFormsApp2
             {
                 countCmd.Parameters.AddWithValue("@id", _userId);
                 int partyCount = Convert.ToInt32(countCmd.ExecuteScalar());
-                if (partyCount >= 5)
+                if (partyCount >= 10)
                 {
                     MessageBox.Show("Party is full. Release a member before hiring.");
                     return;

--- a/WinFormsApp2/HireMultiplayerPartyWindow.cs
+++ b/WinFormsApp2/HireMultiplayerPartyWindow.cs
@@ -9,6 +9,7 @@ namespace WinFormsApp2
     public partial class HireMultiplayerPartyWindow : Form
     {
         private readonly int _accountId;
+        private readonly Action? _onChange;
 
         private readonly ListBox _partyList = new();
         private readonly ListBox _memberList = new();
@@ -18,9 +19,10 @@ namespace WinFormsApp2
         private readonly ListBox _myPartyList = new();
         private readonly NumericUpDown _costInput = new();
 
-        public HireMultiplayerPartyWindow(int accountId, bool showHireOut = false)
+        public HireMultiplayerPartyWindow(int accountId, Action? onChange = null, bool showHireOut = false)
         {
             _accountId = accountId;
+            _onChange = onChange;
             Text = "Multiplayer Tavern";
             Width = 520;
             Height = 360;
@@ -87,6 +89,9 @@ namespace WinFormsApp2
                 _myPartyList.Items.Add($"{party.Name} {status} - Earned {party.GoldEarned}g");
 
             }
+
+            _memberList.Items.Clear();
+            _statsLabel.Text = string.Empty;
         }
 
         private void PartySelected(object? sender, EventArgs e)
@@ -126,6 +131,7 @@ namespace WinFormsApp2
                 {
                     MessageBox.Show($"Hired {party.Name} for {party.Cost}g.");
                     RefreshLists();
+                    _onChange?.Invoke();
                 }
                 else
                 {
@@ -141,6 +147,7 @@ namespace WinFormsApp2
             {
                 MessageBox.Show("Party deposited for hire.");
                 RefreshLists();
+                _onChange?.Invoke();
             }
             else
             {
@@ -163,6 +170,7 @@ namespace WinFormsApp2
             int gold = PartyHireService.RetrieveParty(_accountId, party);
             MessageBox.Show(gold > 0 ? $"Party retrieved. Earned {gold}g." : "Party retrieved.");
             RefreshLists();
+            _onChange?.Invoke();
         }
     }
 }

--- a/WinFormsApp2/TavernForm.cs
+++ b/WinFormsApp2/TavernForm.cs
@@ -22,7 +22,7 @@ namespace WinFormsApp2
         private void btnRecruit_Click(object? sender, EventArgs e)
         {
             _searchCost = CalculateSearchCost(out int partyCount);
-            if (partyCount >= 5)
+            if (partyCount >= 10)
             {
                 MessageBox.Show("Party is full. Release a member before recruiting.");
                 RefreshSearchCost();
@@ -65,13 +65,13 @@ namespace WinFormsApp2
 
         private void btnJoin_Click(object? sender, EventArgs e)
         {
-            using var window = new HireMultiplayerPartyWindow(_accountId);
+            using var window = new HireMultiplayerPartyWindow(_accountId, OnHire);
             window.ShowDialog(this);
         }
 
         private void btnHireOut_Click(object? sender, EventArgs e)
         {
-            using var window = new HireMultiplayerPartyWindow(_accountId, showHireOut: true);
+            using var window = new HireMultiplayerPartyWindow(_accountId, OnHire, showHireOut: true);
             window.ShowDialog(this);
         }
 
@@ -84,7 +84,7 @@ namespace WinFormsApp2
         private void RefreshSearchCost()
         {
             _searchCost = CalculateSearchCost(out int partyCount);
-            if (partyCount >= 5)
+            if (partyCount >= 10)
             {
                 btnRecruit.Text = "Party Full";
                 btnRecruit.Enabled = false;


### PR DESCRIPTION
## Summary
- Allow up to 10 party members across tavern, hero recruitment, and arena
- Refresh parent views when parties are hired, deposited, or withdrawn

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afcec376348333a4a8eedbc14ddb30