### PR TITLE
Handle empty NPC list in loot generation

### DIFF
--- a/WinFormsApp2/LootService.cs
+++ b/WinFormsApp2/LootService.cs
@@ -13,9 +13,16 @@ namespace WinFormsApp2
         public static Dictionary<string, int> GenerateLoot(IEnumerable<(string name, int level)> npcs, int userId, string? areaId = null)
         {
             var drops = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            var npcList = npcs.ToList();
+            if (npcList.Count == 0)
+            {
+                return drops;
+            }
+
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            foreach (var npc in npcs)
+            foreach (var npc in npcList)
             {
                 using MySqlCommand cmd = new MySqlCommand("SELECT item_name, drop_chance, min_quantity, max_quantity FROM npc_loot WHERE npc_name=@name", conn);
                 cmd.Parameters.AddWithValue("@name", npc.name);
@@ -33,7 +40,7 @@ namespace WinFormsApp2
                     }
                 }
             }
-            int avgLevel = Math.Max(1, (int)Math.Round(npcs.Average(n => n.level)));
+            int avgLevel = Math.Max(1, (int)Math.Round(npcList.Average(n => n.level)));
             if (drops.TryGetValue("gold", out int gold))
             {
                 int boostedGold = (int)Math.Round(gold * 1.5);


### PR DESCRIPTION
## Summary
- avoid averaging over empty NPC collections in loot generation

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj`
- `dotnet build WinFormsApp2/BattleLands.csproj -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b68047a1b88333b516d4d69c93b023