### PR TITLE
Enable equipping gear directly from inventory

### DIFF
--- a/WinFormsApp2.Tests/EquipmentTests.cs
+++ b/WinFormsApp2.Tests/EquipmentTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Windows.Forms;
+using WinFormsApp2;
+using Xunit;
+
+namespace WinFormsApp2.Tests;
+
+public class EquipmentTests
+{
+    private static void ResetInventoryService()
+    {
+        var itemsField = typeof(InventoryService).GetField("_items", BindingFlags.NonPublic | BindingFlags.Static);
+        ((List<InventoryItem>)itemsField!.GetValue(null)!).Clear();
+        var equipField = typeof(InventoryService).GetField("_equipment", BindingFlags.NonPublic | BindingFlags.Static);
+        ((Dictionary<string, Dictionary<EquipmentSlot, Item?>>)equipField!.GetValue(null)!).Clear();
+        var loadedField = typeof(InventoryService).GetField("_loaded", BindingFlags.NonPublic | BindingFlags.Static);
+        loadedField!.SetValue(null, false);
+    }
+
+    [Fact]
+    public void EquipItemRemovesFromInventory()
+    {
+        ResetInventoryService();
+        var sword = new Weapon { Name = "Sword", Slot = EquipmentSlot.RightHand, Stackable = false };
+        InventoryService.AddItem(sword);
+        InventoryService.Equip("Hero", EquipmentSlot.RightHand, sword);
+        Assert.Empty(InventoryService.Items);
+        Assert.Equal(sword, InventoryService.GetEquippedItem("Hero", EquipmentSlot.RightHand));
+    }
+
+    [Fact]
+    public void EquipReplacesExistingGear()
+    {
+        ResetInventoryService();
+        var oldSword = new Weapon { Name = "OldSword", Slot = EquipmentSlot.RightHand, Stackable = false };
+        var newSword = new Weapon { Name = "NewSword", Slot = EquipmentSlot.RightHand, Stackable = false };
+        InventoryService.AddItem(oldSword);
+        InventoryService.Equip("Hero", EquipmentSlot.RightHand, oldSword);
+        InventoryService.AddItem(newSword);
+        InventoryService.Equip("Hero", EquipmentSlot.RightHand, newSword);
+        Assert.Single(InventoryService.Items);
+        Assert.Equal("OldSword", InventoryService.Items[0].Item.Name);
+        Assert.Equal(newSword, InventoryService.GetEquippedItem("Hero", EquipmentSlot.RightHand));
+    }
+
+    private class TestInventoryForm : InventoryForm
+    {
+        public string? LastMessage;
+        public TestInventoryForm() : base(0) {}
+        protected override void ShowMessage(string text) => LastMessage = text;
+        public void TestSelectAndEquip(Item item, string target)
+        {
+            InventoryService.AddItem(item);
+            var refresh = typeof(InventoryForm).GetMethod("RefreshItems", BindingFlags.NonPublic | BindingFlags.Instance);
+            refresh!.Invoke(this, null);
+            var listBox = (ListBox)typeof(InventoryForm).GetField("lstItems", BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(this)!;
+            listBox.SelectedIndex = 0;
+            typeof(InventoryForm).GetField("_selectedTarget", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(this, target);
+            var use = typeof(InventoryForm).GetMethod("btnUse_Click", BindingFlags.NonPublic | BindingFlags.Instance);
+            use!.Invoke(this, new object?[] { null, EventArgs.Empty });
+        }
+    }
+
+    [Fact]
+    public void EquipShowsMessage()
+    {
+        ResetInventoryService();
+        var form = new TestInventoryForm();
+        var sword = new Weapon { Name = "Sword", Slot = EquipmentSlot.RightHand, Stackable = false };
+        form.TestSelectAndEquip(sword, "Hero");
+        Assert.Equal("Equipped Sword to Hero", form.LastMessage);
+    }
+}

--- a/WinFormsApp2.Tests/WinFormsApp2.Tests.csproj
+++ b/WinFormsApp2.Tests/WinFormsApp2.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -20,6 +21,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../WinFormsApp2/BattleLands.csproj" />
   </ItemGroup>
 
 </Project>

--- a/WinFormsApp2/InventoryForm.cs
+++ b/WinFormsApp2/InventoryForm.cs
@@ -73,11 +73,14 @@ namespace WinFormsApp2
             {
                 lblDescription.Text = string.Empty;
                 btnUse.Enabled = false;
+                btnUse.Text = "Use";
             }
             else
             {
                 lblDescription.Text = DescribeItem(item);
-                btnUse.Enabled = _selectedTarget != null && (item is HealingPotion || item is AbilityTome);
+                bool isEquipment = item is Weapon || item is Armor || item is Trinket;
+                btnUse.Text = isEquipment ? "Equip" : "Use";
+                btnUse.Enabled = _selectedTarget != null && (isEquipment || item is HealingPotion || item is AbilityTome);
             }
         }
 
@@ -118,7 +121,16 @@ namespace WinFormsApp2
                 InventoryService.RemoveItem(item);
                 RefreshItems();
             }
+            else if (item is Weapon || item is Armor || item is Trinket)
+            {
+                InventoryService.Equip(_selectedTarget, item.Slot!.Value, item);
+                InventoryService.RemoveItem(item);
+                RefreshItems();
+                ShowMessage($"Equipped {item.Name} to {_selectedTarget}");
+            }
         }
+
+        protected virtual void ShowMessage(string text) => MessageBox.Show(text);
 
         private void LoadTargets()
         {
@@ -138,7 +150,9 @@ namespace WinFormsApp2
         {
             _selectedTarget = cmbTarget.SelectedItem?.ToString();
             var item = SelectedItem();
-            btnUse.Enabled = _selectedTarget != null && (item is HealingPotion || item is AbilityTome);
+            bool isEquipment = item is Weapon || item is Armor || item is Trinket;
+            btnUse.Text = isEquipment ? "Equip" : "Use";
+            btnUse.Enabled = _selectedTarget != null && (isEquipment || item is HealingPotion || item is AbilityTome);
         }
 
         private void LstItems_DrawItem(object? sender, DrawItemEventArgs e)


### PR DESCRIPTION
## Summary
- Switch Use button to Equip when selecting weapons, armor or trinkets
- Equip button invokes InventoryService.Equip and shows confirmation message
- Add tests for equipping items, replacing gear and message display

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: The imported project "Microsoft.NET.Sdk.WindowsDesktop.targets" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b67edbe30c8333b94593ebc24919aa