### PR TITLE
Allow interacting with multiple windows

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -916,9 +916,10 @@ namespace WinFormsApp2
                 SaveState();
                 var playerSummaries = _players.Select(p => new CombatantSummary(p.Name, p.DamageDone, p.DamageTaken));
                 var enemySummaries = _npcs.Select(n => new CombatantSummary(n.Name, n.DamageDone, n.DamageTaken));
-                using var summary = new BattleSummaryForm(playerSummaries, enemySummaries, playersWin, lootSummary);
+                var summary = new BattleSummaryForm(playerSummaries, enemySummaries, playersWin, lootSummary);
                 Hide();
-                summary.ShowDialog(this.Owner);
+                summary.FormClosed += (_, __) => summary.Dispose();
+                summary.Show(this.Owner);
                 Close();
             }
         }

--- a/WinFormsApp2/Form1.cs
+++ b/WinFormsApp2/Form1.cs
@@ -45,8 +45,9 @@ namespace WinFormsApp2
 
         private void btnCreateAccount_Click(object? sender, EventArgs e)
         {
-            using RegisterForm register = new RegisterForm();
-            register.ShowDialog();
+            var register = new RegisterForm();
+            register.FormClosed += (_, __) => register.Dispose();
+            register.Show(this);
         }
 
         internal static string HashPassword(string password)

--- a/WinFormsApp2/HeroInspectForm.cs
+++ b/WinFormsApp2/HeroInspectForm.cs
@@ -129,9 +129,13 @@ namespace WinFormsApp2
         private void BtnLevelUp_Click(object? sender, EventArgs e)
         {
             if (_readOnly) return;
-            using var form = new LevelUpForm(_userId, _characterId);
-            form.ShowDialog(this);
-            HeroInspectForm_Load(null, EventArgs.Empty);
+            var form = new LevelUpForm(_userId, _characterId);
+            form.FormClosed += (_, __) =>
+            {
+                HeroInspectForm_Load(null, EventArgs.Empty);
+                form.Dispose();
+            };
+            form.Show(this);
         }
 
         private void CmbRole_SelectedIndexChanged(object? sender, EventArgs e)

--- a/WinFormsApp2/NavigationWindow.cs
+++ b/WinFormsApp2/NavigationWindow.cs
@@ -206,44 +206,56 @@ namespace WinFormsApp2
 
         private void BtnShop_Click(object? sender, EventArgs e)
         {
-            using var shop = new ShopForm(_accountId, _currentNode);
-            shop.ShowDialog(this);
-            _refresh();
-            UpdatePartySize();
+            var shop = new ShopForm(_accountId, _currentNode);
+            shop.FormClosed += (_, __) =>
+            {
+                _refresh();
+                UpdatePartySize();
+                shop.Dispose();
+            };
+            shop.Show(this);
         }
 
         private void BtnGraveyard_Click(object? sender, EventArgs e)
         {
-            using var grave = new GraveyardForm(_accountId, () => { _refresh(); UpdatePartySize(); });
-            grave.ShowDialog(this);
+            var grave = new GraveyardForm(_accountId, () => { _refresh(); UpdatePartySize(); });
+            grave.FormClosed += (_, __) => grave.Dispose();
+            grave.Show(this);
         }
 
         private void BtnTavern_Click(object? sender, EventArgs e)
         {
-            using var tavern = new TavernForm(_accountId, () => { _refresh(); UpdatePartySize(); });
-            tavern.ShowDialog(this);
+            var tavern = new TavernForm(_accountId, () => { _refresh(); UpdatePartySize(); });
+            tavern.FormClosed += (_, __) => tavern.Dispose();
+            tavern.Show(this);
         }
 
         private void BtnFindEnemies_Click(object? sender, EventArgs e)
         {
             var node = WorldMapService.GetNode(_currentNode);
-            using var battle = new BattleForm(_accountId, areaMinLevel: node.MinEnemyLevel, areaMaxLevel: node.MaxEnemyLevel);
-            battle.ShowDialog(this);
-            _refresh();
-            UpdatePartySize();
-            LoadNode(_currentNode);
+            var battle = new BattleForm(_accountId, areaMinLevel: node.MinEnemyLevel, areaMaxLevel: node.MaxEnemyLevel);
+            battle.FormClosed += (_, __) =>
+            {
+                _refresh();
+                UpdatePartySize();
+                LoadNode(_currentNode);
+                battle.Dispose();
+            };
+            battle.Show(this);
         }
 
         private void BtnArena_Click(object? sender, EventArgs e)
         {
-            using var arena = new ArenaForm(_accountId);
-            arena.ShowDialog(this);
+            var arena = new ArenaForm(_accountId);
+            arena.FormClosed += (_, __) => arena.Dispose();
+            arena.Show(this);
         }
 
         private void BtnTemple_Click(object? sender, EventArgs e)
         {
-            using var temple = new TempleForm(_accountId, RefreshBlessing);
-            temple.ShowDialog(this);
+            var temple = new TempleForm(_accountId, RefreshBlessing);
+            temple.FormClosed += (_, __) => temple.Dispose();
+            temple.Show(this);
         }
 
         private void RefreshBlessing()
