### PR TITLE
Add Stone Skin shield and defense buff

### DIFF
--- a/add_more_spells.sql
+++ b/add_more_spells.sql
@@ -4,7 +4,7 @@ INSERT INTO abilities (name, description, cost, cooldown) VALUES
 ('Lightning Bolt', 'Call down lightning dealing 4 + 120% of your INT damage to a single foe.', 45, 0),
 ('Shield Bash', 'Bash a foe for 2 + 50% of your STR damage and stun briefly.', 30, 0),
 ('Rejuvenate', 'Heal an ally over time for 1 + 60% of your INT every 2s for 6s.', 35, 0),
-('Stone Skin', 'Increase an ally\'s defense by 20% for 5s.', 25, 0),
+('Stone Skin', 'Increase an ally\'s defense by 20% and grant an absorb shield for 5s.', 25, 0),
 ('Arcane Blast', 'Unleash arcane energy dealing 8 + 90% of your INT damage to all enemies.', 60, 0),
 ('Poison Arrow', 'Fire a toxic shot dealing 2 + 40% of your DEX damage and poisoning for 6s.', 30, 0),
 ('Cleanse', 'Remove negative effects from an ally.', 20, 0),


### PR DESCRIPTION
## Summary
- Extend Stone Skin spell description with new absorb shield effect
- Add Stone Skin handling in battle logic to grant temporary defense buff and strength-based shield
- Track and expire Stone Skin buffs over time

## Testing
- `dotnet build WinFormsApp2` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3dd146c9c8333bef7e9cef10ecd0c