### PR TITLE
Fix battle generation after merge

### DIFF
--- a/WinFormsApp2/WorldMapService.cs
+++ b/WinFormsApp2/WorldMapService.cs
@@ -78,7 +78,7 @@ namespace WinFormsApp2
             nodeSouthernIsland.Connections["nodeSmallVillage"] = 10;
             nodeSouthernIsland.Activities.Add("Fisherman work: assign party member for N minutes → earns 5 gp/min");
             nodeSouthernIsland.Activities.Add("Tavern: hire hostile NPC mercenaries (no exp/power/equipment/resurrection)");
-            nodeSouthernIsland.Activities.Add("Temple: blessing that reduces travel ≥2 days by 1
+            nodeSouthernIsland.Activities.Add("Temple: blessing that reduces travel ≥2 days by 1 day");
             nodeSouthernIsland.Activities.Add("Search for enemies (Party Power 45-50)");
             Nodes[nodeSouthernIsland.Id] = nodeSouthernIsland;
 


### PR DESCRIPTION
## Summary
- compute average player level and adjust NPC power ranges
- rebuild NPC creation logic and power calculation
- correct Southern Island activity text in world map

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*
- `dotnet build WinFormsApp2/BattleLands.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b68727f8a48333b1f4355b8242994a