### PR TITLE
Store hireable parties in database

### DIFF
--- a/party_hires.sql
+++ b/party_hires.sql
@@ -1,0 +1,16 @@
+-- MySQL script to create the party_hires table for shared hireable parties
+USE accounts;
+
+CREATE TABLE IF NOT EXISTS party_hires (
+    id VARCHAR(36) PRIMARY KEY,
+    owner_id INT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    cost INT NOT NULL,
+    members_json TEXT NOT NULL,
+    on_mission TINYINT(1) NOT NULL DEFAULT 0,
+    current_hirer INT NULL,
+    hired_until DATETIME NULL,
+    gold_earned INT NOT NULL DEFAULT 0,
+    FOREIGN KEY (owner_id) REFERENCES users(id),
+    FOREIGN KEY (current_hirer) REFERENCES users(id)
+);


### PR DESCRIPTION
## Summary
- Store tavern hireable parties in a shared `party_hires` MySQL table instead of local JSON
- Provide SQL schema for the new table

## Testing
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b523a8f70c833385bba13fdb1051c2