### PR TITLE
Add armor specialization passives

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -1592,6 +1592,42 @@ namespace WinFormsApp2
                     case "Arcane Siphon":
                         c.SpellManaLeechPercent += 0.05;
                         break;
+                    case "Plate Mastery":
+                        foreach (var item in c.Equipment.Values)
+                        {
+                            if (item is Armor a && a.Name.Contains("Plate", StringComparison.OrdinalIgnoreCase))
+                            {
+                                if (a.FlatBonuses.TryGetValue("Melee Defense", out int md))
+                                    c.MeleeDefense += (int)(md * 0.5);
+                                if (a.FlatBonuses.TryGetValue("Magic Defense", out int mgd))
+                                    c.MagicDefense += (int)(mgd * 0.5);
+                            }
+                        }
+                        break;
+                    case "Cloth Mastery":
+                        foreach (var item in c.Equipment.Values)
+                        {
+                            if (item is Armor a && (a.Name.Contains("Cloth", StringComparison.OrdinalIgnoreCase) || a.Name.Contains("Robe", StringComparison.OrdinalIgnoreCase)))
+                            {
+                                if (a.FlatBonuses.TryGetValue("Melee Defense", out int md))
+                                    c.MeleeDefense += (int)(md * 0.5);
+                                if (a.FlatBonuses.TryGetValue("Magic Defense", out int mgd))
+                                    c.MagicDefense += (int)(mgd * 0.5);
+                            }
+                        }
+                        break;
+                    case "Leather Mastery":
+                        foreach (var item in c.Equipment.Values)
+                        {
+                            if (item is Armor a && a.Name.Contains("Leather", StringComparison.OrdinalIgnoreCase))
+                            {
+                                if (a.FlatBonuses.TryGetValue("Melee Defense", out int md))
+                                    c.MeleeDefense += (int)(md * 0.5);
+                                if (a.FlatBonuses.TryGetValue("Magic Defense", out int mgd))
+                                    c.MagicDefense += (int)(mgd * 0.5);
+                            }
+                        }
+                        break;
                 }
             }
             if (c.ShieldStartPercent > 0)

--- a/passives.sql
+++ b/passives.sql
@@ -47,4 +47,7 @@ INSERT INTO passives (name, description) VALUES
 ('Nature\'s Grace', 'Healing over time effects you cast tick 50% faster.'),
 ('Spell Deflection', '10% chance to completely avoid spell damage.'),
 ('Rejuvenating Healer', 'Healing others also heals you for 20% of the amount.'),
-('Arcane Siphon', 'Dealing spell damage restores mana equal to 5% of the damage done.');
+('Arcane Siphon', 'Dealing spell damage restores mana equal to 5% of the damage done.'),
+('Plate Mastery', 'Increases plate armor effectiveness by 50%.'),
+('Cloth Mastery', 'Increases cloth armor effectiveness by 50%.'),
+('Leather Mastery', 'Increases leather armor effectiveness by 50%.');

--- a/rebuild_database.sql
+++ b/rebuild_database.sql
@@ -203,7 +203,10 @@ INSERT INTO passives (name, description) VALUES
 ('Flesh Rip', '5% +1% per 15 STR chance to inflict a bleed dealing 10% +1% per 15 STR of weapon damage.'),
 ('Deadly Strikes', 'Crit chance increased by 1% for every 10 DEX.'),
 ('Battle Mage', 'Leech mana equal to 15% of INT on weapon hit.'),
-('Bloodlust', 'Take 75% more damage and deal +2% weapon damage. Missing HP reduces damage taken and increases bonus.');
+('Bloodlust', 'Take 75% more damage and deal +2% weapon damage. Missing HP reduces damage taken and increases bonus.'),
+('Plate Mastery', 'Increases plate armor effectiveness by 50%.'),
+('Cloth Mastery', 'Increases cloth armor effectiveness by 50%.'),
+('Leather Mastery', 'Increases leather armor effectiveness by 50%.');
 
 -- File: inventory_tables.sql
 -- MySQL script to create tables for storing user inventory and equipment


### PR DESCRIPTION
## Summary
- add plate, cloth, and leather mastery passives
- apply armor mastery bonuses during battle calculations
- seed new passives in database scripts

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b513c11f688333b9a4b660ccdf7ffd