### PR TITLE
Add login scene and manager

### DIFF
--- a/New Unity Project/Assets/Scenes/Login/Login.unity
+++ b/New Unity Project/Assets/Scenes/Login/Login.unity
@@ -1,0 +1,51 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4}
+  - component: {fileID: 11400000}
+  m_Layer: 0
+  m_Name: LoginManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c5d195f8b7f795ff16ba1de95dba323c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  usernameField: {fileID: 0}
+  passwordField: {fileID: 0}
+  debugServerToggle: {fileID: 0}
+  kimServerToggle: {fileID: 0}
+  loginButton: {fileID: 0}
+  createAccountButton: {fileID: 0}

--- a/New Unity Project/Assets/Scenes/Login/Login.unity.meta
+++ b/New Unity Project/Assets/Scenes/Login/Login.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a8917ef87efd9b26172ed36b571c8877
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Scripts/LoginManager.cs
+++ b/New Unity Project/Assets/Scripts/LoginManager.cs
@@ -1,0 +1,205 @@
+using System.Security.Cryptography;
+using System.Text;
+using MySql.Data.MySqlClient;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+
+public class LoginManager : MonoBehaviour
+{
+    public InputField usernameField;
+    public InputField passwordField;
+    public Toggle debugServerToggle;
+    public Toggle kimServerToggle;
+    public Button loginButton;
+    public Button createAccountButton;
+
+    private void Start()
+    {
+        if (usernameField == null || passwordField == null ||
+            debugServerToggle == null || kimServerToggle == null ||
+            loginButton == null || createAccountButton == null)
+        {
+            CreateDefaultUI();
+        }
+
+        if (loginButton != null)
+            loginButton.onClick.AddListener(OnLoginClicked);
+        if (createAccountButton != null)
+            createAccountButton.onClick.AddListener(OnCreateAccountClicked);
+    }
+
+    private void CreateDefaultUI()
+    {
+        var canvasGO = new GameObject("Canvas", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+        var canvas = canvasGO.GetComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+
+        if (FindObjectOfType<EventSystem>() == null)
+        {
+            new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
+        }
+
+        usernameField = CreateInputField(canvas.transform, "Username", new Vector2(0, 60));
+        passwordField = CreateInputField(canvas.transform, "Password", new Vector2(0, 0));
+        debugServerToggle = CreateToggle(canvas.transform, "Debug Server", new Vector2(-80, -60));
+        kimServerToggle = CreateToggle(canvas.transform, "Kim Server", new Vector2(80, -60));
+        loginButton = CreateButton(canvas.transform, "Login", new Vector2(-60, -120));
+        createAccountButton = CreateButton(canvas.transform, "Create Account", new Vector2(60, -120));
+    }
+
+    private InputField CreateInputField(Transform parent, string placeholder, Vector2 position)
+    {
+        var go = new GameObject(placeholder + "Input", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(InputField));
+        var rt = go.GetComponent<RectTransform>();
+        rt.SetParent(parent);
+        rt.sizeDelta = new Vector2(160, 30);
+        rt.anchoredPosition = position;
+
+        var textGO = new GameObject("Text", typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
+        var textRT = textGO.GetComponent<RectTransform>();
+        textRT.SetParent(go.transform);
+        textRT.anchorMin = new Vector2(0, 0);
+        textRT.anchorMax = new Vector2(1, 1);
+        textRT.offsetMin = Vector2.zero;
+        textRT.offsetMax = Vector2.zero;
+        var text = textGO.GetComponent<Text>();
+        text.text = "";
+        text.color = Color.black;
+
+        var placeholderGO = new GameObject("Placeholder", typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
+        var placeholderRT = placeholderGO.GetComponent<RectTransform>();
+        placeholderRT.SetParent(go.transform);
+        placeholderRT.anchorMin = new Vector2(0, 0);
+        placeholderRT.anchorMax = new Vector2(1, 1);
+        placeholderRT.offsetMin = Vector2.zero;
+        placeholderRT.offsetMax = Vector2.zero;
+        var placeholderText = placeholderGO.GetComponent<Text>();
+        placeholderText.text = placeholder;
+        placeholderText.color = new Color(0.5f, 0.5f, 0.5f);
+
+        var input = go.GetComponent<InputField>();
+        input.textComponent = text;
+        input.placeholder = placeholderText;
+        return input;
+    }
+
+    private Toggle CreateToggle(Transform parent, string label, Vector2 position)
+    {
+        var go = new GameObject(label + "Toggle", typeof(RectTransform), typeof(CanvasRenderer), typeof(Toggle));
+        var rt = go.GetComponent<RectTransform>();
+        rt.SetParent(parent);
+        rt.sizeDelta = new Vector2(160, 20);
+        rt.anchoredPosition = position;
+
+        var bg = new GameObject("Background", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+        var bgRT = bg.GetComponent<RectTransform>();
+        bgRT.SetParent(go.transform);
+        bgRT.sizeDelta = new Vector2(20, 20);
+        bgRT.anchoredPosition = new Vector2(-70, 0);
+        var checkmark = new GameObject("Checkmark", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+        var cmRT = checkmark.GetComponent<RectTransform>();
+        cmRT.SetParent(bg.transform);
+        cmRT.sizeDelta = new Vector2(20, 20);
+
+        var textGO = new GameObject("Label", typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
+        var textRT = textGO.GetComponent<RectTransform>();
+        textRT.SetParent(go.transform);
+        textRT.anchoredPosition = new Vector2(10, 0);
+        var text = textGO.GetComponent<Text>();
+        text.text = label;
+        text.color = Color.black;
+
+        var toggle = go.GetComponent<Toggle>();
+        toggle.graphic = checkmark.GetComponent<Image>();
+        toggle.targetGraphic = bg.GetComponent<Image>();
+        return toggle;
+    }
+
+    private Button CreateButton(Transform parent, string label, Vector2 position)
+    {
+        var go = new GameObject(label + "Button", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button));
+        var rt = go.GetComponent<RectTransform>();
+        rt.SetParent(parent);
+        rt.sizeDelta = new Vector2(120, 30);
+        rt.anchoredPosition = position;
+
+        var textGO = new GameObject("Text", typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
+        var textRT = textGO.GetComponent<RectTransform>();
+        textRT.SetParent(go.transform);
+        textRT.anchorMin = new Vector2(0, 0);
+        textRT.anchorMax = new Vector2(1, 1);
+        textRT.offsetMin = Vector2.zero;
+        textRT.offsetMax = Vector2.zero;
+        var text = textGO.GetComponent<Text>();
+        text.text = label;
+        text.alignment = TextAnchor.MiddleCenter;
+        text.color = Color.black;
+
+        return go.GetComponent<Button>();
+    }
+
+    private void OnDestroy()
+    {
+        if (loginButton != null)
+            loginButton.onClick.RemoveListener(OnLoginClicked);
+        if (createAccountButton != null)
+            createAccountButton.onClick.RemoveListener(OnCreateAccountClicked);
+    }
+
+    private void OnLoginClicked()
+    {
+        string username = usernameField != null ? usernameField.text : string.Empty;
+        string passwordHash = HashPassword(passwordField != null ? passwordField.text : string.Empty);
+        string connectionString = GetConnectionString();
+
+        using (var connection = new MySqlConnection(connectionString))
+        {
+            connection.Open();
+            using (var command = connection.CreateCommand())
+            {
+                command.CommandText = "SELECT id FROM accounts WHERE username=@user AND password_hash=@pass";
+                command.Parameters.AddWithValue("@user", username);
+                command.Parameters.AddWithValue("@pass", passwordHash);
+
+                using (var reader = command.ExecuteReader())
+                {
+                    if (reader.Read())
+                    {
+                        SceneManager.LoadScene("RPG");
+                    }
+                }
+            }
+        }
+    }
+
+    private string GetConnectionString()
+    {
+        if (debugServerToggle != null && debugServerToggle.isOn)
+            return "server=debug;user=dbuser;password=dbpass;database=game";
+        if (kimServerToggle != null && kimServerToggle.isOn)
+            return "server=kim;user=dbuser;password=dbpass;database=game";
+        return "server=prod;user=dbuser;password=dbpass;database=game";
+    }
+
+    private string HashPassword(string password)
+    {
+        using (var sha = SHA256.Create())
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(password);
+            byte[] hash = sha.ComputeHash(bytes);
+            var builder = new StringBuilder();
+            foreach (byte b in hash)
+            {
+                builder.Append(b.ToString("x2"));
+            }
+            return builder.ToString();
+        }
+    }
+
+    private void OnCreateAccountClicked()
+    {
+        // Placeholder for create account workflow
+    }
+}

--- a/New Unity Project/Assets/Scripts/LoginManager.cs.meta
+++ b/New Unity Project/Assets/Scripts/LoginManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c5d195f8b7f795ff16ba1de95dba323c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/login_query.sql
+++ b/login_query.sql
@@ -1,0 +1,2 @@
+-- Query used by LoginManager to authenticate users
+SELECT id FROM accounts WHERE username = ? AND password_hash = ?;


### PR DESCRIPTION
## Summary
- Create runtime-generated login UI scene
- Implement LoginManager with SHA256 password hashing and MySQL authentication
- Provide SQL query for account validation

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7be7c75808333b782eb452bfe9288