### PR TITLE
Use central PowerCalculator for party power calculations

### DIFF
--- a/WinFormsApp2/ArenaForm.cs
+++ b/WinFormsApp2/ArenaForm.cs
@@ -152,7 +152,7 @@ namespace WinFormsApp2
                 sCmd.Parameters.AddWithValue("@id", accountId);
                 skillCount = Convert.ToInt32(sCmd.ExecuteScalar() ?? 0);
             }
-            return (int)Math.Ceiling((totalLevel + equipCost + 3 * skillCount) * 0.15);
+            return PowerCalculator.CalculatePartyPower(totalLevel, equipCost, skillCount);
         }
 
         private void LstTeams_MouseMove(object? sender, MouseEventArgs e)

--- a/WinFormsApp2/PowerCalculator.cs
+++ b/WinFormsApp2/PowerCalculator.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace WinFormsApp2
+{
+    public static class PowerCalculator
+    {
+        public static int CalculateUnitPower(int level, int equipCost, int skillCount)
+        {
+            return (int)Math.Ceiling((level + equipCost + 3 * skillCount) * 0.15);
+        }
+
+        public static int CalculatePartyPower(int totalLevel, int totalEquipCost, int totalSkillCount)
+        {
+            return CalculateUnitPower(totalLevel, totalEquipCost, totalSkillCount);
+        }
+    }
+}

--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -122,7 +122,7 @@ namespace WinFormsApp2
                 object? sres = skillCmd.ExecuteScalar();
                 totalSkills = sres == null || sres == DBNull.Value ? 0 : Convert.ToInt32(sres);
             }
-            int partyPower = (int)Math.Ceiling((totalLevel + totalEquipCost + 3 * totalSkills) * 0.15);
+            int partyPower = PowerCalculator.CalculatePartyPower(totalLevel, totalEquipCost, totalSkills);
             partyPowerLabel.Text = $"Party Power: {partyPower}";
 
             using MySqlCommand goldCmd = new MySqlCommand("SELECT gold FROM users WHERE id=@id", conn);


### PR DESCRIPTION
## Summary
- add PowerCalculator helper to compute unit and party power
- refactor RPGForm and ArenaForm to use PowerCalculator instead of inline formulas

## Testing
- ⚠️ `dotnet test WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b68010a4988333b71ae873e0492f6d