### PR TITLE
Enable multi-item selling and adjust loot drop rates

### DIFF
--- a/reduce_non_tome_drop_rates.sql
+++ b/reduce_non_tome_drop_rates.sql
@@ -1,0 +1,10 @@
+USE accounts;
+
+-- Halve drop chances for all items except tomes
+UPDATE npc_loot
+SET drop_chance = drop_chance * 0.5
+WHERE item_name NOT LIKE '%Tome%';
+
+UPDATE trinkets
+SET drop_chance = drop_chance * 0.5
+WHERE name NOT LIKE '%Tome%';


### PR DESCRIPTION
## Summary
- Halve loot drop chances for all non-tome items in `npc_loot` and `trinkets`
- Allow selecting multiple inventory items and specify quantities when selling

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b654632b488333a33e112fc8f55d4b