### PR TITLE
Scale NPC equipment rarity by level

### DIFF
--- a/WinFormsApp2.Tests/RarityScalingTests.cs
+++ b/WinFormsApp2.Tests/RarityScalingTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Linq;
+using Xunit;
+
+namespace WinFormsApp2.Tests;
+
+public class RarityScalingTests
+{
+    [Fact]
+    public void LowLevelNpcRareItemsAreScarce()
+    {
+        int rareOrBetter = 0;
+        for (int i = 0; i < 1000; i++)
+        {
+            var rarity = LootService.RollRarityForLevel(1);
+            if (rarity >= Rarity.Blue)
+                rareOrBetter++;
+        }
+        Assert.True(rareOrBetter < 150, $"Unexpected rare count: {rareOrBetter}");
+    }
+
+    [Fact]
+    public void HighLevelNpcGetsMoreRareItems()
+    {
+        int rareOrBetter = 0;
+        for (int i = 0; i < 1000; i++)
+        {
+            var rarity = LootService.RollRarityForLevel(50);
+            if (rarity >= Rarity.Blue)
+                rareOrBetter++;
+        }
+        Assert.True(rareOrBetter > 300, $"Unexpected rare count: {rareOrBetter}");
+    }
+}

--- a/WinFormsApp2.Tests/WinFormsApp2.Tests.csproj
+++ b/WinFormsApp2.Tests/WinFormsApp2.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -20,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <ProjectReference Include="..\WinFormsApp2\BattleLands.csproj" />
   </ItemGroup>
 
 </Project>

--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -229,7 +229,7 @@ namespace WinFormsApp2
                     TargetingStyle = style
                 };
 
-                foreach (var kv in InventoryService.GetNpcEquipment(name))
+                foreach (var kv in InventoryService.GetNpcEquipment(name, level))
                     npc.Equipment[kv.Key] = kv.Value;
                 ApplyEquipmentBonuses(npc);
 

--- a/WinFormsApp2/InventoryService.cs
+++ b/WinFormsApp2/InventoryService.cs
@@ -295,7 +295,7 @@ namespace WinFormsApp2
         }
 
 
-        public static Dictionary<EquipmentSlot, Item?> GetNpcEquipment(string npcName)
+        public static Dictionary<EquipmentSlot, Item?> GetNpcEquipment(string npcName, int level)
         {
             var dict = new Dictionary<EquipmentSlot, Item?>();
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
@@ -307,6 +307,17 @@ namespace WinFormsApp2
             {
                 var slot = Enum.Parse<EquipmentSlot>(r.GetString("slot"));
                 var item = CreateItem(r.GetString("item_name"));
+                if (item is Weapon or Armor)
+                {
+                    var rarity = LootService.RollRarityForLevel(level);
+                    if (rarity != Rarity.None && item != null)
+                    {
+                        string baseName = item.Name;
+                        item.Stackable = false;
+                        item.Name = MagicItemNameGenerator.Generate(baseName, rarity);
+                        LootService.ApplyBonuses(item, level, rarity);
+                    }
+                }
                 if (item is Weapon w && w.TwoHanded)
                 {
                     dict[EquipmentSlot.LeftHand] = w;

--- a/WinFormsApp2/LootService.cs
+++ b/WinFormsApp2/LootService.cs
@@ -169,7 +169,24 @@ namespace WinFormsApp2
             return rarity;
         }
 
-        private static void ApplyBonuses(Item item, int maxPoints, Rarity rarity)
+        public static Rarity RollRarityForLevel(int level)
+        {
+            double scale = Math.Clamp(level / 50.0, 0, 1);
+            double roll = _rng.NextDouble();
+            double threshold = 0.2 + 0.3 * scale; // Green
+            if (roll < threshold) return Rarity.Green;
+            threshold += 0.05 + 0.2 * scale; // Blue
+            if (roll < threshold) return Rarity.Blue;
+            threshold += 0.01 + 0.1 * scale; // Purple
+            if (roll < threshold) return Rarity.Purple;
+            threshold += 0.002 + 0.05 * scale; // Red
+            if (roll < threshold) return Rarity.Red;
+            threshold += 0.0005 + 0.02 * scale; // Rainbow
+            if (roll < threshold) return Rarity.Rainbow;
+            return Rarity.None;
+        }
+
+        public static void ApplyBonuses(Item item, int maxPoints, Rarity rarity)
         {
             int min = rarity switch
             {


### PR DESCRIPTION
## Summary
- add level-based rarity roll helper
- upgrade NPC equipment with rolled rarity
- forward NPC level when fetching equipment
- test rarity scaling between low and high level NPCs

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b67ed601a083338ba57d58948450b3