### PR TITLE
Fix NPC location queries to use id column

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -151,7 +151,7 @@ namespace WinFormsApp2
             var candidates = new List<(string Name, int Power, int Level)>();
             using (var listCmd = new MySqlCommand(@"SELECT n.name, n.power, n.level
                                                     FROM npcs n
-                                                    LEFT JOIN npc_locations l ON n.name = l.npc_name
+                                                    LEFT JOIN npc_locations l ON n.id = l.npc_id
                                                     WHERE n.level BETWEEN @min AND @max
                                                       AND (@area IS NULL OR l.node_id = @area)", conn))
             {

--- a/WinFormsApp2/WorldMapService.cs
+++ b/WinFormsApp2/WorldMapService.cs
@@ -175,7 +175,7 @@ namespace WinFormsApp2
                 {
                     int minLevel = int.MaxValue;
                     int maxLevel = 0;
-                    using (var cmd = new MySqlCommand("SELECT n.level FROM npcs n JOIN npc_locations l ON n.name=l.npc_name WHERE l.node_id=@id", conn))
+                    using (var cmd = new MySqlCommand("SELECT n.level FROM npcs n JOIN npc_locations l ON n.id=l.npc_id WHERE l.node_id=@id", conn))
                     {
                         cmd.Parameters.AddWithValue("@id", node.Id);
                         using var reader = cmd.ExecuteReader();


### PR DESCRIPTION
## Summary
- join npc_locations on npc_id rather than npc_name
- update world map service to fetch enemy levels using npc_id

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: error NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a1a6ee4c8333b2c133b6ff86e49d