### PR TITLE
Prevent NumericUpDown initialization overflow

### DIFF
--- a/WinFormsApp2/LevelUpForm.cs
+++ b/WinFormsApp2/LevelUpForm.cs
@@ -19,6 +19,7 @@ namespace WinFormsApp2
         private int _ownedPassiveCount;
         private int _maxMana;
         private readonly ToolTip _tip = new();
+        private bool _loading;
 
         public LevelUpForm(int userId, int characterId)
         {
@@ -40,6 +41,7 @@ namespace WinFormsApp2
 
         private void LevelUpForm_Load(object? sender, EventArgs e)
         {
+            _loading = true;
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
 
@@ -60,13 +62,12 @@ namespace WinFormsApp2
                     _baseInt = reader.GetInt32("intelligence");
                     _availablePoints = reader.GetInt32("skill_points");
                     _maxMana = 10 + 5 * _baseInt;
-                    numStr.Value = _baseStr;
-                    numDex.Value = _baseDex;
-                    numInt.Value = _baseInt;
-                    // Prevent lowering stats below their original values
                     numStr.Minimum = _baseStr;
                     numDex.Minimum = _baseDex;
                     numInt.Minimum = _baseInt;
+                    numStr.Value = _baseStr;
+                    numDex.Value = _baseDex;
+                    numInt.Value = _baseInt;
                     lblPoints.Text = $"Points: {_availablePoints}";
                 }
             }
@@ -95,10 +96,12 @@ namespace WinFormsApp2
                 lstPassives.Items.Add(p.Name);
             }
             UpdatePassiveCostButton();
+            _loading = false;
         }
 
         private void StatsChanged(object? sender, EventArgs e)
         {
+            if (_loading) return;
             int spent = (int)((numStr.Value - _baseStr) + (numDex.Value - _baseDex) + (numInt.Value - _baseInt));
             if (spent < 0)
             {


### PR DESCRIPTION
## Summary
- Avoid ValueChanged events during LevelUpForm load by adding a loading flag
- Set stat minimums before values to keep NumericUpDowns in range
- Bypass stat recalculations while loading to prevent out-of-range errors

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68b661f86a888333b84baa5ae9461681