### PR TITLE
Replace enemy level ranges with power

### DIFF
--- a/WinFormsApp2/NavigationWindow.cs
+++ b/WinFormsApp2/NavigationWindow.cs
@@ -104,7 +104,7 @@ namespace WinFormsApp2
             btnShop.Enabled = activities.Any(a => a.StartsWith("Shop"));
             btnGraveyard.Enabled = activities.Any(a => a.StartsWith("Graveyard"));
             btnTavern.Enabled = activities.Any(a => a.Contains("Tavern"));
-            btnFindEnemies.Enabled = node.MinEnemyLevel.HasValue;
+            btnFindEnemies.Enabled = node.MinEnemyPower.HasValue;
             btnFindEnemies.Text = "Search for Enemies";
             if (id == "nodeDarkSpire")
             {
@@ -131,9 +131,9 @@ namespace WinFormsApp2
             knownEnemyList.Items.Clear();
             enemyInfo.Clear();
             var node = WorldMapService.GetNode(_currentNode);
-            if (!node.MinEnemyLevel.HasValue) return;
-            int min = node.MinEnemyLevel.Value;
-            int max = node.MaxEnemyLevel ?? int.MaxValue;
+            if (!node.MinEnemyPower.HasValue) return;
+            int min = node.MinEnemyPower.Value;
+            int max = node.MaxEnemyPower ?? int.MaxValue;
             if (_currentNode == "nodeDarkSpire")
             {
                 (min, max) = GetDarkSpireBracket();
@@ -260,8 +260,8 @@ namespace WinFormsApp2
         private void BtnFindEnemies_Click(object? sender, EventArgs e)
         {
             var node = WorldMapService.GetNode(_currentNode);
-            int? min = node.MinEnemyLevel;
-            int? max = node.MaxEnemyLevel;
+            int? min = node.MinEnemyPower;
+            int? max = node.MaxEnemyPower;
             bool darkSpire = _currentNode == "nodeDarkSpire";
             if (darkSpire)
             {

--- a/WinFormsApp2/PowerCalculator.cs
+++ b/WinFormsApp2/PowerCalculator.cs
@@ -1,0 +1,38 @@
+using System;
+using MySql.Data.MySqlClient;
+
+namespace WinFormsApp2
+{
+    public static class PowerCalculator
+    {
+        public static int CalculateNpcPower(MySqlConnection conn, string npcName, int level)
+        {
+            int equipCost = 0;
+            using (var eqCmd = new MySqlCommand("SELECT item_name FROM npc_equipment WHERE npc_name=@n", conn))
+            {
+                eqCmd.Parameters.AddWithValue("@n", npcName);
+                using var er = eqCmd.ExecuteReader();
+                while (er.Read())
+                {
+                    var item = InventoryService.CreateItem(er.GetString("item_name"));
+                    if (item != null)
+                        equipCost += item.Price;
+                }
+            }
+
+            int abilityCount;
+            using (var abilCmd = new MySqlCommand("SELECT COUNT(*) FROM npc_abilities WHERE npc_name=@n", conn))
+            {
+                abilCmd.Parameters.AddWithValue("@n", npcName);
+                abilityCount = Convert.ToInt32(abilCmd.ExecuteScalar() ?? 0);
+            }
+
+            return CalculatePower(level, equipCost, abilityCount);
+        }
+
+        public static int CalculatePower(int level, int equipmentCost, int abilityCount)
+        {
+            return (int)Math.Ceiling((level + equipmentCost + 3 * abilityCount) * 0.15);
+        }
+    }
+}

--- a/WinFormsApp2/WorldMapNode.cs
+++ b/WinFormsApp2/WorldMapNode.cs
@@ -11,17 +11,17 @@ namespace WinFormsApp2
     {
         public string Id { get; }
         public string Name { get; }
-        public string Description { get; }
+        public string Description { get; set; }
         public Dictionary<string, int> Connections { get; } = new();
         public List<string> Activities { get; } = new();
         /// <summary>
-        /// Minimum level of enemies encountered at this node, if any.
+        /// Minimum power of enemies encountered at this node, if any.
         /// </summary>
-        public int? MinEnemyLevel { get; set; }
+        public int? MinEnemyPower { get; set; }
         /// <summary>
-        /// Maximum level of enemies encountered at this node, if any.
+        /// Maximum power of enemies encountered at this node, if any.
         /// </summary>
-        public int? MaxEnemyLevel { get; set; }
+        public int? MaxEnemyPower { get; set; }
 
         public WorldMapNode(string id, string name, string description = "")
         {

--- a/WinFormsApp2/WorldMapService.cs
+++ b/WinFormsApp2/WorldMapService.cs
@@ -1,5 +1,6 @@
+using System;
 using System.Collections.Generic;
-using System.Linq;
+using MySql.Data.MySqlClient;
 
 namespace WinFormsApp2
 {
@@ -16,20 +17,11 @@ namespace WinFormsApp2
         {
             Nodes = new Dictionary<string, WorldMapNode>();
 
-            var nodeMountain = new WorldMapNode("nodeMountain", "Mountain", "Towering peaks home to dangerous beasts. Enemies around Lv10-20.")
-            {
-                MinEnemyLevel = 10,
-                MaxEnemyLevel = 20
-            };
+            var nodeMountain = new WorldMapNode("nodeMountain", "Mountain", "Towering peaks home to dangerous beasts.");
             nodeMountain.Connections["nodeMounttown"] = 2;
-            nodeMountain.Activities.Add("Search for enemies (Lv10-20)");
             Nodes[nodeMountain.Id] = nodeMountain;
 
-            var nodeMounttown = new WorldMapNode("nodeMounttown", "Mounttown", "A bustling town carved into the mountainside. Generally safe from wild enemies.")
-            {
-                MinEnemyLevel = 5,
-                MaxEnemyLevel = 15
-            };
+            var nodeMounttown = new WorldMapNode("nodeMounttown", "Mounttown", "A bustling town carved into the mountainside. Generally safe from wild enemies.");
             nodeMounttown.Connections["nodeMountain"] = 2;
             nodeMounttown.Connections["nodeDarkSpire"] = 1;
             nodeMounttown.Connections["nodeRiverVillage"] = 3;
@@ -37,45 +29,29 @@ namespace WinFormsApp2
             nodeMounttown.Activities.Add("Temple (30 min +10% HP buff)");
             nodeMounttown.Activities.Add("Graveyard (resurrect screen)");
             nodeMounttown.Activities.Add("Tavern (recruit Lv5 adventurers w/2 random passives)");
-            nodeMounttown.Activities.Add("Search for enemies (Lv5-15)");
             Nodes[nodeMounttown.Id] = nodeMounttown;
 
-            var nodeDarkSpire = new WorldMapNode("nodeDarkSpire", "Dark Spire", "An ominous tower shrouded in eternal twilight. Foes start around Lv1-5 and grow stronger each floor.")
-            {
-                MinEnemyLevel = 1,
-                MaxEnemyLevel = 999
-            };
+            var nodeDarkSpire = new WorldMapNode("nodeDarkSpire", "Dark Spire", "An ominous tower shrouded in eternal twilight. Foes grow stronger each floor.");
             nodeDarkSpire.Connections["nodeMounttown"] = 1;
             nodeDarkSpire.Connections["nodeRiverVillage"] = 3;
             nodeDarkSpire.Connections["nodeForestValley"] = 3;
-            nodeDarkSpire.Activities.Add("Search for enemies (Lv1-5, +5 Lv per win)");
             nodeDarkSpire.Activities.Add("Track floors cleared and reward bonus (15-20% for Lv15-20 floor)");
             Nodes[nodeDarkSpire.Id] = nodeDarkSpire;
 
-            var nodeNorthernIsland = new WorldMapNode("nodeNorthernIsland", "Northern Island", "A remote island swept by cold winds. Home to formidable Lv25-35 foes.")
-            {
-                MinEnemyLevel = 25,
-                MaxEnemyLevel = 35
-            };
+            var nodeNorthernIsland = new WorldMapNode("nodeNorthernIsland", "Northern Island", "A remote island swept by cold winds.");
             nodeNorthernIsland.Connections["nodeDarkSpire"] = 3;
             nodeNorthernIsland.Connections["nodeForestValley"] = 4;
             nodeNorthernIsland.Activities.Add("Ancient Stone of Regret (reset stats to 5 for 150% hire value cost)");
-            nodeNorthernIsland.Activities.Add("Search for enemies (Lv25-35)");
             Nodes[nodeNorthernIsland.Id] = nodeNorthernIsland;
 
-            var nodeSouthernIsland = new WorldMapNode("nodeSouthernIsland", "Southern Island", "A tropical island dotted with fishing huts. Dangerous foes roam at Lv45-50.")
-            {
-                MinEnemyLevel = 45,
-                MaxEnemyLevel = 50
-            };
+            var nodeSouthernIsland = new WorldMapNode("nodeSouthernIsland", "Southern Island", "A tropical island dotted with fishing huts.");
             nodeSouthernIsland.Connections["nodeSmallVillage"] = 10;
             nodeSouthernIsland.Activities.Add("Fisherman work: assign party member for N minutes → earns 5 gp/min");
             nodeSouthernIsland.Activities.Add("Tavern: hire hostile NPC mercenaries (no exp/level/equipment/resurrection)");
             nodeSouthernIsland.Activities.Add("Temple: blessing that reduces travel ≥2 days by 1 day");
-            nodeSouthernIsland.Activities.Add("Search for enemies (Lv45-50)");
             Nodes[nodeSouthernIsland.Id] = nodeSouthernIsland;
 
-            var nodeRiverVillage = new WorldMapNode("nodeRiverVillage", "River Village", "A prosperous settlement along winding rivers. Nearby foes span a wide range of levels.");
+            var nodeRiverVillage = new WorldMapNode("nodeRiverVillage", "River Village", "A prosperous settlement along winding rivers.");
             nodeRiverVillage.Connections["nodeSmallVillage"] = 1;
             nodeRiverVillage.Connections["nodeDarkSpire"] = 3;
             nodeRiverVillage.Connections["nodeMounttown"] = 3;
@@ -87,64 +63,82 @@ namespace WinFormsApp2
             nodeRiverVillage.Activities.Add("Wizard Tower: teleport to any node for cost");
             Nodes[nodeRiverVillage.Id] = nodeRiverVillage;
 
-            var nodeSmallVillage = new WorldMapNode("nodeSmallVillage", "Small Village", "A quaint village surrounded by whispering woods. Local enemies range from Lv1-10.")
-            {
-                MinEnemyLevel = 1,
-                MaxEnemyLevel = 10
-            };
+            var nodeSmallVillage = new WorldMapNode("nodeSmallVillage", "Small Village", "A quaint village surrounded by whispering woods.");
             nodeSmallVillage.Connections["nodeSouthernIsland"] = 10;
             nodeSmallVillage.Connections["nodeRiverVillage"] = 1;
             nodeSmallVillage.Activities.Add("Shop");
             nodeSmallVillage.Activities.Add("Tavern (recruit DEX specialists)");
-            nodeSmallVillage.Activities.Add("Search for enemies (Lv1-10)");
             Nodes[nodeSmallVillage.Id] = nodeSmallVillage;
 
-            var nodeDesert = new WorldMapNode("nodeDesert", "Desert", "An endless expanse of scorching sands. Enemies range around Lv20-45.")
-            {
-                MinEnemyLevel = 20,
-                MaxEnemyLevel = 45
-            };
+            var nodeDesert = new WorldMapNode("nodeDesert", "Desert", "An endless expanse of scorching sands.");
             nodeDesert.Connections["nodeForestValley"] = 4;
             nodeDesert.Connections["nodeFarCliffs"] = 5;
             nodeDesert.Connections["nodeForestPlains"] = 5;
             nodeDesert.Activities.Add("Wander the desert: spend 1 day, chance to encounter Lv45 giant worm raid boss");
-            nodeDesert.Activities.Add("Search for enemies (Lv20-45)");
             Nodes[nodeDesert.Id] = nodeDesert;
 
-            var nodeForestValley = new WorldMapNode("nodeForestValley", "Forest Valley", "A lush valley teeming with hidden wildlife. Expect enemies around Lv5-15.")
-            {
-                MinEnemyLevel = 5,
-                MaxEnemyLevel = 15
-            };
+            var nodeForestValley = new WorldMapNode("nodeForestValley", "Forest Valley", "A lush valley teeming with hidden wildlife.");
             nodeForestValley.Connections["nodeDarkSpire"] = 3;
             nodeForestValley.Connections["nodeRiverVillage"] = 4;
             nodeForestValley.Connections["nodeForestPlains"] = 3;
             nodeForestValley.Connections["nodeDesert"] = 4;
-            nodeForestValley.Activities.Add("Search for enemies (Lv5-15)");
             Nodes[nodeForestValley.Id] = nodeForestValley;
 
-            var nodeForestPlains = new WorldMapNode("nodeForestPlains", "Forest Plains", "Open plains where the forest meets the sky. Enemies generally Lv15-25.")
-            {
-                MinEnemyLevel = 15,
-                MaxEnemyLevel = 25
-            };
+            var nodeForestPlains = new WorldMapNode("nodeForestPlains", "Forest Plains", "Open plains where the forest meets the sky.");
             nodeForestPlains.Connections["nodeFarCliffs"] = 1;
             nodeForestPlains.Connections["nodeDesert"] = 5;
             nodeForestPlains.Connections["nodeForestValley"] = 3;
             nodeForestPlains.Activities.Add("Commune with nature (receive raid-boss quest)");
-            nodeForestPlains.Activities.Add("Search for enemies (Lv15-25)");
             Nodes[nodeForestPlains.Id] = nodeForestPlains;
 
-            var nodeFarCliffs = new WorldMapNode("nodeFarCliffs", "Far Cliffs", "Sheer cliffs that overlook the restless sea. Local foes range around Lv30-40.")
-            {
-                MinEnemyLevel = 30,
-                MaxEnemyLevel = 40
-            };
+            var nodeFarCliffs = new WorldMapNode("nodeFarCliffs", "Far Cliffs", "Sheer cliffs that overlook the restless sea.");
             nodeFarCliffs.Connections["nodeForestPlains"] = 1;
             nodeFarCliffs.Connections["nodeDesert"] = 5;
             nodeFarCliffs.Activities.Add("Ancient Altar: does nothing unless holding 'Orb of Unknowable Evil'");
-            nodeFarCliffs.Activities.Add("Search for enemies (Lv30-40)");
             Nodes[nodeFarCliffs.Id] = nodeFarCliffs;
+
+            PopulateEnemyPowers();
+        }
+
+        private static void PopulateEnemyPowers()
+        {
+            try
+            {
+                using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+                conn.Open();
+                foreach (var node in Nodes.Values)
+                {
+                    var npcs = new List<(string name, int level)>();
+                    using (var cmd = new MySqlCommand("SELECT n.name, n.level FROM npcs n JOIN npc_locations l ON n.name=l.npc_name WHERE l.node_id=@id", conn))
+                    {
+                        cmd.Parameters.AddWithValue("@id", node.Id);
+                        using var reader = cmd.ExecuteReader();
+                        while (reader.Read())
+                        {
+                            npcs.Add((reader.GetString("name"), reader.GetInt32("level")));
+                        }
+                    }
+
+                    int strongest = 0;
+                    foreach (var (name, level) in npcs)
+                    {
+                        int power = PowerCalculator.CalculateNpcPower(conn, name, level);
+                        if (power > strongest) strongest = power;
+                    }
+
+                    if (strongest > 0)
+                    {
+                        node.MinEnemyPower = strongest;
+                        node.MaxEnemyPower = strongest * 4;
+                        node.Description = $"{node.Description} Party Power {node.MinEnemyPower}-{node.MaxEnemyPower}.";
+                        node.Activities.Add($"Search for enemies (Party Power {node.MinEnemyPower}-{node.MaxEnemyPower})");
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // If the database is unavailable, nodes simply lack enemy power data.
+            }
         }
 
         public static WorldMapNode GetNode(string id) => Nodes[id];

--- a/npc_locations.sql
+++ b/npc_locations.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS npc_locations (
+    npc_name VARCHAR(255) NOT NULL,
+    node_id VARCHAR(50) NOT NULL,
+    PRIMARY KEY (npc_name, node_id),
+    FOREIGN KEY (npc_name) REFERENCES npcs(name),
+    FOREIGN KEY (node_id) REFERENCES nodes(id)
+);


### PR DESCRIPTION
## Summary
- replace level range properties with enemy power
- dynamically compute world map enemy power from NPC data
- add PowerCalculator and NPC location schema

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68b6801131a08333bfdbfd5f50ee5738