### PR TITLE
Reload inventory after hiring parties

### DIFF
--- a/WinFormsApp2/HireMultiplayerPartyWindow.cs
+++ b/WinFormsApp2/HireMultiplayerPartyWindow.cs
@@ -130,6 +130,7 @@ namespace WinFormsApp2
                 if (PartyHireService.HireParty(_accountId, party))
                 {
                     MessageBox.Show($"Hired {party.Name} for {party.Cost}g.");
+                    InventoryService.Reload(_accountId);
                     RefreshLists();
                     _onChange?.Invoke();
                 }

--- a/WinFormsApp2/InventoryService.cs
+++ b/WinFormsApp2/InventoryService.cs
@@ -19,12 +19,21 @@ namespace WinFormsApp2
 
         public static IReadOnlyList<InventoryItem> Items => _items;
 
-        public static void Load(int userId)
+        public static void Reload(int userId)
         {
-            if (_loaded && _userId == userId) return;
+            _items.Clear();
+            _equipment.Clear();
+            _loaded = false;
+            Load(userId, true);
+        }
+
+        public static void Load(int userId, bool forceReload = false)
+        {
+            if (_loaded && _userId == userId && !forceReload) return;
             _loaded = true;
             _userId = userId;
             _items.Clear();
+            _equipment.Clear();
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
             using MySqlCommand cmd = new MySqlCommand("SELECT item_name, quantity FROM user_items WHERE account_id=@id", conn);


### PR DESCRIPTION
## Summary
- Add `InventoryService.Reload` to reset inventory and equipment for an account
- Allow `InventoryService.Load` to force reloading via new `forceReload` parameter
- Refresh inventory after hiring a party so new mercenary equipment is visible

## Testing
- ⚠️ `dotnet build WinFormsApp2/BattleLands.sln` *(missing Microsoft.NET.Sdk.WindowsDesktop targets)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c6a425dc8333876f9b52ec686458