### PR TITLE
Reset npc power column before re-adding

### DIFF
--- a/reset_npc_power_column.sql
+++ b/reset_npc_power_column.sql
@@ -1,0 +1,25 @@
+-- Removes and re-adds the power column on the npcs table to avoid duplicate column errors.
+USE accounts;
+
+ALTER TABLE npcs
+    DROP COLUMN IF EXISTS power;
+
+DROP TRIGGER IF EXISTS before_insert_npcs_power;
+
+ALTER TABLE npcs
+    ADD COLUMN power INT;
+
+DELIMITER $$
+CREATE TRIGGER before_insert_npcs_power
+BEFORE INSERT ON npcs
+FOR EACH ROW
+BEGIN
+    IF NEW.power IS NULL THEN
+        SET NEW.power = 75 * NEW.level;
+    END IF;
+END$$
+DELIMITER ;
+
+UPDATE npcs
+SET power = 75 * level
+WHERE power IS NULL;


### PR DESCRIPTION
## Summary
- Add SQL script to drop and recreate the `power` column on the `npcs` table, removing the trigger and reapplying it to avoid duplicate column errors

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b3bb34c8833389c038955a18460d