### PR TITLE
Add NPC equipment and apply item bonuses

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -106,6 +106,7 @@ namespace WinFormsApp2
                     {
                         player.Equipment[slot] = InventoryService.GetEquippedItem(player.Name, slot);
                     }
+                    ApplyEquipmentBonuses(player);
 
                     _players.Add(player);
                     _playerIds[player] = cid;
@@ -186,6 +187,9 @@ namespace WinFormsApp2
                         Role = role,
                         TargetingStyle = style
                     };
+                    foreach (var kv in InventoryService.GetNpcEquipment(name))
+                        npc.Equipment[kv.Key] = kv.Value;
+                    ApplyEquipmentBonuses(npc);
                     using var abilCmd = new MySqlCommand(@"SELECT slot, priority, a.id, a.name, a.description, a.cost, a.cooldown
                                                           FROM npc_abilities na
                                                           JOIN abilities a ON na.ability_id = a.id
@@ -289,6 +293,7 @@ namespace WinFormsApp2
                     };
                     foreach (EquipmentSlot slot in Enum.GetValues(typeof(EquipmentSlot)))
                         npc.Equipment[slot] = InventoryService.GetEquippedItem(npc.Name, slot);
+                    ApplyEquipmentBonuses(npc);
                     _npcs.Add(npc);
                     npcIds[npc] = cid;
                 }
@@ -1308,6 +1313,95 @@ namespace WinFormsApp2
             public int AmountPerTick { get; set; }
             public bool SourceIsPlayer { get; set; }
             public string? SourceName { get; set; }
+        }
+
+
+        private void ApplyEquipmentBonuses(Creature c)
+        {
+            foreach (var item in c.Equipment.Values)
+            {
+                if (item == null) continue;
+                foreach (var kv in item.FlatBonuses)
+                {
+                    switch (kv.Key)
+                    {
+                        case "Strength":
+                            c.Strength += kv.Value;
+                            break;
+                        case "Dexterity":
+                            c.Dex += kv.Value;
+                            break;
+                        case "Intelligence":
+                            c.Intelligence += kv.Value;
+                            c.MaxMana += kv.Value;
+                            c.Mana += kv.Value;
+                            break;
+                        case "HP":
+                            c.MaxHp += kv.Value;
+                            c.CurrentHp += kv.Value;
+                            break;
+                        case "Mana":
+                            c.MaxMana += kv.Value;
+                            c.Mana += kv.Value;
+                            break;
+                        case "Melee Defense":
+                            c.MeleeDefense += kv.Value;
+                            break;
+                        case "Magic Defense":
+                            c.MagicDefense += kv.Value;
+                            break;
+                        case "Attack":
+                            c.AttackFlatBonus += kv.Value;
+                            break;
+                    }
+                }
+                foreach (var kv in item.PercentBonuses)
+                {
+                    switch (kv.Key)
+                    {
+                        case "Damage Dealt":
+                            c.DamageDealtMultiplier *= 1 + kv.Value / 100.0;
+                            break;
+                        case "Damage Taken":
+                            c.DamageTakenMultiplier *= 1 + kv.Value / 100.0;
+                            break;
+                        case "Attack Speed":
+                            c.AttackSpeedMultiplier *= 1 + kv.Value / 100.0;
+                            break;
+                        case "Healing Done":
+                            c.HealingDealtMultiplier *= 1 + kv.Value / 100.0;
+                            break;
+                        case "Healing Received":
+                            c.HealingReceivedMultiplier *= 1 + kv.Value / 100.0;
+                            break;
+                        case "Strength":
+                            c.Strength = (int)(c.Strength * (1 + kv.Value / 100.0));
+                            break;
+                        case "Dexterity":
+                            c.Dex = (int)(c.Dex * (1 + kv.Value / 100.0));
+                            break;
+                        case "Intelligence":
+                            c.Intelligence = (int)(c.Intelligence * (1 + kv.Value / 100.0));
+                            c.MaxMana = (int)(c.MaxMana * (1 + kv.Value / 100.0));
+                            c.Mana = (int)(c.Mana * (1 + kv.Value / 100.0));
+                            break;
+                        case "HP":
+                            c.MaxHp = (int)(c.MaxHp * (1 + kv.Value / 100.0));
+                            c.CurrentHp = (int)(c.CurrentHp * (1 + kv.Value / 100.0));
+                            break;
+                        case "Mana":
+                            c.MaxMana = (int)(c.MaxMana * (1 + kv.Value / 100.0));
+                            c.Mana = (int)(c.Mana * (1 + kv.Value / 100.0));
+                            break;
+                        case "Melee Defense":
+                            c.MeleeDefense = (int)(c.MeleeDefense * (1 + kv.Value / 100.0));
+                            break;
+                        case "Magic Defense":
+                            c.MagicDefense = (int)(c.MagicDefense * (1 + kv.Value / 100.0));
+                            break;
+                    }
+                }
+            }
         }
 
         private void ApplyPassiveModifiers(Creature c)

