### PR TITLE
Randomize additional enemy spawns

### DIFF
--- a/WinFormsApp2/BattleForm.cs
+++ b/WinFormsApp2/BattleForm.cs
@@ -217,6 +217,23 @@ namespace WinFormsApp2
                 return;
             }
 
+            // Randomly add up to 5 additional low-level enemies within 10 levels of the area's minimum
+            int additionalCount = _rng.Next(0, 6);
+            if (additionalCount > 0)
+            {
+                int additionalMaxLevel = Math.Min(maxLevel, minLevel + 10);
+                var extraCandidates = candidates
+                    .Where(c => c.Level >= minLevel && c.Level <= additionalMaxLevel && !selected.Any(s => s.Name == c.Name))
+                    .ToList();
+
+                for (int i = 0; i < additionalCount && extraCandidates.Count > 0; i++)
+                {
+                    var pick = extraCandidates[_rng.Next(extraCandidates.Count)];
+                    selected.Add(pick);
+                    extraCandidates.Remove(pick);
+                }
+            }
+
             foreach (var sel in selected)
             {
                 using var npcCmd = new MySqlCommand(@"SELECT n.name, n.level, n.current_hp, n.max_hp, n.mana, n.strength, n.dex,

--- a/additional_low_level_enemies.sql
+++ b/additional_low_level_enemies.sql
@@ -1,0 +1,7 @@
+-- Query to fetch additional enemies within 10 levels of the area's minimum level
+SELECT n.name, n.power, n.level
+FROM npcs n
+LEFT JOIN npc_locations l ON n.id = l.npc_id
+WHERE n.level BETWEEN @min AND @min + 10
+  AND (@area IS NULL OR l.node_id = @area)
+ORDER BY RAND();


### PR DESCRIPTION
## Summary
- Use RNG to add up to five extra enemies within ten levels of the area's minimum level.
- Document query for low-level enemy selection in a new SQL script.

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: NETSDK1100 To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true; NuGet.Config is not valid XML)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a77ac53c8333beeed19029dbc355