### PR TITLE
Use database power ratings for enemy teams

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -185,7 +185,9 @@ namespace WinFormsApp2
             {
                 for (int attempt = 0; attempt < 50; attempt++)
                 {
-                    using var npcCmd = new MySqlCommand("SELECT name, level, current_hp, max_hp, mana, strength, dex, intelligence, action_speed, melee_defense, magic_defense, role, targeting_style FROM npcs ORDER BY RAND() LIMIT 1", conn);
+                    using var npcCmd = new MySqlCommand("SELECT name, level, current_hp, max_hp, mana, strength, dex, intelligence, action_speed, melee_defense, magic_defense, role, targeting_style, power FROM npcs WHERE power BETWEEN @min AND @max ORDER BY RAND() LIMIT 1", conn);
+                    npcCmd.Parameters.AddWithValue("@min", minPower);
+                    npcCmd.Parameters.AddWithValue("@max", maxPower);
                     using var r2 = npcCmd.ExecuteReader();
                     if (!r2.Read())
                         return null;
@@ -203,6 +205,7 @@ namespace WinFormsApp2
                     int magicDef = r2.GetInt32("magic_defense");
                     string role = r2.GetString("role");
                     string style = r2.GetString("targeting_style");
+                    int power = r2.GetInt32("power");
                     r2.Close();
 
                     var npc = new Creature
@@ -249,10 +252,6 @@ namespace WinFormsApp2
                     if (!npc.Abilities.Any())
                         npc.Abilities.Add(new Ability { Id = 0, Name = "-basic attack-", Priority = 1, Cost = 0, Slot = 1 });
 
-                    int eqCostNpc = npc.Equipment.Values.Sum(i => i?.Price ?? 0);
-                    int power = PowerCalculator.CalculatePower(npc.Level, eqCostNpc, npc.Abilities.Count);
-                    if (power < minPower || power > maxPower)
-                        continue;
                     npc.Power = power;
                     _npcs.Add(npc);
                     npcPower += power;

--- a/WinFormsApp2/EnemyKnowledgeService.cs
+++ b/WinFormsApp2/EnemyKnowledgeService.cs
@@ -45,20 +45,17 @@ ON DUPLICATE KEY UPDATE kill_count = kill_count + 1", conn);
             var list = new List<EnemyInfo>();
             using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using (var cmd = new MySqlCommand("SELECT name, role, targeting_style FROM npcs", conn))
+            using (var cmd = new MySqlCommand("SELECT name, role, targeting_style, power FROM npcs WHERE power BETWEEN @min AND @max", conn))
             {
                 cmd.Parameters.AddWithValue("@min", minPower);
                 cmd.Parameters.AddWithValue("@max", maxPower);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
-                    string name = reader.GetString("name");
-                    int power = PowerCalculator.GetNpcPower(name);
-                    if (power < minPower || power > maxPower) continue;
                     var info = new EnemyInfo
                     {
-                        Name = name,
-                        Power = power,
+                        Name = reader.GetString("name"),
+                        Power = reader.GetInt32("power"),
                         Role = reader.GetString("role"),
                         TargetingStyle = reader.GetString("targeting_style")
                     };

--- a/WinFormsApp2/PowerCalculator.cs
+++ b/WinFormsApp2/PowerCalculator.cs
@@ -7,32 +7,6 @@ namespace WinFormsApp2
     {
 
 
-        public static int CalculateNpcPower(MySqlConnection conn, string npcName, int level)
-        {
-            int equipCost = 0;
-            using (var eqCmd = new MySqlCommand("SELECT item_name FROM npc_equipment WHERE npc_name=@n", conn))
-            {
-                eqCmd.Parameters.AddWithValue("@n", npcName);
-                using var er = eqCmd.ExecuteReader();
-                while (er.Read())
-                {
-                    var item = InventoryService.CreateItem(er.GetString("item_name"));
-                    if (item != null)
-                        equipCost += item.Price;
-                }
-            }
-
-            int abilityCount;
-
-            using (var abilCmd = new MySqlCommand("SELECT COUNT(*) FROM npc_abilities WHERE npc_name=@n", conn))
-            {
-                abilCmd.Parameters.AddWithValue("@n", npcName);
-                abilityCount = Convert.ToInt32(abilCmd.ExecuteScalar() ?? 0);
-            }
-
-            return CalculatePower(level, equipCost, abilityCount);
-        }
-
         public static int CalculatePower(int level, int equipmentCost, int abilityCount)
         {
             return (int)Math.Ceiling((level + equipmentCost + 3 * abilityCount) * 0.15);
@@ -48,14 +22,10 @@ namespace WinFormsApp2
         {
             using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            int level;
-            using (var cmd = new MySqlCommand("SELECT level FROM npcs WHERE name=@n", conn))
-            {
-                cmd.Parameters.AddWithValue("@n", npcName);
-                object? result = cmd.ExecuteScalar();
-                level = result == null ? 0 : Convert.ToInt32(result);
-            }
-            return CalculateNpcPower(conn, npcName, level);
+            using var cmd = new MySqlCommand("SELECT power FROM npcs WHERE name=@n", conn);
+            cmd.Parameters.AddWithValue("@n", npcName);
+            object? result = cmd.ExecuteScalar();
+            return result == null ? 0 : Convert.ToInt32(result);
         }
     }
 }

--- a/WinFormsApp2/WorldMapService.cs
+++ b/WinFormsApp2/WorldMapService.cs
@@ -173,22 +173,16 @@ namespace WinFormsApp2
                 conn.Open();
                 foreach (var node in Nodes.Values)
                 {
-                    var npcs = new List<(string name, int level)>();
-                    using (var cmd = new MySqlCommand("SELECT n.name, n.level FROM npcs n JOIN npc_locations l ON n.name=l.npc_name WHERE l.node_id=@id", conn))
+                    int strongest = 0;
+                    using (var cmd = new MySqlCommand("SELECT n.power FROM npcs n JOIN npc_locations l ON n.name=l.npc_name WHERE l.node_id=@id", conn))
                     {
                         cmd.Parameters.AddWithValue("@id", node.Id);
                         using var reader = cmd.ExecuteReader();
                         while (reader.Read())
                         {
-                            npcs.Add((reader.GetString("name"), reader.GetInt32("level")));
+                            int power = reader.GetInt32("power");
+                            if (power > strongest) strongest = power;
                         }
-                    }
-
-                    int strongest = 0;
-                    foreach (var (name, level) in npcs)
-                    {
-                        int power = PowerCalculator.CalculateNpcPower(conn, name, level);
-                        if (power > strongest) strongest = power;
                     }
 
                     if (strongest > 0)


### PR DESCRIPTION
## Summary
- pull NPC power directly from the database when assembling enemy teams instead of calculating values
- query stored enemy power for world map nodes and enemy knowledge listings
- simplify power calculator to read NPC power from the `npcs` table

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b86b36b4833399e236c3e4e56091