### PR TITLE
Display shield progress bar in battle UI

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -417,6 +417,12 @@ namespace WinFormsApp2
                         if (eff.RemainingMs <= 0)
                         {
                             c.Effects.RemoveAt(i);
+                            if (eff.Kind == EffectKind.Shield)
+                            {
+                                c.ShieldBar.Visible = false;
+                                c.ShieldBar.Value = 0;
+                                c.ShieldBar.Maximum = 1;
+                            }
                         }
                     }
                     if (c.ForcedTargetMs > 0)
@@ -847,6 +853,9 @@ namespace WinFormsApp2
                 AmountPerTick = shield,
                 SourceIsPlayer = _players.Contains(actor)
             });
+            target.ShieldBar.Maximum = Math.Max(1, shield);
+            target.ShieldBar.Value = Math.Max(0, shield);
+            target.ShieldBar.Visible = true;
             AppendLog($"{target.Name} is protected by a magical shield ({shield}).", _players.Contains(actor), true);
         }
 
@@ -858,9 +867,12 @@ namespace WinFormsApp2
                 int absorb = Math.Min(dmg, shield.AmountPerTick);
                 dmg -= absorb;
                 shield.AmountPerTick -= absorb;
+                target.ShieldBar.Maximum = Math.Max(1, shield.AmountPerTick);
+                target.ShieldBar.Value = Math.Max(0, shield.AmountPerTick);
                 if (shield.AmountPerTick <= 0)
                 {
                     target.Effects.Remove(shield);
+                    target.ShieldBar.Visible = false;
                 }
             }
         }
@@ -930,6 +942,9 @@ namespace WinFormsApp2
                 if (shield > 0)
                 {
                     target.Effects.Add(new StatusEffect { Kind = EffectKind.Shield, RemainingMs = 15000, TickIntervalMs = int.MaxValue, TimeUntilTickMs = int.MaxValue, AmountPerTick = shield, SourceIsPlayer = _players.Contains(actor) });
+                    target.ShieldBar.Maximum = Math.Max(1, shield);
+                    target.ShieldBar.Value = Math.Max(0, shield);
+                    target.ShieldBar.Visible = true;
                 }
             }
             if (actor.SelfHealOnHealPercent > 0 && target != actor)
@@ -1096,6 +1111,10 @@ namespace WinFormsApp2
             {
                 _battleEnded = true;
                 _gameTimer.Stop();
+                foreach (var c in _players.Concat(_npcs))
+                {
+                    c.ShieldBar.Visible = false;
+                }
                 bool playersWin = _players.Any(p => p.CurrentHp > 0);
                 _playersWin = playersWin;
                 string lootSummary = string.Empty;
@@ -1276,6 +1295,7 @@ namespace WinFormsApp2
             public ProgressBar HpBar { get; set; } = new();
             public ProgressBar ManaBar { get; set; } = new();
             public ProgressBar AttackBar { get; set; } = new();
+            public ProgressBar ShieldBar { get; set; } = new();
             public int AttackInterval { get; set; }
             public int NextActionMs { get; set; }
             public int DamageDone { get; set; }
@@ -1546,34 +1566,51 @@ namespace WinFormsApp2
 
         private Control CreatePanel(Creature c)
         {
-            var panel = new Panel { Width = 180, Height = 80 };
+            var panel = new Panel { Width = 180, Height = 100 };
             var lbl = new Label { Text = c.Name, AutoSize = true };
+            // shield bar, hidden by default and placed above HP
+            c.ShieldBar = CloneProgressBar(manaTemplate);
+            c.ShieldBar.Visible = false;
+            c.ShieldBar.Location = new Point(0, 15);
+
             c.HpBar = CloneProgressBar(hpTemplate);
             c.HpBar.Maximum = Math.Max(1, c.MaxHp);
             c.HpBar.Value = Math.Min(c.HpBar.Maximum, Math.Max(0, c.CurrentHp));
-            c.HpBar.Location = new Point(0, 15);
+            c.HpBar.Location = new Point(0, 35);
+
             panel.Controls.Add(lbl);
+            panel.Controls.Add(c.ShieldBar);
             panel.Controls.Add(c.HpBar);
+
             if (c.MaxMana > 0)
             {
                 c.ManaBar = CloneProgressBar(manaTemplate);
                 c.ManaBar.Maximum = Math.Max(1, c.MaxMana);
                 c.ManaBar.Value = Math.Min(c.ManaBar.Maximum, Math.Max(0, c.Mana));
-                c.ManaBar.Location = new Point(0, 35);
+                c.ManaBar.Location = new Point(0, 55);
                 panel.Controls.Add(c.ManaBar);
                 c.AttackBar = CloneProgressBar(attackTemplate);
                 c.AttackBar.Maximum = 100;
                 c.AttackBar.Value = 100;
-                c.AttackBar.Location = new Point(0, 55);
+                c.AttackBar.Location = new Point(0, 75);
             }
             else
             {
                 c.AttackBar = CloneProgressBar(attackTemplate);
                 c.AttackBar.Maximum = 100;
                 c.AttackBar.Value = 100;
-                c.AttackBar.Location = new Point(0, 35);
+                c.AttackBar.Location = new Point(0, 55);
             }
             panel.Controls.Add(c.AttackBar);
+
+            var existingShield = c.Effects.FirstOrDefault(e => e.Kind == EffectKind.Shield);
+            if (existingShield != null)
+            {
+                c.ShieldBar.Maximum = Math.Max(1, existingShield.AmountPerTick);
+                c.ShieldBar.Value = Math.Max(0, existingShield.AmountPerTick);
+                c.ShieldBar.Visible = true;
+            }
+
             return panel;
         }
 


### PR DESCRIPTION
## Summary
- add a dedicated ShieldBar to creatures and position it above HP
- show and update ShieldBar when shields are applied or reduced
- hide ShieldBar when shields expire or the battle ends

## Testing
- `dotnet build BattleLands.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3dd1e73ec83339d1c11cd7ee6e74b