@@ -267,7 +279,15 @@ namespace WinFormsApp2
         private void TravelManager_AmbushEncounter()
         {
             lblTravelInfo.Text = "Ambushed by wild enemies!";
-            using var battle = new BattleForm(_accountId, true);
+            var battle = new BattleForm(_accountId, true);
+            battle.FormClosed += (_, __) =>
+            {
+                _refresh();
+                UpdatePartySize();
+                LoadNode(_currentNode);
+                _travelManager.ResumeAfterEncounter();
+                battle.Dispose();
+            };
             // If the navigation window has already been disposed (for example
             // when the user closes the form while travel continues), showing
             // a dialog with this form as the owner will throw an
@@ -275,16 +295,12 @@ namespace WinFormsApp2
             // form as the owner when it's still alive.
             if (!IsDisposed && IsHandleCreated)
             {
-                battle.ShowDialog(this);
+                battle.Show(this);
             }
             else
             {
-                battle.ShowDialog();
+                battle.Show();
             }
-            _refresh();
-            UpdatePartySize();
-            LoadNode(_currentNode);
-            _travelManager.ResumeAfterEncounter();
         }
 
         protected override void OnFormClosed(FormClosedEventArgs e)

--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -155,15 +155,19 @@ namespace WinFormsApp2
                 if (result != null)
                 {
                     int charId = Convert.ToInt32(result);
-                    using var inspect = new HeroInspectForm(_userId, charId, _hiredMembers.Contains(name));
-                    inspect.ShowDialog(this);
-                    LoadPartyData();
+                    var inspect = new HeroInspectForm(_userId, charId, _hiredMembers.Contains(name));
+                    inspect.FormClosed += (_, __) =>
+                    {
+                        LoadPartyData();
+                        inspect.Dispose();
+                    };
+                    inspect.Show(this);
                 }
         }
 
-        private bool ConfirmFire(string name)
+        private void ConfirmFire(string name, Action onConfirm)
         {
-            using var confirm = new Form
+            var confirm = new Form
             {
                 Width = 300,
                 Height = 150,
@@ -174,16 +178,16 @@ namespace WinFormsApp2
 
             var lbl = new Label { Left = 10, Top = 10, Width = 260, Text = $"Type '{name}' to confirm firing:" };
             var txt = new TextBox { Left = 10, Top = 40, Width = 260 };
-            var btn = new Button { Text = "Confirm", Left = 10, Top = 70, Width = 100, DialogResult = DialogResult.OK, Enabled = false };
-            btn.Click += (s, e) => confirm.Close();
+            var btn = new Button { Text = "Confirm", Left = 10, Top = 70, Width = 100, Enabled = false };
+            btn.Click += (s, e) => { confirm.Close(); onConfirm(); };
             txt.TextChanged += (s, e) => btn.Enabled = txt.Text == name;
 
             confirm.Controls.Add(lbl);
             confirm.Controls.Add(txt);
             confirm.Controls.Add(btn);
             confirm.AcceptButton = btn;
-
-            return confirm.ShowDialog(this) == DialogResult.OK;
+            confirm.FormClosed += (_, __) => confirm.Dispose();
+            confirm.Show(this);
         }
 
         private void btnFire_Click(object? sender, EventArgs e)
@@ -198,8 +202,11 @@ namespace WinFormsApp2
                 return;
             }
 
-            if (!ConfirmFire(name)) return;
+            ConfirmFire(name, () => FireHero(name));
+        }
 
