### PR TITLE
Tune encounter scaling for player searches

### DIFF
--- a/MANUAL_TEST_PLAN.md
+++ b/MANUAL_TEST_PLAN.md
@@ -1,0 +1,14 @@
+# Battle Encounter Manual Test Plan
+
+## 1. Player-initiated search scaling
+1. Launch the game and create a party of known total level (e.g., 50).
+2. Travel to an area with a matching level bracket (area min = 50).
+3. Initiate a battle search.
+4. Observe the enemy party level total from the battle log or debugger.
+5. Verify the total enemy level lies between `ceil(totalLevel * 0.8)` and `ceil(totalLevel * 1.2)` (40–60 in this example).
+
+## 2. Under-leveled party enforcement
+1. Use a party with total level lower than the area's minimum (e.g., total 40, area min 50).
+2. Initiate a battle search in that area.
+3. Observe the enemy party level total.
+4. Confirm the enemies' combined level is approximately `ceil(areaMin * 1.2)` (60 in this example) regardless of the party's level.


### PR DESCRIPTION
## Summary
- Scale player-initiated encounters to 80–120% of party level and enforce tougher battles when under-levelled
- Document manual test steps for encounter scaling

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3cd12096c8333b7b77d5ccbe1796e