### PR TITLE
Use power-based enemy info and add NPC power calculator

### DIFF
--- a/WinFormsApp2/EnemyKnowledgeService.cs
+++ b/WinFormsApp2/EnemyKnowledgeService.cs
@@ -40,22 +40,23 @@ ON DUPLICATE KEY UPDATE kill_count = kill_count + 1", conn);
             return result == null ? 0 : System.Convert.ToInt32(result);
         }
 
-        public static List<EnemyInfo> GetEnemiesForArea(int minLevel, int maxLevel)
+        public static List<EnemyInfo> GetEnemiesForArea(int minPower, int maxPower)
         {
             var list = new List<EnemyInfo>();
             using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using (var cmd = new MySqlCommand("SELECT name, level, role, targeting_style FROM npcs WHERE level BETWEEN @min AND @max ORDER BY level", conn))
+            using (var cmd = new MySqlCommand("SELECT name, role, targeting_style FROM npcs", conn))
             {
-                cmd.Parameters.AddWithValue("@min", minLevel);
-                cmd.Parameters.AddWithValue("@max", maxLevel);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
+                    string name = reader.GetString("name");
+                    int power = PowerCalculator.GetNpcPower(name);
+                    if (power < minPower || power > maxPower) continue;
                     var info = new EnemyInfo
                     {
-                        Name = reader.GetString("name"),
-                        Level = reader.GetInt32("level"),
+                        Name = name,
+                        Power = power,
                         Role = reader.GetString("role"),
                         TargetingStyle = reader.GetString("targeting_style")
                     };
@@ -87,7 +88,7 @@ ON DUPLICATE KEY UPDATE kill_count = kill_count + 1", conn);
     public class EnemyInfo
     {
         public string Name { get; set; } = string.Empty;
-        public int Level { get; set; }
+        public int Power { get; set; }
         public string Role { get; set; } = string.Empty;
         public string TargetingStyle { get; set; } = string.Empty;
         public List<Ability> Skills { get; } = new();

--- a/WinFormsApp2/NavigationWindow.cs
+++ b/WinFormsApp2/NavigationWindow.cs
@@ -154,7 +154,7 @@ namespace WinFormsApp2
                 {
                     var sb = new StringBuilder();
                     sb.AppendLine($"Name: {item.Info.Name}");
-                    sb.AppendLine($"Level: {item.Info.Level}");
+                    sb.AppendLine($"Power: {item.Info.Power}");
                     sb.AppendLine(item.Info.Description);
                     if (item.Info.Skills.Count > 0)
                     {

--- a/WinFormsApp2/PowerCalculator.cs
+++ b/WinFormsApp2/PowerCalculator.cs
@@ -1,0 +1,43 @@
+using System;
+using MySql.Data.MySqlClient;
+
+namespace WinFormsApp2
+{
+    public static class PowerCalculator
+    {
+        public static int GetNpcPower(string npcName)
+        {
+            using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+
+            int level;
+            using (var lvlCmd = new MySqlCommand("SELECT level FROM npcs WHERE name=@n", conn))
+            {
+                lvlCmd.Parameters.AddWithValue("@n", npcName);
+                level = Convert.ToInt32(lvlCmd.ExecuteScalar() ?? 0);
+            }
+
+            int equipCost = 0;
+            using (var eqCmd = new MySqlCommand("SELECT item_name FROM npc_equipment WHERE npc_name=@n", conn))
+            {
+                eqCmd.Parameters.AddWithValue("@n", npcName);
+                using var er = eqCmd.ExecuteReader();
+                while (er.Read())
+                {
+                    var item = InventoryService.CreateItem(er.GetString("item_name"));
+                    if (item != null)
+                        equipCost += item.Price;
+                }
+            }
+
+            int abilityCount;
+            using (var sCmd = new MySqlCommand("SELECT COUNT(*) FROM npc_abilities WHERE npc_name=@n", conn))
+            {
+                sCmd.Parameters.AddWithValue("@n", npcName);
+                abilityCount = Convert.ToInt32(sCmd.ExecuteScalar() ?? 0);
+            }
+
+            return (int)Math.Ceiling((level + equipCost + 3 * abilityCount) * 0.15);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Calculate NPC power with new `PowerCalculator`
- Filter enemies by power and expose power on `EnemyInfo`
- Show enemy power instead of level in navigation window

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b68013065c8333a68764f4a7cfcb80