### PR TITLE
Treat low power parties as max and boost enemy damage

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -148,16 +148,15 @@ namespace WinFormsApp2
             int areaMin = _areaMinPower ?? 1;
             int areaMax = _areaMaxPower ?? int.MaxValue;
 
-            int minTotal = (int)Math.Ceiling(playerPower * 0.8);
-            int maxTotal = _wildEncounter ? (int)Math.Ceiling(playerPower * 1.0)
-                                          : (int)Math.Ceiling(playerPower * 1.2);
-            if (playerPower < areaMin)
-            {
-                int tough = (int)Math.Ceiling(areaMin * 1.2);
-                minTotal = maxTotal = tough;
-            }
+            int effectivePlayerPower = playerPower;
+            if (playerPower < areaMin && _areaMaxPower.HasValue)
+                effectivePlayerPower = areaMax;
 
-            int targetAvg = playerPower < areaMin ? areaMin : avgPower;
+            int minTotal = (int)Math.Ceiling(effectivePlayerPower * 0.8);
+            int maxTotal = _wildEncounter ? (int)Math.Ceiling(effectivePlayerPower * 1.0)
+                                          : (int)Math.Ceiling(effectivePlayerPower * 1.2);
+
+            int targetAvg = playerPower < areaMin && _areaMaxPower.HasValue ? areaMax : avgPower;
 
             // NPC party power ranges from roughly 60% to 100% of the party's average party power,
             // while still respecting any area power restrictions.

--- a/increase_enemy_damage.sql
+++ b/increase_enemy_damage.sql
@@ -1,0 +1,4 @@
+UPDATE npcs
+SET strength = CEIL(strength * 1.2),
+    dex = CEIL(dex * 1.2),
+    intelligence = CEIL(intelligence * 1.2);


### PR DESCRIPTION
## Summary
- Treat parties below an area's recommended power range as having max recommended power for encounter calculations
- Introduce SQL update to raise all enemy offensive stats by 20%

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b68596225883338412d093c4c24f23