### PR TITLE
Add Fortify shield ability

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -592,7 +592,22 @@ namespace WinFormsApp2
                 }
                 else if (ability.Name == "Taunting Blows") ApplyTaunt(actor, opponents);
                 else if (ability.Name == "Vanish") { actor.IsVanished = true; actor.VanishRemainingMs = 5000; actor.AttackBar.Value = actor.AttackInterval; CheckEnd(); return; }
-                else if (ability.Name == "Arcane Shield") { ApplyShield(actor, target); actor.AttackBar.Value = actor.AttackInterval; CheckEnd(); return; }
+                else if (ability.Name == "Arcane Shield")
+                {
+                    int shield = (int)Math.Max(1, 5 + actor.Intelligence * 1.5);
+                    ApplyShield(actor, target, shield, 15000);
+                    actor.AttackBar.Value = actor.AttackInterval;
+                    CheckEnd();
+                    return;
+                }
+                else if (ability.Name == "Fortify")
+                {
+                    int shield = (int)Math.Max(1, 3 + actor.Intelligence * 0.6);
+                    ApplyShield(actor, target, shield, 8000);
+                    actor.AttackBar.Value = actor.AttackInterval;
+                    CheckEnd();
+                    return;
+                }
                 else if (ability.Name == "Shockwave" || ability.Name == "Frost Nova" || ability.Name == "Earthquake" || ability.Name == "Meteor" || ability.Name == "Flame Strike" || ability.Name == "Arcane Blast")
                 {
                     foreach (var o in opponents.Where(o => o.CurrentHp > 0))
@@ -835,19 +850,18 @@ namespace WinFormsApp2
             }
         }
 
-        private void ApplyShield(Creature actor, Creature target)
+        private void ApplyShield(Creature actor, Creature target, int shieldAmount, int durationMs)
         {
-            int shield = (int)Math.Max(1, 5 + actor.Intelligence * 1.5);
             target.Effects.Add(new StatusEffect
             {
                 Kind = EffectKind.Shield,
-                RemainingMs = 15000,
+                RemainingMs = durationMs,
                 TickIntervalMs = int.MaxValue,
                 TimeUntilTickMs = int.MaxValue,
-                AmountPerTick = shield,
+                AmountPerTick = shieldAmount,
                 SourceIsPlayer = _players.Contains(actor)
             });
-            AppendLog($"{target.Name} is protected by a magical shield ({shield}).", _players.Contains(actor), true);
+            AppendLog($"{target.Name} is protected by a magical shield ({shieldAmount}).", _players.Contains(actor), true);
         }
 
         private void ApplyShieldReduction(Creature target, ref int dmg)

--- a/additional_skills.sql
+++ b/additional_skills.sql
@@ -22,7 +22,7 @@ INSERT INTO abilities (name, description, cost, cooldown) VALUES
 ('Blood Pact', 'Deal 8 + 120% of your STR damage but take 2 + 50% of your STR recoil.', 40, 10),
 ('Enrage', 'Increase your damage by 5 + 40% of your STR for 8s.', 30, 25),
 ('Healing Wave', 'Heal the party for 4 + 100% of your INT HP.', 60, 20),
-('Fortify', 'Grant a shield of 3 + 60% of your INT damage for 8s.', 35, 15),
+('Fortify', 'Grant a shield absorbing 3 + 60% of your INT damage for 8s.', 35, 15),
 ('Flame Strike', 'Smash the ground for 7 + 110% of your INT fire damage to all enemies.', 65, 12),
 ('Silencing Shot', 'Deal 4 + 80% of your DEX damage and silence for 3s.', 30, 8),
 ('Rend Armor', 'Rip armor dealing 3 + 70% of your STR damage and reducing defense.', 30, 10),


### PR DESCRIPTION
## Summary
- Support the Fortify ability by applying a shield scaling with 3 + 60% INT for 8s
- Generalize ApplyShield to take shield amount and duration
- Clarify Fortify description in SQL data

## Testing
- `dotnet build WinFormsApp2/BattleLands.csproj -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3dd1328708333ad3fa5c32fedf2ff