### PR TITLE
Introduce shared max party size constant

### DIFF
--- a/WinFormsApp2/ArenaForm.cs
+++ b/WinFormsApp2/ArenaForm.cs
@@ -89,9 +89,9 @@ namespace WinFormsApp2
                 using var arenaCountCmd = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=1", conn);
                 arenaCountCmd.Parameters.AddWithValue("@id", _userId);
                 int arenaCount = Convert.ToInt32(arenaCountCmd.ExecuteScalar());
-                if (partyCount + arenaCount > 10)
+                if (partyCount + arenaCount > GameConfig.MAX_PARTY_SIZE)
                 {
-                    MessageBox.Show("You need to make room to withdraw your party members.");
+                    MessageBox.Show($"You need to make room to withdraw your party members (max {GameConfig.MAX_PARTY_SIZE}).");
                     return;
                 }
                 using var del = new MySqlCommand("DELETE FROM arena_teams WHERE account_id=@id", conn);

--- a/WinFormsApp2/GameConfig.cs
+++ b/WinFormsApp2/GameConfig.cs
@@ -1,0 +1,7 @@
+namespace WinFormsApp2
+{
+    internal static class GameConfig
+    {
+        public const int MAX_PARTY_SIZE = 10;
+    }
+}

--- a/WinFormsApp2/HeroViewForm.cs
+++ b/WinFormsApp2/HeroViewForm.cs
@@ -64,9 +64,9 @@ namespace WinFormsApp2
             {
                 countCmd.Parameters.AddWithValue("@id", _userId);
                 int partyCount = Convert.ToInt32(countCmd.ExecuteScalar());
-                if (partyCount >= 10)
+                if (partyCount >= GameConfig.MAX_PARTY_SIZE)
                 {
-                    MessageBox.Show("Party is full. Release a member before hiring.");
+                    MessageBox.Show($"Party is full. Maximum size is {GameConfig.MAX_PARTY_SIZE}. Release a member before hiring.");
                     return;
                 }
             }

--- a/WinFormsApp2/PartyHireService.cs
+++ b/WinFormsApp2/PartyHireService.cs
@@ -357,6 +357,13 @@ namespace WinFormsApp2.Multiplayer
                 if (gold < party.Cost)
                     return false;
             }
+            using (var sizeCmd = new MySqlCommand("SELECT COUNT(*) FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn))
+            {
+                sizeCmd.Parameters.AddWithValue("@id", hirerId);
+                int currentSize = Convert.ToInt32(sizeCmd.ExecuteScalar() ?? 0);
+                if (currentSize + party.Members.Count > GameConfig.MAX_PARTY_SIZE)
+                    return false;
+            }
             using (var pay = new MySqlCommand("UPDATE users SET gold = GREATEST(gold-@c,0) WHERE id=@id", conn))
             {
                 pay.Parameters.AddWithValue("@c", party.Cost);

--- a/WinFormsApp2/TavernForm.cs
+++ b/WinFormsApp2/TavernForm.cs
@@ -22,9 +22,9 @@ namespace WinFormsApp2
         private void btnRecruit_Click(object? sender, EventArgs e)
         {
             _searchCost = CalculateSearchCost(out int partyCount);
-            if (partyCount >= 10)
+            if (partyCount >= GameConfig.MAX_PARTY_SIZE)
             {
-                MessageBox.Show("Party is full. Release a member before recruiting.");
+                MessageBox.Show($"Party is full. Maximum size is {GameConfig.MAX_PARTY_SIZE}. Release a member before recruiting.");
                 RefreshSearchCost();
                 return;
             }
@@ -87,9 +87,9 @@ namespace WinFormsApp2
         private void RefreshSearchCost()
         {
             _searchCost = CalculateSearchCost(out int partyCount);
-            if (partyCount >= 10)
+            if (partyCount >= GameConfig.MAX_PARTY_SIZE)
             {
-                btnRecruit.Text = "Party Full";
+                btnRecruit.Text = $"Party Full (Max {GameConfig.MAX_PARTY_SIZE})";
                 btnRecruit.Enabled = false;
             }
             else


### PR DESCRIPTION
## Summary
- Add `GameConfig.MAX_PARTY_SIZE` for centralized party limit
- Replace hard-coded party size checks in recruitment and arena forms
- Prevent hiring parties that would exceed the limit

## Testing
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build WinFormsApp2/BattleLands.csproj -p:UseAppHost=false` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c06669448333a31ecd628b56d09f