### PR TITLE
Distribute battle XP among active participants

### DIFF
--- a/WinFormsApp2/PartyHireService.cs
+++ b/WinFormsApp2/PartyHireService.cs
@@ -249,6 +249,26 @@ namespace WinFormsApp2.Multiplayer
             }
             return gold;
         }
+
+        public static void ApplyMercenaryExperience(int hirerId, Dictionary<string, int> expGains)
+        {
+            if (expGains == null || expGains.Count == 0) return;
+            CleanupExpired();
+            var list = LoadState();
+            bool changed = false;
+            foreach (var party in list.Where(p => p.OnMission && p.CurrentHirer == hirerId))
+            {
+                foreach (var member in party.Members)
+                {
+                    if (expGains.TryGetValue(member.Name, out int gain))
+                    {
+                        member.Experience += gain;
+                        changed = true;
+                    }
+                }
+            }
+            if (changed) SaveState();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- track character IDs and mercenary status during battles
- award experience only to participating characters and distribute remainders to highest-level members
- persist hired mercenary XP gains so party owners recover upgraded parties

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bb787c448333a7ebc2acd2b914ca