### PR TITLE
Standardize DPI scaling for WinForms

### DIFF
--- a/WinFormsApp2/ArenaForm.Designer.cs
+++ b/WinFormsApp2/ArenaForm.Designer.cs
@@ -59,8 +59,8 @@ namespace WinFormsApp2
             // 
             // ArenaForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(300, 260);
             Controls.Add(_lblStatus);
             Controls.Add(_lstTeams);

--- a/WinFormsApp2/BattleForm.Designer.cs
+++ b/WinFormsApp2/BattleForm.Designer.cs
@@ -92,8 +92,8 @@ namespace WinFormsApp2
             // 
             // BattleForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(931, 631);
             Controls.Add(attackTemplate);
             Controls.Add(manaTemplate);

--- a/WinFormsApp2/BattleLogForm.Designer.cs
+++ b/WinFormsApp2/BattleLogForm.Designer.cs
@@ -45,8 +45,8 @@ namespace WinFormsApp2
             // 
             // BattleLogForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(841, 218);
             Controls.Add(lstLog);
             Controls.Add(lstBattles);

--- a/WinFormsApp2/BattleSummaryForm.Designer.cs
+++ b/WinFormsApp2/BattleSummaryForm.Designer.cs
@@ -38,8 +38,8 @@ namespace WinFormsApp2
             // 
             // BattleSummaryForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(450, 300);
             Controls.Add(_btnContinue);
             Controls.Add(_list);

--- a/WinFormsApp2/Form1.Designer.cs
+++ b/WinFormsApp2/Form1.Designer.cs
@@ -124,8 +124,8 @@ namespace WinFormsApp2
             // 
             // Form1
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(264, 240);
             Controls.Add(kimCheckbox);
             Controls.Add(chkDebugMode);

--- a/WinFormsApp2/GraveyardForm.Designer.cs
+++ b/WinFormsApp2/GraveyardForm.Designer.cs
@@ -58,8 +58,8 @@ namespace WinFormsApp2
             // 
             // GraveyardForm
             // 
