### PR TITLE
Handle non-item entries in shop list

### DIFF
--- a/WinFormsApp2/ShopForm.Designer.cs
+++ b/WinFormsApp2/ShopForm.Designer.cs
@@ -37,7 +37,6 @@ namespace WinFormsApp2
             // 
             _lstShop.Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point, 0);
             _lstShop.ItemHeight = 15;
-            _lstShop.Items.AddRange(new object[] { "1", "2", "3", "4", "5" });
             _lstShop.Location = new Point(10, 25);
             _lstShop.Name = "_lstShop";
             _lstShop.Size = new Size(250, 139);

--- a/WinFormsApp2/ShopForm.cs
+++ b/WinFormsApp2/ShopForm.cs
@@ -173,7 +173,7 @@ namespace WinFormsApp2
         private void LstShop_MeasureItem(object? sender, MeasureItemEventArgs e)
         {
             if (e.Index < 0) return;
-            var item = (Item)_lstShop.Items[e.Index];
+            if (_lstShop.Items[e.Index] is not Item item) return;
             string price = $" - {item.Price}g";
             float width;
             if (item.RainbowColors != null)
@@ -222,7 +222,7 @@ namespace WinFormsApp2
         private void LstShop_DrawItem(object? sender, DrawItemEventArgs e)
         {
             if (e.Index < 0) return;
-            var item = (Item)_lstShop.Items[e.Index];
+            if (_lstShop.Items[e.Index] is not Item item) return;
             e.DrawBackground();
             if (item.RainbowColors != null)
             {


### PR DESCRIPTION
## Summary
- remove placeholder strings from shop form list
- skip drawing/measurement if listbox item is not a real Item

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5136180d88333a75a0bce91f28525