### PR TITLE
Add probability-gated enemy loot drop with tests

### DIFF
--- a/WinFormsApp2.Tests/LootServiceTests.cs
+++ b/WinFormsApp2.Tests/LootServiceTests.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Linq;
+using WinFormsApp2;
+
+namespace WinFormsApp2.Tests;
+
+public class LootServiceTests
+{
+    [Fact]
+    public void BonusLootDropRateIsApproximatelyHalf()
+    {
+        var rng = new Random(0);
+        const int trials = 10000;
+        int drops = Enumerable.Range(0, trials)
+            .Count(_ => LootService.ShouldDropBonusLoot(rng));
+        double rate = drops / (double)trials;
+        Assert.InRange(rate, 0.45, 0.55);
+    }
+}

--- a/WinFormsApp2.Tests/WinFormsApp2.Tests.csproj
+++ b/WinFormsApp2.Tests/WinFormsApp2.Tests.csproj
@@ -22,4 +22,8 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\WinFormsApp2\LootService.Probability.cs" Link="LootService.Probability.cs" />
+  </ItemGroup>
+
 </Project>

--- a/WinFormsApp2/AssemblyInfo.cs
+++ b/WinFormsApp2/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("WinFormsApp2.Tests")]

--- a/WinFormsApp2/LootService.Probability.cs
+++ b/WinFormsApp2/LootService.Probability.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace WinFormsApp2
+{
+    public static partial class LootService
+    {
+        private const double BonusLootDropRate = 0.5;
+
+        // Exposed for testing to verify bonus loot probability
+        internal static bool ShouldDropBonusLoot(Random rng) => rng.NextDouble() <= BonusLootDropRate;
+    }
+}

--- a/WinFormsApp2/LootService.cs
+++ b/WinFormsApp2/LootService.cs
@@ -6,7 +6,7 @@ using MySql.Data.MySqlClient;
 
 namespace WinFormsApp2
 {
-    public static class LootService
+    public static partial class LootService
     {
         private static readonly Random _rng = new();
 
@@ -52,12 +52,15 @@ namespace WinFormsApp2
                     drops[trinket] = drops.GetValueOrDefault(trinket) + 1;
             }
 
-            // chance to drop additional loot from global pool
-            Item? bonusLoot = LootPool.GetEnemyLoot(areaId);
-            if (bonusLoot != null)
+            // 50% chance to drop additional loot from global pool
+            if (ShouldDropBonusLoot(_rng))
             {
-                drops[bonusLoot.Name] = drops.GetValueOrDefault(bonusLoot.Name) + 1;
-                InventoryService.AddItem(bonusLoot);
+                Item? bonusLoot = LootPool.GetEnemyLoot(areaId);
+                if (bonusLoot != null)
+                {
+                    drops[bonusLoot.Name] = drops.GetValueOrDefault(bonusLoot.Name) + 1;
+                    InventoryService.AddItem(bonusLoot);
+                }
             }
 
             foreach (var kvp in drops.Where(k => k.Key != "gold"))


### PR DESCRIPTION
## Summary
- Gate global loot pool drops behind a 50% roll in `GenerateLoot`
- Expose bonus drop roll in partial class for testing
- Test that bonus loot roll succeeds roughly half the time

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b67eda5efc8333aadd59921a96e477