### PR TITLE
Limit shops to base items

### DIFF
--- a/WinFormsApp2/LootPool.cs
+++ b/WinFormsApp2/LootPool.cs
@@ -13,6 +13,28 @@ namespace WinFormsApp2
             kv => CreateRegionalPool(kv.Value)
         );
 
+        private static readonly List<string> _baseItems = new()
+        {
+            "Cloth Robe",
+            "Leather Armor",
+            "Leather Cap",
+            "Leather Boots",
+            "Plate Armor",
+            "Heavy Shield",
+            "Shortsword",
+            "Dagger",
+            "Bow",
+            "Longsword",
+            "Staff",
+            "Wand",
+            "Rod",
+            "Greataxe",
+            "Scythe",
+            "Greatsword",
+            "Mace",
+            "Greatmaul"
+        };
+
         private static List<string> CreateRegionalPool(string regionDisplay)
         {
             var items = new List<string>();
@@ -41,7 +63,7 @@ namespace WinFormsApp2
             if (_shopStocks.TryGetValue(nodeId, out var stock))
                 return stock;
 
-            var pool = GetPool(nodeId);
+            var pool = _baseItems;
             if (!_usedItems.TryGetValue(nodeId, out var used))
                 _usedItems[nodeId] = used = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 


### PR DESCRIPTION
## Summary
- Add base item pool for shops
- Limit shop inventory to base items while regional upgrades drop from enemies

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b523eff4d48333b4291c6ba76b5870