+        private void FireHero(string name)
+        {
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
             using MySqlCommand cmd = new MySqlCommand("SELECT id, level FROM characters WHERE account_id=@id AND name=@name AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn);
@@ -259,8 +266,9 @@ namespace WinFormsApp2
 
         private void btnLogs_Click(object? sender, EventArgs e)
         {
-            using var logs = new BattleLogForm();
-            logs.ShowDialog(this);
+            var logs = new BattleLogForm();
+            logs.FormClosed += (_, __) => logs.Dispose();
+            logs.Show(this);
         }
 
         private void btnNavigate_Click(object? sender, EventArgs e)
@@ -273,22 +281,31 @@ namespace WinFormsApp2
                 cmd.Parameters.AddWithValue("@a", _userId);
                 hasBlessing = Convert.ToBoolean(cmd.ExecuteScalar() ?? 0);
             }
-            using var nav = new NavigationWindow(_userId, lstParty.Items.Count, hasBlessing, LoadPartyData);
-            nav.ShowDialog(this);
-            LoadPartyData();
+            var nav = new NavigationWindow(_userId, lstParty.Items.Count, hasBlessing, LoadPartyData);
+            nav.FormClosed += (_, __) =>
+            {
+                LoadPartyData();
+                nav.Dispose();
+            };
+            nav.Show(this);
         }
 
         private void btnMail_Click(object? sender, EventArgs e)
         {
-            using var box = new MailboxForm(_userId);
-            box.ShowDialog(this);
+            var box = new MailboxForm(_userId);
+            box.FormClosed += (_, __) => box.Dispose();
+            box.Show(this);
         }
 
         private void btnInventory_Click(object? sender, EventArgs e)
         {
-            using var inv = new InventoryForm(_userId);
-            inv.ShowDialog(this);
-            LoadPartyData();
+            var inv = new InventoryForm(_userId);
+            inv.FormClosed += (_, __) =>
+            {
+                LoadPartyData();
+                inv.Dispose();
+            };
+            inv.Show(this);
         }
 
         private void Regenerate()

--- a/WinFormsApp2/RecruitForm.cs
+++ b/WinFormsApp2/RecruitForm.cs
@@ -32,14 +32,19 @@ namespace WinFormsApp2
         {
             if (lstCandidates.SelectedIndex < 0) return;
             var candidate = _candidates[lstCandidates.SelectedIndex];
-            using var view = new HeroViewForm(_userId, candidate, _getSearchCost());
-            if (view.ShowDialog(this) == DialogResult.OK)
+            int index = lstCandidates.SelectedIndex;
+            var view = new HeroViewForm(_userId, candidate, _getSearchCost());
+            view.FormClosed += (_, __) =>
             {
-                int index = lstCandidates.SelectedIndex;
-                _candidates.RemoveAt(index);
-                lstCandidates.Items.RemoveAt(index);
-                _onHire();
-            }
+                if (view.DialogResult == DialogResult.OK)
+                {
+                    _candidates.RemoveAt(index);
+                    lstCandidates.Items.RemoveAt(index);
+                    _onHire();
+                }
+                view.Dispose();
+            };
+            view.Show(this);
         }
     }
 }

--- a/WinFormsApp2/TavernForm.cs
+++ b/WinFormsApp2/TavernForm.cs
@@ -59,20 +59,23 @@ namespace WinFormsApp2
                 candidates.Add(RecruitCandidate.Generate(rng, i));
             }
 
-            using var recruitForm = new RecruitForm(_accountId, candidates, () => _searchCost, OnHire);
-            recruitForm.ShowDialog(this);
+            var recruitForm = new RecruitForm(_accountId, candidates, () => _searchCost, OnHire);
+            recruitForm.FormClosed += (_, __) => recruitForm.Dispose();
+            recruitForm.Show(this);
         }
 
         private void btnJoin_Click(object? sender, EventArgs e)
         {
-            using var window = new HireMultiplayerPartyWindow(_accountId, OnHire);
-            window.ShowDialog(this);
+            var window = new HireMultiplayerPartyWindow(_accountId, OnHire);
+            window.FormClosed += (_, __) => window.Dispose();
+            window.Show(this);
         }
 
         private void btnHireOut_Click(object? sender, EventArgs e)
         {
-            using var window = new HireMultiplayerPartyWindow(_accountId, OnHire, showHireOut: true);
-            window.ShowDialog(this);
+            var window = new HireMultiplayerPartyWindow(_accountId, OnHire, showHireOut: true);
+            window.FormClosed += (_, __) => window.Dispose();
+            window.Show(this);
         }
 
         private void OnHire()


### PR DESCRIPTION
## Summary
- Replace modal `ShowDialog` calls with modeless `Show` across forms
- Use `FormClosed` handlers to perform refresh and cleanup after windows close
- Enable battle summaries and other dialogs to remain open without blocking other windows

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln` *(fails: dotnet not installed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b22c04848333bd451ebaa4f99983