### PR TITLE
Add manual power column for NPCs

### DIFF
--- a/add_npc_power_column.sql
+++ b/add_npc_power_column.sql
@@ -1,0 +1,20 @@
+-- Adds a power column to the npcs table for manual power assignment.
+USE accounts;
+
+ALTER TABLE npcs
+    ADD COLUMN power INT;
+
+DELIMITER $$
+CREATE TRIGGER before_insert_npcs_power
+BEFORE INSERT ON npcs
+FOR EACH ROW
+BEGIN
+    IF NEW.power IS NULL THEN
+        SET NEW.power = 75 * NEW.level;
+    END IF;
+END$$
+DELIMITER ;
+
+UPDATE npcs
+SET power = 75 * level
+WHERE power IS NULL;


### PR DESCRIPTION
## Summary
- allow manual power assignment for npcs with a default of 75 times their level
- populate existing npcs with default power values

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a1d888bc833398ce3bab8207769f