--- a/WinFormsApp2/InventoryService.cs
+++ b/WinFormsApp2/InventoryService.cs
@@ -176,6 +176,32 @@ namespace WinFormsApp2
             return null;
         }
 
+
+        public static Dictionary<EquipmentSlot, Item?> GetNpcEquipment(string npcName)
+        {
+            var dict = new Dictionary<EquipmentSlot, Item?>();
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using MySqlCommand cmd = new MySqlCommand("SELECT slot, item_name FROM npc_equipment WHERE npc_name=@n", conn);
+            cmd.Parameters.AddWithValue("@n", npcName);
+            using var r = cmd.ExecuteReader();
+            while (r.Read())
+            {
+                var slot = Enum.Parse<EquipmentSlot>(r.GetString("slot"));
+                var item = CreateItem(r.GetString("item_name"));
+                if (item is Weapon w && w.TwoHanded)
+                {
+                    dict[EquipmentSlot.LeftHand] = w;
+                    dict[EquipmentSlot.RightHand] = w;
+                }
+                else
+                {
+                    dict[slot] = item;
+                }
+            }
+            return dict;
+        }
+
         public static void Equip(string character, EquipmentSlot slot, Item? item)
         {
             if (!_equipment.ContainsKey(character))

--- a/npc_equipment.sql
+++ b/npc_equipment.sql
@@ -1,0 +1,27 @@
+USE accounts;
+
+CREATE TABLE IF NOT EXISTS npc_equipment (
+    npc_name VARCHAR(255) NOT NULL,
+    slot VARCHAR(50) NOT NULL,
+    item_name VARCHAR(255) NOT NULL
+);
+
+INSERT INTO npc_equipment (npc_name, slot, item_name)
+SELECT name, 'LeftHand',
+       CASE
+           WHEN level <= 5 THEN 'Dagger'
+           WHEN level <= 10 THEN 'Shortsword'
+           WHEN level <= 15 THEN 'Longsword'
+           WHEN level <= 20 THEN 'Greatsword'
+           ELSE 'Greatsword'
+       END
+FROM npcs;
+
+INSERT INTO npc_equipment (npc_name, slot, item_name)
+SELECT name, 'Body',
+       CASE
+           WHEN level <= 5 THEN 'Cloth Robe'
+           WHEN level <= 10 THEN 'Leather Armor'
+           ELSE 'Plate Armor'
+       END
+FROM npcs;

--- a/rebuild_database.sql
+++ b/rebuild_database.sql
@@ -593,6 +593,35 @@ INSERT INTO npc_abilities (npc_name, ability_id, slot, priority) VALUES
 ('Fire Spirit', 41, 1, 1),
 ('Forest Guardian', 40, 1, 1);
 
+-- File: npc_equipment.sql
+USE accounts;
+
+CREATE TABLE IF NOT EXISTS npc_equipment (
+    npc_name VARCHAR(255) NOT NULL,
+    slot VARCHAR(50) NOT NULL,
+    item_name VARCHAR(255) NOT NULL
+);
+
+INSERT INTO npc_equipment (npc_name, slot, item_name)
+SELECT name, 'LeftHand',
+       CASE
+           WHEN level <= 5 THEN 'Dagger'
+           WHEN level <= 10 THEN 'Shortsword'
+           WHEN level <= 15 THEN 'Longsword'
+           WHEN level <= 20 THEN 'Greatsword'
+           ELSE 'Greatsword'
+       END
+FROM npcs;
+
+INSERT INTO npc_equipment (npc_name, slot, item_name)
+SELECT name, 'Body',
+       CASE
+           WHEN level <= 5 THEN 'Cloth Robe'
+           WHEN level <= 10 THEN 'Leather Armor'
+           ELSE 'Plate Armor'
+       END
+FROM npcs;
+
 -- File: npc_loot_tables.sql
 USE accounts;
 


### PR DESCRIPTION
## Summary
- Define `npc_equipment` table and seed gear based on NPC level
- Load NPC equipment and account for item stat bonuses during battles
- Add helper to fetch NPC gear

## Testing
- `dotnet build WinFormsApp2/BattleLands.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3cd1a05748333b6698268a20de98a