### PR TITLE
Track Dark Spire progress using power columns

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -1347,7 +1347,7 @@ namespace WinFormsApp2
                 {
                     using var dsConn = new MySqlConnection(DatabaseConfig.ConnectionString);
                     dsConn.Open();
-                    using var dsCmd = new MySqlCommand("UPDATE dark_spire_state SET current_min = current_min + 5, current_max = current_max + 5 WHERE account_id=@id", dsConn);
+                    using var dsCmd = new MySqlCommand("UPDATE dark_spire_state SET current_min_power = current_min_power + 5, current_max_power = current_max_power + 5 WHERE account_id=@id", dsConn);
                     dsCmd.Parameters.AddWithValue("@id", _userId);
                     dsCmd.ExecuteNonQuery();
                 }

--- a/WinFormsApp2/NavigationWindow.cs
+++ b/WinFormsApp2/NavigationWindow.cs
@@ -326,17 +326,17 @@ namespace WinFormsApp2
         {
             using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using var cmd = new MySqlCommand("SELECT current_min, current_max FROM dark_spire_state WHERE account_id=@id", conn);
+            using var cmd = new MySqlCommand("SELECT current_min_power, current_max_power FROM dark_spire_state WHERE account_id=@id", conn);
             cmd.Parameters.AddWithValue("@id", _accountId);
             using var reader = cmd.ExecuteReader();
             if (reader.Read())
             {
-                int min = reader.GetInt32("current_min");
-                int max = reader.GetInt32("current_max");
+                int min = reader.GetInt32("current_min_power");
+                int max = reader.GetInt32("current_max_power");
                 return (min, max);
             }
             reader.Close();
-            using var ins = new MySqlCommand("INSERT INTO dark_spire_state(account_id, current_min, current_max) VALUES (@id, 1, 5)", conn);
+            using var ins = new MySqlCommand("INSERT INTO dark_spire_state(account_id, current_min_power, current_max_power) VALUES (@id, 1, 5)", conn);
             ins.Parameters.AddWithValue("@id", _accountId);
             ins.ExecuteNonQuery();
             return (1, 5);
@@ -346,7 +346,7 @@ namespace WinFormsApp2
         {
             using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using var cmd = new MySqlCommand("UPDATE dark_spire_state SET current_min=1, current_max=5 WHERE account_id=@id", conn);
+            using var cmd = new MySqlCommand("UPDATE dark_spire_state SET current_min_power=1, current_max_power=5 WHERE account_id=@id", conn);
             cmd.Parameters.AddWithValue("@id", _accountId);
             cmd.ExecuteNonQuery();
         }

--- a/update_dark_spire_power.sql
+++ b/update_dark_spire_power.sql
@@ -1,0 +1,14 @@
+-- Adds power tracking columns for Dark Spire progression and migrates data.
+ALTER TABLE dark_spire_state
+    ADD COLUMN current_min_power INT NOT NULL DEFAULT 1,
+    ADD COLUMN current_max_power INT NOT NULL DEFAULT 5;
+
+-- Migrate existing min/max level data to new power columns.
+UPDATE dark_spire_state
+    SET current_min_power = current_min,
+        current_max_power = current_max;
+
+-- Remove old level columns.
+ALTER TABLE dark_spire_state
+    DROP COLUMN current_min,
+    DROP COLUMN current_max;


### PR DESCRIPTION
## Summary
- add migration to store Dark Spire progress in `current_min_power` and `current_max_power`
- adjust NavigationWindow to use new power-based columns
- update BattleForm to advance Dark Spire power after battles

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b680151084833395402319d3df191c