### PR TITLE
Generate enemy groups using party power and level ranges

### DIFF
--- a/WinFormsApp2/EnemyKnowledgeService.cs
+++ b/WinFormsApp2/EnemyKnowledgeService.cs
@@ -40,15 +40,15 @@ ON DUPLICATE KEY UPDATE kill_count = kill_count + 1", conn);
             return result == null ? 0 : System.Convert.ToInt32(result);
         }
 
-        public static List<EnemyInfo> GetEnemiesForArea(int minPower, int maxPower)
+        public static List<EnemyInfo> GetEnemiesForArea(int minLevel, int maxLevel)
         {
             var list = new List<EnemyInfo>();
             using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using (var cmd = new MySqlCommand("SELECT name, role, targeting_style, power FROM npcs WHERE power BETWEEN @min AND @max", conn))
+            using (var cmd = new MySqlCommand("SELECT name, role, targeting_style, power FROM npcs WHERE level BETWEEN @min AND @max", conn))
             {
-                cmd.Parameters.AddWithValue("@min", minPower);
-                cmd.Parameters.AddWithValue("@max", maxPower);
+                cmd.Parameters.AddWithValue("@min", minLevel);
+                cmd.Parameters.AddWithValue("@max", maxLevel);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {

--- a/WinFormsApp2/NavigationWindow.cs
+++ b/WinFormsApp2/NavigationWindow.cs
@@ -104,7 +104,7 @@ namespace WinFormsApp2
             btnShop.Enabled = activities.Any(a => a.StartsWith("Shop"));
             btnGraveyard.Enabled = activities.Any(a => a.StartsWith("Graveyard"));
             btnTavern.Enabled = activities.Any(a => a.Contains("Tavern"));
-            btnFindEnemies.Enabled = node.MinEnemyPower.HasValue;
+            btnFindEnemies.Enabled = node.MinEnemyLevel.HasValue;
             btnFindEnemies.Text = "Search for Enemies";
             if (id == "nodeDarkSpire")
             {
@@ -131,9 +131,9 @@ namespace WinFormsApp2
             knownEnemyList.Items.Clear();
             enemyInfo.Clear();
             var node = WorldMapService.GetNode(_currentNode);
-            if (!node.MinEnemyPower.HasValue) return;
-            int min = node.MinEnemyPower.Value;
-            int max = node.MaxEnemyPower ?? int.MaxValue;
+            if (!node.MinEnemyLevel.HasValue) return;
+            int min = node.MinEnemyLevel.Value;
+            int max = node.MaxEnemyLevel ?? int.MaxValue;
             if (_currentNode == "nodeDarkSpire")
             {
                 (min, max) = GetDarkSpireBracket();
@@ -260,14 +260,14 @@ namespace WinFormsApp2
         private void BtnFindEnemies_Click(object? sender, EventArgs e)
         {
             var node = WorldMapService.GetNode(_currentNode);
-            int? min = node.MinEnemyPower;
-            int? max = node.MaxEnemyPower;
+            int? min = node.MinEnemyLevel;
+            int? max = node.MaxEnemyLevel;
             bool darkSpire = _currentNode == "nodeDarkSpire";
             if (darkSpire)
             {
                 (min, max) = GetDarkSpireBracket();
             }
-            var battle = new BattleForm(_accountId, areaMinPower: min, areaMaxPower: max, darkSpireBattle: darkSpire, areaId: _currentNode);
+            var battle = new BattleForm(_accountId, areaMinLevel: min, areaMaxLevel: max, darkSpireBattle: darkSpire, areaId: _currentNode);
             if (sender is Button btn) btn.Enabled = false;
             battle.FormClosed += (_, __) =>
             {
@@ -355,13 +355,13 @@ namespace WinFormsApp2
         {
             lblTravelInfo.Text = "Ambushed by wild enemies!";
             var node = WorldMapService.GetNode(_currentNode);
-            int? min = node.MinEnemyPower;
-            int? max = node.MaxEnemyPower;
+            int? min = node.MinEnemyLevel;
+            int? max = node.MaxEnemyLevel;
             if (_currentNode == "nodeDarkSpire")
             {
                 (min, max) = GetDarkSpireBracket();
             }
-            var battle = new BattleForm(_accountId, true, areaMinPower: min, areaMaxPower: max, areaId: _currentNode);
+            var battle = new BattleForm(_accountId, true, areaMinLevel: min, areaMaxLevel: max, areaId: _currentNode);
             battle.FormClosed += (_, __) =>
             {
                 _refresh();

--- a/WinFormsApp2/WorldMapNode.cs
+++ b/WinFormsApp2/WorldMapNode.cs
@@ -15,11 +15,13 @@ namespace WinFormsApp2
         public Dictionary<string, int> Connections { get; } = new();
         public List<string> Activities { get; } = new();
         /// <summary>
+        /// Minimum level of enemies that can appear in this node.
         /// </summary>
-        public int? MinEnemyPower { get; set; }
+        public int? MinEnemyLevel { get; set; }
         /// <summary>
+        /// Maximum level of enemies that can appear in this node.
         /// </summary>
-        public int? MaxEnemyPower { get; set; }
+        public int? MaxEnemyLevel { get; set; }
 
         public WorldMapNode(string id, string name, string description = "")
         {

--- a/WinFormsApp2/WorldMapService.cs
+++ b/WinFormsApp2/WorldMapService.cs
@@ -17,21 +17,21 @@ namespace WinFormsApp2
         {
             Nodes = new Dictionary<string, WorldMapNode>();
 
-            var nodeMountain = new WorldMapNode("nodeMountain", "Mountain", "Towering peaks home to dangerous beasts. Enemies around party power 10-20.")
+            var nodeMountain = new WorldMapNode("nodeMountain", "Mountain", "Towering peaks home to dangerous beasts. Enemies around level 10-20.")
             {
-                MinEnemyPower = 10,
-                MaxEnemyPower = 20
+                MinEnemyLevel = 10,
+                MaxEnemyLevel = 20
             };
 
             nodeMountain.Connections["nodeMounttown"] = 2;
-            nodeMountain.Activities.Add("Search for enemies (Party Power 10-20)");
+            nodeMountain.Activities.Add("Search for enemies (Level 10-20)");
 
             Nodes[nodeMountain.Id] = nodeMountain;
 
             var nodeMounttown = new WorldMapNode("nodeMounttown", "Mounttown", "A bustling town carved into the mountainside. Generally safe from wild enemies.")
             {
-                MinEnemyPower = 5,
-                MaxEnemyPower = 15
+                MinEnemyLevel = 5,
+                MaxEnemyLevel = 15
             };
 
             nodeMounttown.Connections["nodeMountain"] = 2;
@@ -41,48 +41,48 @@ namespace WinFormsApp2
             nodeMounttown.Activities.Add("Temple (30 min +10% HP buff)");
             nodeMounttown.Activities.Add("Graveyard (resurrect screen)");
             nodeMounttown.Activities.Add("Tavern (recruit party power 5 adventurers w/2 random passives)");
-            nodeMounttown.Activities.Add("Search for enemies (Party Power 5-15)");
+            nodeMounttown.Activities.Add("Search for enemies (Level 5-15)");
             Nodes[nodeMounttown.Id] = nodeMounttown;
 
-            var nodeDarkSpire = new WorldMapNode("nodeDarkSpire", "Dark Spire", "An ominous tower shrouded in eternal twilight. Foes start around party power 1-5 and grow stronger each floor.")
+            var nodeDarkSpire = new WorldMapNode("nodeDarkSpire", "Dark Spire", "An ominous tower shrouded in eternal twilight. Foes start around level 1-5 and grow stronger each floor.")
             {
-                MinEnemyPower = 1,
-                MaxEnemyPower = 999
+                MinEnemyLevel = 1,
+                MaxEnemyLevel = 999
             };
 
             nodeDarkSpire.Connections["nodeMounttown"] = 1;
             nodeDarkSpire.Connections["nodeRiverVillage"] = 3;
             nodeDarkSpire.Connections["nodeForestValley"] = 3;
-            nodeDarkSpire.Activities.Add("Search for enemies (Party Power 1-5, +5 Power per win)");
+            nodeDarkSpire.Activities.Add("Search for enemies (Level 1-5, +5 Power per win)");
             nodeDarkSpire.Activities.Add("Track floors cleared and reward bonus (15-20% for party power 15-20 floor)");
             Nodes[nodeDarkSpire.Id] = nodeDarkSpire;
 
-            var nodeNorthernIsland = new WorldMapNode("nodeNorthernIsland", "Northern Island", "A remote island swept by cold winds. Home to formidable party power 25-35 foes.")
+            var nodeNorthernIsland = new WorldMapNode("nodeNorthernIsland", "Northern Island", "A remote island swept by cold winds. Home to formidable level 25-35 foes.")
             {
-                MinEnemyPower = 25,
-                MaxEnemyPower = 35
+                MinEnemyLevel = 25,
+                MaxEnemyLevel = 35
             };
 
             nodeNorthernIsland.Connections["nodeDarkSpire"] = 3;
             nodeNorthernIsland.Connections["nodeForestValley"] = 4;
             nodeNorthernIsland.Activities.Add("Ancient Stone of Regret (reset stats to 5 for 150% hire value cost)");
-            nodeNorthernIsland.Activities.Add("Search for enemies (Party Power 25-35)");
+            nodeNorthernIsland.Activities.Add("Search for enemies (Level 25-35)");
             Nodes[nodeNorthernIsland.Id] = nodeNorthernIsland;
 
-            var nodeSouthernIsland = new WorldMapNode("nodeSouthernIsland", "Southern Island", "A tropical island dotted with fishing huts. Dangerous foes roam at party power 45-50.")
+            var nodeSouthernIsland = new WorldMapNode("nodeSouthernIsland", "Southern Island", "A tropical island dotted with fishing huts. Dangerous foes roam at level 45-50.")
             {
-                MinEnemyPower = 45,
-                MaxEnemyPower = 50
+                MinEnemyLevel = 45,
+                MaxEnemyLevel = 50
             };
 
             nodeSouthernIsland.Connections["nodeSmallVillage"] = 10;
             nodeSouthernIsland.Activities.Add("Fisherman work: assign party member for N minutes → earns 5 gp/min");
             nodeSouthernIsland.Activities.Add("Tavern: hire hostile NPC mercenaries (no exp/power/equipment/resurrection)");
             nodeSouthernIsland.Activities.Add("Temple: blessing that reduces travel ≥2 days by 1 day");
-            nodeSouthernIsland.Activities.Add("Search for enemies (Party Power 45-50)");
+            nodeSouthernIsland.Activities.Add("Search for enemies (Level 45-50)");
             Nodes[nodeSouthernIsland.Id] = nodeSouthernIsland;
 
-            var nodeRiverVillage = new WorldMapNode("nodeRiverVillage", "River Village", "A prosperous settlement along winding rivers. Nearby foes span a wide range of party power.");
+            var nodeRiverVillage = new WorldMapNode("nodeRiverVillage", "River Village", "A prosperous settlement along winding rivers. Nearby foes span a wide range of levels.");
 
             nodeRiverVillage.Connections["nodeSmallVillage"] = 1;
             nodeRiverVillage.Connections["nodeDarkSpire"] = 3;
@@ -95,77 +95,77 @@ namespace WinFormsApp2
             nodeRiverVillage.Activities.Add("Wizard Tower: teleport to any node for cost");
             Nodes[nodeRiverVillage.Id] = nodeRiverVillage;
 
-            var nodeSmallVillage = new WorldMapNode("nodeSmallVillage", "Small Village", "A quaint village surrounded by whispering woods. Local enemies range from party power 1-10.")
+            var nodeSmallVillage = new WorldMapNode("nodeSmallVillage", "Small Village", "A quaint village surrounded by whispering woods. Local enemies range from level 1-10.")
             {
-                MinEnemyPower = 1,
-                MaxEnemyPower = 10
+                MinEnemyLevel = 1,
+                MaxEnemyLevel = 10
             };
 
             nodeSmallVillage.Connections["nodeSouthernIsland"] = 10;
             nodeSmallVillage.Connections["nodeRiverVillage"] = 1;
             nodeSmallVillage.Activities.Add("Shop");
             nodeSmallVillage.Activities.Add("Tavern (recruit DEX specialists)");
-            nodeSmallVillage.Activities.Add("Search for enemies (Party Power 1-10)");
+            nodeSmallVillage.Activities.Add("Search for enemies (Level 1-10)");
 
             Nodes[nodeSmallVillage.Id] = nodeSmallVillage;
 
-            var nodeDesert = new WorldMapNode("nodeDesert", "Desert", "An endless expanse of scorching sands. Enemies range around party power 20-45.")
+            var nodeDesert = new WorldMapNode("nodeDesert", "Desert", "An endless expanse of scorching sands. Enemies range around level 20-45.")
             {
-                MinEnemyPower = 20,
-                MaxEnemyPower = 45
+                MinEnemyLevel = 20,
+                MaxEnemyLevel = 45
             };
 
             nodeDesert.Connections["nodeForestValley"] = 4;
             nodeDesert.Connections["nodeFarCliffs"] = 5;
             nodeDesert.Connections["nodeForestPlains"] = 5;
             nodeDesert.Activities.Add("Wander the desert: spend 1 day, chance to encounter power 45 giant worm raid boss");
-            nodeDesert.Activities.Add("Search for enemies (Party Power 20-45)");
+            nodeDesert.Activities.Add("Search for enemies (Level 20-45)");
 
             Nodes[nodeDesert.Id] = nodeDesert;
 
-            var nodeForestValley = new WorldMapNode("nodeForestValley", "Forest Valley", "A lush valley teeming with hidden wildlife. Expect enemies around party power 5-15.")
+            var nodeForestValley = new WorldMapNode("nodeForestValley", "Forest Valley", "A lush valley teeming with hidden wildlife. Expect enemies around level 5-15.")
             {
-                MinEnemyPower = 5,
-                MaxEnemyPower = 15
+                MinEnemyLevel = 5,
+                MaxEnemyLevel = 15
             };
 
             nodeForestValley.Connections["nodeDarkSpire"] = 3;
             nodeForestValley.Connections["nodeRiverVillage"] = 4;
             nodeForestValley.Connections["nodeForestPlains"] = 3;
             nodeForestValley.Connections["nodeDesert"] = 4;
-            nodeForestValley.Activities.Add("Search for enemies (Party Power 5-15)");
+            nodeForestValley.Activities.Add("Search for enemies (Level 5-15)");
 
             Nodes[nodeForestValley.Id] = nodeForestValley;
 
-            var nodeForestPlains = new WorldMapNode("nodeForestPlains", "Forest Plains", "Open plains where the forest meets the sky. Enemies generally party power 15-25.")
+            var nodeForestPlains = new WorldMapNode("nodeForestPlains", "Forest Plains", "Open plains where the forest meets the sky. Enemies generally level 15-25.")
             {
-                MinEnemyPower = 15,
-                MaxEnemyPower = 25
+                MinEnemyLevel = 15,
+                MaxEnemyLevel = 25
             };
 
             nodeForestPlains.Connections["nodeFarCliffs"] = 1;
             nodeForestPlains.Connections["nodeDesert"] = 5;
             nodeForestPlains.Connections["nodeForestValley"] = 3;
             nodeForestPlains.Activities.Add("Commune with nature (receive raid-boss quest)");
-            nodeForestPlains.Activities.Add("Search for enemies (Party Power 15-25)");
+            nodeForestPlains.Activities.Add("Search for enemies (Level 15-25)");
             Nodes[nodeForestPlains.Id] = nodeForestPlains;
 
-            var nodeFarCliffs = new WorldMapNode("nodeFarCliffs", "Far Cliffs", "Sheer cliffs that overlook the restless sea. Local foes range around party power 30-40.")
+            var nodeFarCliffs = new WorldMapNode("nodeFarCliffs", "Far Cliffs", "Sheer cliffs that overlook the restless sea. Local foes range around level 30-40.")
             {
-                MinEnemyPower = 30,
-                MaxEnemyPower = 40
+                MinEnemyLevel = 30,
+                MaxEnemyLevel = 40
             };
 
             nodeFarCliffs.Connections["nodeForestPlains"] = 1;
             nodeFarCliffs.Connections["nodeDesert"] = 5;
             nodeFarCliffs.Activities.Add("Ancient Altar: does nothing unless holding 'Orb of Unknowable Evil'");
-            nodeFarCliffs.Activities.Add("Search for enemies (Party Power 30-40)");
+            nodeFarCliffs.Activities.Add("Search for enemies (Level 30-40)");
             Nodes[nodeFarCliffs.Id] = nodeFarCliffs;
 
-            PopulateEnemyPowers();
+            PopulateEnemyLevels();
         }
 
-        private static void PopulateEnemyPowers()
+        private static void PopulateEnemyLevels()
         {
             try
             {
@@ -173,30 +173,32 @@ namespace WinFormsApp2
                 conn.Open();
                 foreach (var node in Nodes.Values)
                 {
-                    int strongest = 0;
-                    using (var cmd = new MySqlCommand("SELECT n.power FROM npcs n JOIN npc_locations l ON n.name=l.npc_name WHERE l.node_id=@id", conn))
+                    int minLevel = int.MaxValue;
+                    int maxLevel = 0;
+                    using (var cmd = new MySqlCommand("SELECT n.level FROM npcs n JOIN npc_locations l ON n.name=l.npc_name WHERE l.node_id=@id", conn))
                     {
                         cmd.Parameters.AddWithValue("@id", node.Id);
                         using var reader = cmd.ExecuteReader();
                         while (reader.Read())
                         {
-                            int power = reader.GetInt32("power");
-                            if (power > strongest) strongest = power;
+                            int level = reader.GetInt32("level");
+                            if (level < minLevel) minLevel = level;
+                            if (level > maxLevel) maxLevel = level;
                         }
                     }
 
-                    if (strongest > 0)
+                    if (maxLevel > 0)
                     {
-                        node.MinEnemyPower = strongest;
-                        node.MaxEnemyPower = strongest * 4;
-                        node.Description = $"{node.Description} Party Power {node.MinEnemyPower}-{node.MaxEnemyPower}.";
-                        node.Activities.Add($"Search for enemies (Party Power {node.MinEnemyPower}-{node.MaxEnemyPower})");
+                        node.MinEnemyLevel = minLevel;
+                        node.MaxEnemyLevel = maxLevel;
+                        node.Description = $"{node.Description} Levels {node.MinEnemyLevel}-{node.MaxEnemyLevel}.";
+                        node.Activities.Add($"Search for enemies (Level {node.MinEnemyLevel}-{node.MaxEnemyLevel})");
                     }
                 }
             }
             catch (Exception)
             {
-                // If the database is unavailable, nodes simply lack enemy power data.
+                // If the database is unavailable, nodes simply lack enemy level data.
             }
         }
 


### PR DESCRIPTION
## Summary
- track enemy level ranges on world map nodes
- fetch enemy data by level and adjust navigation to pass level ranges
- generate enemy parties whose combined power approximates the player's party

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b79f0c568c8333bc3a2bfd3210139c