### PR TITLE
Scale enemy levels to party average

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -154,8 +154,21 @@ namespace WinFormsApp2
             }
 
             int targetAvg = totalLevel < areaMin ? areaMin : avgLevel;
-            int perNpcMin = Math.Max(areaMin, (int)Math.Ceiling(targetAvg * 0.8));
-            int perNpcMax = Math.Min(areaMax, (int)Math.Ceiling(targetAvg * (_wildEncounter ? 1.0 : 1.2)));
+
+            // NPC levels range from roughly 60% to 100% of the party's average level,
+            // while still respecting any area-level restrictions.
+            int perNpcMin = (int)(avgLevel * 0.6);
+            int perNpcMax = avgLevel;
+            if (_areaMinLevel.HasValue)
+            {
+                perNpcMin = Math.Max(perNpcMin, areaMin);
+                perNpcMax = Math.Max(perNpcMax, areaMin);
+            }
+            if (_areaMaxLevel.HasValue)
+            {
+                perNpcMin = Math.Min(perNpcMin, areaMax);
+                perNpcMax = Math.Min(perNpcMax, areaMax);
+            }
             if (perNpcMin > perNpcMax)
                 perNpcMin = perNpcMax = Math.Min(areaMax, perNpcMin);
 
@@ -231,8 +244,9 @@ namespace WinFormsApp2
                 return null;
             }
 
-            int strongMin = Math.Max(perNpcMin, (int)Math.Ceiling(targetAvg * 1.2));
-            int strongMax = Math.Min(perNpcMax, (int)Math.Ceiling(targetAvg * 1.5));
+            // Start with a foe at the upper end of the allowed range.
+            int strongMin = perNpcMax;
+            int strongMax = perNpcMax;
             AddNpc(strongMin, strongMax);
 
             int weakerCount = _rng.Next(1, 3);

--- a/WinFormsApp2/NavigationWindow.cs
+++ b/WinFormsApp2/NavigationWindow.cs
@@ -68,7 +68,7 @@ namespace WinFormsApp2
             toolTip1.SetToolTip(btnShop, "Buy and sell items");
             toolTip1.SetToolTip(btnGraveyard, "View and resurrect fallen heroes");
             toolTip1.SetToolTip(btnTavern, "Visit the tavern");
-            toolTip1.SetToolTip(btnFindEnemies, "Search the area for trouble");
+            toolTip1.SetToolTip(btnFindEnemies, "Search the area for enemies scaled to your party");
             toolTip1.SetToolTip(btnArena, "Enter the battle arena");
             toolTip1.SetToolTip(btnTemple, "Receive divine blessings");
             _travelManager.Resume();


### PR DESCRIPTION
## Summary
- Compute average party level to set enemy level range
- Limit NPC levels to 60-100% of party average, respecting area bounds
- Update search tooltip to mention party-based scaling

## Testing
- `dotnet build BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f2e4c4a8833393769a7798808f91