### PR TITLE
Apply equipment bonuses and smooth health bars

### DIFF
--- a/WinFormsApp2/ColoredProgressBar.cs
+++ b/WinFormsApp2/ColoredProgressBar.cs
@@ -10,7 +10,9 @@ namespace WinFormsApp2
 
         public ColoredProgressBar()
         {
-            this.SetStyle(ControlStyles.UserPaint, true);
+            SetStyle(ControlStyles.UserPaint | ControlStyles.AllPaintingInWmPaint |
+                     ControlStyles.OptimizedDoubleBuffer, true);
+            DoubleBuffered = true;
         }
 
         protected override void OnPaint(PaintEventArgs e)
@@ -24,6 +26,10 @@ namespace WinFormsApp2
                 e.Graphics.FillRectangle(brush, 0, 0, rect.Width, rect.Height);
             }
             e.Graphics.DrawRectangle(Pens.Black, 0, 0, this.Width - 1, this.Height - 1);
+        }
+
+        protected override void OnPaintBackground(PaintEventArgs e)
+        {
         }
     }
 }

--- a/WinFormsApp2/HeroInspectForm.cs
+++ b/WinFormsApp2/HeroInspectForm.cs
@@ -19,6 +19,7 @@ namespace WinFormsApp2
         private bool _loadingEquipment;
         private System.Collections.Generic.List<Passive> _passives = new();
         private readonly ToolTip _tip = new();
+        private int _baseStr, _baseDex, _baseInt, _baseHp, _baseMaxHp, _baseMana, _level, _exp;
 
         public HeroInspectForm(int userId, int characterId, bool readOnly = false)
         {
@@ -64,17 +65,16 @@ namespace WinFormsApp2
             {
                 string name = reader.GetString("name");
                 _characterName = name;
-                int level = reader.GetInt32("level");
-                int exp = reader.GetInt32("experience_points");
-                int str = reader.GetInt32("strength");
-                int dex = reader.GetInt32("dex");
-                int intel = reader.GetInt32("intelligence");
-                int hp = reader.GetInt32("current_hp");
-                int maxHp = reader.GetInt32("max_hp");
-                int nextExp = ExperienceHelper.GetNextLevelRequirement(level);
-                lblStats.Text = $"{name}\nLevel: {level}\nEXP: {exp}/{nextExp}\nHP: {hp}/{maxHp}\nSTR: {str}\nDEX: {dex}\nINT: {intel}";
-                ShowPredictions(str, dex, intel);
-                btnLevelUp.Enabled = !_readOnly && exp >= nextExp;
+                _level = reader.GetInt32("level");
+                _exp = reader.GetInt32("experience_points");
+                _baseStr = reader.GetInt32("strength");
+                _baseDex = reader.GetInt32("dex");
+                _baseInt = reader.GetInt32("intelligence");
+                _baseHp = reader.GetInt32("current_hp");
+                _baseMaxHp = reader.GetInt32("max_hp");
+                _baseMana = 10 + 5 * _baseInt;
+                DisplayStats();
+                btnLevelUp.Enabled = !_readOnly && _exp >= ExperienceHelper.GetNextLevelRequirement(_level);
 
                 string role = reader.GetString("role");
                 string targeting = reader.GetString("targeting_style");
@@ -100,6 +100,15 @@ namespace WinFormsApp2
                     cmbTrinket.Enabled = false;
                 }
             }
+        }
+
+        private void DisplayStats()
+        {
+            int str = _baseStr, dex = _baseDex, intel = _baseInt, hp = _baseHp, maxHp = _baseMaxHp, mana = _baseMana, maxMana = _baseMana;
+            InventoryService.ApplyEquipmentBonuses(_characterName, ref str, ref dex, ref intel, ref hp, ref maxHp, ref mana, ref maxMana);
+            int nextExp = ExperienceHelper.GetNextLevelRequirement(_level);
+            lblStats.Text = $"{_characterName}\nLevel: {_level}\nEXP: {_exp}/{nextExp}\nHP: {hp}/{maxHp}\nSTR: {str}\nDEX: {dex}\nINT: {intel}";
+            ShowPredictions(str, dex, intel);
         }
 
         private void ShowPredictions(int str, int dex, int intel)
@@ -282,6 +291,7 @@ namespace WinFormsApp2
                 }
             }
             LoadEquipment();
+            DisplayStats();
         }
 
         private void LoadAbilities()

--- a/WinFormsApp2/InventoryService.cs
+++ b/WinFormsApp2/InventoryService.cs
@@ -302,6 +302,85 @@ namespace WinFormsApp2
             }
         }
 
