### PR TITLE
Color mana/action speed bars and adjust dex scaling

### DIFF
--- a/WinFormsApp2/BattleForm.Designer.cs
+++ b/WinFormsApp2/BattleForm.Designer.cs
@@ -9,9 +9,9 @@ namespace WinFormsApp2
         private FlowLayoutPanel pnlPlayers;
         private FlowLayoutPanel pnlEnemies;
         private ListBox lstLog;
-        private ProgressBar hpTemplate;
-        private ProgressBar manaTemplate;
-        private ProgressBar attackTemplate;
+        private ColoredProgressBar hpTemplate;
+        private ColoredProgressBar manaTemplate;
+        private ColoredProgressBar attackTemplate;
 
         protected override void Dispose(bool disposing)
         {
@@ -27,9 +27,9 @@ namespace WinFormsApp2
             pnlPlayers = new FlowLayoutPanel();
             pnlEnemies = new FlowLayoutPanel();
             lstLog = new ListBox();
-            hpTemplate = new ProgressBar();
-            manaTemplate = new ProgressBar();
-            attackTemplate = new ProgressBar();
+            hpTemplate = new ColoredProgressBar();
+            manaTemplate = new ColoredProgressBar();
+            attackTemplate = new ColoredProgressBar();
             SuspendLayout();
             // 
             // pnlPlayers
@@ -66,6 +66,7 @@ namespace WinFormsApp2
             hpTemplate.Location = new Point(210, 8);
             hpTemplate.Margin = new Padding(2, 2, 2, 2);
             hpTemplate.Name = "hpTemplate";
+            hpTemplate.ProgressColor = Color.Red;
             hpTemplate.Size = new Size(119, 12);
             hpTemplate.Style = ProgressBarStyle.Continuous;
             hpTemplate.TabIndex = 2;
@@ -76,6 +77,7 @@ namespace WinFormsApp2
             manaTemplate.Location = new Point(210, 26);
             manaTemplate.Margin = new Padding(2, 2, 2, 2);
             manaTemplate.Name = "manaTemplate";
+            manaTemplate.ProgressColor = Color.Blue;
             manaTemplate.Size = new Size(119, 12);
             manaTemplate.Style = ProgressBarStyle.Continuous;
             manaTemplate.TabIndex = 1;
@@ -86,7 +88,9 @@ namespace WinFormsApp2
             attackTemplate.Location = new Point(210, 44);
             attackTemplate.Margin = new Padding(2, 2, 2, 2);
             attackTemplate.Name = "attackTemplate";
+            attackTemplate.ProgressColor = Color.Yellow;
             attackTemplate.Size = new Size(119, 12);
+            attackTemplate.Style = ProgressBarStyle.Continuous;
             attackTemplate.TabIndex = 0;
             attackTemplate.Visible = false;
             // 

--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -341,7 +341,7 @@ namespace WinFormsApp2
         {
             foreach (var p in _players)
             {
-                double speed = (p.ActionSpeed + p.Dex / 25.0) * p.AttackSpeedMultiplier;
+                double speed = p.ActionSpeed * (1 + p.Dex / 1000.0) * p.AttackSpeedMultiplier;
                 Weapon? left = p.Equipment.GetValueOrDefault(EquipmentSlot.LeftHand) as Weapon;
                 Weapon? right = p.Equipment.GetValueOrDefault(EquipmentSlot.RightHand) as Weapon;
                 if (left != null) speed *= (1 + left.AttackSpeedMod);
@@ -354,7 +354,7 @@ namespace WinFormsApp2
             }
             foreach (var n in _npcs)
             {
-                double speed = (n.ActionSpeed + n.Dex / 25.0) * n.AttackSpeedMultiplier;
+                double speed = n.ActionSpeed * (1 + n.Dex / 1000.0) * n.AttackSpeedMultiplier;
                 n.AttackInterval = (int)(3000 / speed);
                 n.AttackBar.Maximum = n.AttackInterval;
                 n.AttackBar.Value = n.AttackInterval;
@@ -1577,13 +1577,13 @@ namespace WinFormsApp2
             return panel;
         }
 
-        private ProgressBar CloneProgressBar(ProgressBar template)
+        private ColoredProgressBar CloneProgressBar(ColoredProgressBar template)
         {
-            return new ProgressBar
+            return new ColoredProgressBar
             {
                 Width = template.Width,
                 Height = template.Height,
-                ForeColor = template.ForeColor,
+                ProgressColor = template.ProgressColor,
                 BackColor = template.BackColor,
                 Style = template.Style
             };

--- a/WinFormsApp2/ColoredProgressBar.cs
+++ b/WinFormsApp2/ColoredProgressBar.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace WinFormsApp2
+{
+    public class ColoredProgressBar : ProgressBar
+    {
+        public Color ProgressColor { get; set; } = Color.Green;
+
+        public ColoredProgressBar()
+        {
+            this.SetStyle(ControlStyles.UserPaint, true);
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            Rectangle rect = e.ClipRectangle;
+            e.Graphics.FillRectangle(new SolidBrush(this.BackColor), rect);
+            if (this.Maximum > 0)
+            {
+                rect.Width = (int)(rect.Width * ((double)this.Value / this.Maximum));
+                using var brush = new SolidBrush(ProgressColor);
+                e.Graphics.FillRectangle(brush, 0, 0, rect.Width, rect.Height);
+            }
+            e.Graphics.DrawRectangle(Pens.Black, 0, 0, this.Width - 1, this.Height - 1);
+        }
+    }
+}

--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -85,12 +85,12 @@ namespace WinFormsApp2
 
                 var panel = new Panel { Width = 180, Height = maxMana > 0 ? 60 : 40, Margin = new Padding(3) };
                 var lbl = new Label { Text = name, AutoSize = true };
-                var hpBar = new ProgressBar { Maximum = maxHp, Value = Math.Min(hp, maxHp), Width = 170, Location = new Point(0, 15), ForeColor = Color.Red, Style = ProgressBarStyle.Continuous };
+                var hpBar = new ColoredProgressBar { Maximum = maxHp, Value = Math.Min(hp, maxHp), Width = 170, Location = new Point(0, 15), ProgressColor = Color.Red, Style = ProgressBarStyle.Continuous };
                 panel.Controls.Add(lbl);
                 panel.Controls.Add(hpBar);
                 if (maxMana > 0)
                 {
-                    var manaBar = new ProgressBar { Maximum = maxMana, Value = Math.Min(mana, maxMana), Width = 170, Location = new Point(0, 35), ForeColor = Color.Blue, Style = ProgressBarStyle.Continuous };
+                    var manaBar = new ColoredProgressBar { Maximum = maxMana, Value = Math.Min(mana, maxMana), Width = 170, Location = new Point(0, 35), ProgressColor = Color.Blue, Style = ProgressBarStyle.Continuous };
                     panel.Controls.Add(manaBar);
                 }
                 int current = index;


### PR DESCRIPTION
## Summary
- show mana bars in blue and action bars in yellow using a new `ColoredProgressBar`
- scale action speed off dexterity at 1% per 10 dex

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d972e0c883338b052b61f0ddc6a4