-            AutoScaleDimensions = new SizeF(10F, 25F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(408, 476);
             Controls.Add(lblInfo);
             Controls.Add(btnResurrect);

--- a/WinFormsApp2/HeroInspectForm.Designer.cs
+++ b/WinFormsApp2/HeroInspectForm.Designer.cs
@@ -314,8 +314,8 @@ namespace WinFormsApp2
             // 
             // HeroInspectForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(435, 572);
             Controls.Add(label12);
             Controls.Add(label11);

--- a/WinFormsApp2/HeroViewForm.Designer.cs
+++ b/WinFormsApp2/HeroViewForm.Designer.cs
@@ -156,8 +156,8 @@ namespace WinFormsApp2
             // 
             // HeroViewForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(220, 257);
             Controls.Add(lblPassive);
             Controls.Add(lblAbility);

--- a/WinFormsApp2/HireMultiplayerPartyWindow.Designer.cs
+++ b/WinFormsApp2/HireMultiplayerPartyWindow.Designer.cs
@@ -217,8 +217,8 @@ namespace WinFormsApp2
             // 
             // HireMultiplayerPartyWindow
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(379, 364);
             Controls.Add(tabControl1);
             Name = "HireMultiplayerPartyWindow";

--- a/WinFormsApp2/InventoryForm.Designer.cs
+++ b/WinFormsApp2/InventoryForm.Designer.cs
@@ -72,8 +72,8 @@ namespace WinFormsApp2
             // 
             // InventoryForm
             // 
-            AutoScaleDimensions = new SizeF(10F, 25F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(543, 542);
             Controls.Add(cmbTarget);
             Controls.Add(btnUse);

--- a/WinFormsApp2/LevelUpForm.Designer.cs
+++ b/WinFormsApp2/LevelUpForm.Designer.cs
@@ -164,8 +164,8 @@ namespace WinFormsApp2
             // 
             // LevelUpForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(441, 222);
             Controls.Add(btnBuyPassive);
             Controls.Add(lstPassives);

--- a/WinFormsApp2/MailboxForm.Designer.cs
+++ b/WinFormsApp2/MailboxForm.Designer.cs
@@ -56,8 +56,8 @@ namespace WinFormsApp2
             // 
             // MailboxForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(500, 420);
             Controls.Add(btnRefresh);
             Controls.Add(txtBody);

--- a/WinFormsApp2/NavigationWindow.Designer.cs
+++ b/WinFormsApp2/NavigationWindow.Designer.cs
@@ -85,6 +85,7 @@
             pictureBox1.Location = new Point(457, 8);
             pictureBox1.Name = "pictureBox1";
             pictureBox1.Size = new Size(641, 618);
+            pictureBox1.SizeMode = PictureBoxSizeMode.Zoom;
             pictureBox1.TabIndex = 0;
             pictureBox1.TabStop = false;
             // 
@@ -563,8 +564,8 @@
             // 
             // NavigationWindow
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(1110, 640);
             Controls.Add(label11);
             Controls.Add(label10);

--- a/WinFormsApp2/NotificationForm.Designer.cs
+++ b/WinFormsApp2/NotificationForm.Designer.cs
@@ -44,8 +44,8 @@ namespace WinFormsApp2
             // 
             // NotificationForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(300, 400);
             Controls.Add(lstNotifications);
             Controls.Add(btnRemove);

--- a/WinFormsApp2/QuestLogForm.Designer.cs
+++ b/WinFormsApp2/QuestLogForm.Designer.cs
@@ -44,8 +44,8 @@ namespace WinFormsApp2
             // 
             // QuestLogForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(300, 400);
             Controls.Add(lstQuests);
             Controls.Add(btnAbandon);

--- a/WinFormsApp2/RPGForm.Designer.cs
+++ b/WinFormsApp2/RPGForm.Designer.cs
@@ -306,8 +306,8 @@ namespace WinFormsApp2
             // 
             // RPGForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(684, 626);
             Controls.Add(tabSocial);
             Controls.Add(lblTotalExp);

--- a/WinFormsApp2/RecruitForm.Designer.cs
+++ b/WinFormsApp2/RecruitForm.Designer.cs
@@ -46,8 +46,8 @@ namespace WinFormsApp2
             // 
             // RecruitForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(224, 141);
             Controls.Add(btnView);
             Controls.Add(lstCandidates);

--- a/WinFormsApp2/RegisterForm.Designer.cs
+++ b/WinFormsApp2/RegisterForm.Designer.cs
@@ -141,8 +141,8 @@ namespace WinFormsApp2
             // 
             // RegisterForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(264, 356);
             Controls.Add(kimCheckbox);
             Controls.Add(chkDebugMode2);

--- a/WinFormsApp2/ShopForm.Designer.cs
+++ b/WinFormsApp2/ShopForm.Designer.cs
@@ -106,8 +106,8 @@ namespace WinFormsApp2
             // 
             // ShopForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(613, 258);
             Controls.Add(shopDescBox);
             Controls.Add(label2);

--- a/WinFormsApp2/TavernForm.Designer.cs
+++ b/WinFormsApp2/TavernForm.Designer.cs
@@ -59,8 +59,8 @@ namespace WinFormsApp2
             // 
             // TavernForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(280, 86);
             Controls.Add(btnHireOut);
             Controls.Add(btnJoin);

--- a/WinFormsApp2/TempleForm.Designer.cs
+++ b/WinFormsApp2/TempleForm.Designer.cs
@@ -34,8 +34,8 @@ namespace WinFormsApp2
             // 
             // TempleForm
             // 
-            AutoScaleDimensions = new SizeF(7F, 15F);
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(96F, 96F);
+            AutoScaleMode = AutoScaleMode.Dpi;
             ClientSize = new Size(280, 150);
             Controls.Add(btnBless);
             FormBorderStyle = FormBorderStyle.FixedDialog;


### PR DESCRIPTION
## Summary
- Set all forms to `AutoScaleMode.Dpi` with `AutoScaleDimensions` baseline of `96F,96F`
- Enable zoom-based scaling for `NavigationWindow`'s image to respect different DPI settings

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_68b3cd20bd848333a6036aedfd4d35c9