### PR TITLE
Dispose party panel controls to prevent handle leak

### DIFF
--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
 using System.Drawing;
+using System.Linq;
 using MySql.Data.MySqlClient;
 using WinFormsApp2.Multiplayer;
 
@@ -55,6 +56,10 @@ namespace WinFormsApp2
             using MySqlDataReader reader = cmd.ExecuteReader();
             lstParty.Items.Clear();
             pnlParty.SuspendLayout();
+            foreach (Control c in pnlParty.Controls.Cast<Control>().ToArray())
+            {
+                c.Dispose();
+            }
             pnlParty.Controls.Clear();
             int totalExp = 0;
             int totalLevel = 0;


### PR DESCRIPTION
## Summary
- Dispose party panel controls before clearing to avoid exhausting window handles during repeated party reloads
- Import `System.Linq` to enable control collection enumeration

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: The imported project `Microsoft.NET.Sdk.WindowsDesktop.targets` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b68134cb688333a8010541538c5a79