+        public static void ApplyEquipmentBonuses(string character, ref int strength, ref int dexterity,
+            ref int intelligence, ref int currentHp, ref int maxHp, ref int mana, ref int maxMana)
+        {
+            if (!_equipment.TryGetValue(character, out var dict)) return;
+            foreach (var item in dict.Values)
+            {
+                if (item == null) continue;
+                foreach (var kv in item.FlatBonuses)
+                {
+                    switch (kv.Key)
+                    {
+                        case "Strength":
+                            strength += kv.Value;
+                            break;
+                        case "Dexterity":
+                            dexterity += kv.Value;
+                            break;
+                        case "Intelligence":
+                            intelligence += kv.Value;
+                            maxMana += 5 * kv.Value;
+                            mana += 5 * kv.Value;
+                            break;
+                        case "HP":
+                            maxHp += kv.Value;
+                            currentHp += kv.Value;
+                            break;
+                        case "Mana":
+                            maxMana += kv.Value;
+                            mana += kv.Value;
+                            break;
+                    }
+                }
+                foreach (var kv in item.PercentBonuses)
+                {
+                    switch (kv.Key)
+                    {
+                        case "Strength":
+                            strength = (int)(strength * (1 + kv.Value / 100.0));
+                            break;
+                        case "Dexterity":
+                            dexterity = (int)(dexterity * (1 + kv.Value / 100.0));
+                            break;
+                        case "Intelligence":
+                            int oldInt = intelligence;
+                            intelligence = (int)(intelligence * (1 + kv.Value / 100.0));
+                            int delta = intelligence - oldInt;
+                            maxMana += 5 * delta;
+                            mana += 5 * delta;
+                            break;
+                        case "HP":
+                            maxHp = (int)(maxHp * (1 + kv.Value / 100.0));
+                            currentHp = (int)(currentHp * (1 + kv.Value / 100.0));
+                            break;
+                        case "Mana":
+                            maxMana = (int)(maxMana * (1 + kv.Value / 100.0));
+                            mana = (int)(mana * (1 + kv.Value / 100.0));
+                            break;
+                    }
+                }
+                if (item is Trinket tr)
+                {
+                    foreach (var ev in tr.Effects)
+                    {
+                        switch (ev.Key)
+                        {
+                            case "max_hp_pct":
+                                maxHp = (int)(maxHp * (1 + ev.Value / 100.0));
+                                currentHp = (int)(currentHp * (1 + ev.Value / 100.0));
+                                break;
+                            case "max_mana_pct":
+                                maxMana = (int)(maxMana * (1 + ev.Value / 100.0));
+                                mana = (int)(mana * (1 + ev.Value / 100.0));
+                                break;
+                        }
+                    }
+                }
+            }
+        }
+
         public static IEnumerable<Item> GetEquippableItems(EquipmentSlot slot, string character)
         {
             foreach (var inv in _items)

--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -49,11 +49,12 @@ namespace WinFormsApp2
             _hiredMembers = PartyHireService.GetHiredMemberNames(_userId);
             _mercenaryMembers.Clear();
 
-            using MySqlCommand cmd = new MySqlCommand("SELECT name, experience_points, level, current_hp, max_hp, mana, intelligence, in_tavern, is_mercenary FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0", conn);
+            using MySqlCommand cmd = new MySqlCommand("SELECT name, experience_points, level, current_hp, max_hp, mana, strength, dex, intelligence, in_tavern, is_mercenary FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0", conn);
 
             cmd.Parameters.AddWithValue("@id", _userId);
             using MySqlDataReader reader = cmd.ExecuteReader();
             lstParty.Items.Clear();
+            pnlParty.SuspendLayout();
             pnlParty.Controls.Clear();
             int totalExp = 0;
             int totalLevel = 0;
@@ -73,8 +74,11 @@ namespace WinFormsApp2
                 int hp = reader.GetInt32("current_hp");
                 int maxHp = reader.GetInt32("max_hp");
                 int mana = reader.GetInt32("mana");
+                int str = reader.GetInt32("strength");
+                int dex = reader.GetInt32("dex");
                 int intel = reader.GetInt32("intelligence");
                 int maxMana = 10 + 5 * intel;
+                InventoryService.ApplyEquipmentBonuses(name, ref str, ref dex, ref intel, ref hp, ref maxHp, ref mana, ref maxMana);
                 int nextExp = ExperienceHelper.GetNextLevelRequirement(level);
                 string display = $"{name} - LVL {level} EXP {exp}/{nextExp}";
                 if (isMerc)
@@ -128,6 +132,7 @@ namespace WinFormsApp2
             lblGold.Text = $"Gold: {_playerGold}";
             btnInspect.Enabled = false;
             btnInspect.Text = "Inspect";
+            pnlParty.ResumeLayout();
         }
 
         private void lstParty_SelectedIndexChanged(object? sender, EventArgs e)


### PR DESCRIPTION
## Summary
- Recalculate character stats with equipped item bonuses
- Update hero inspection and party view when gear changes
- Reduce health bar flicker with double-buffered progress bars

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b657360e588333bdca92a5a6ea42f7