### PR TITLE
Add Unity inventory UI

### DIFF
--- a/New Unity Project/Assets/Prefabs/InventoryCanvas.prefab
+++ b/New Unity Project/Assets/Prefabs/InventoryCanvas.prefab
@@ -1,0 +1,111 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1000
+GameObject:
+  m_Name: InventoryCanvas
+  m_IsActive: 1
+  m_Layer: 5
+  m_Component:
+  - component: {fileID: 2240}
+  - component: {fileID: 2230}
+  - component: {fileID: 1140}
+--- !u!224 &2240
+RectTransform:
+  m_GameObject: {fileID: 1000}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &2230
+Canvas:
+  m_GameObject: {fileID: 1000}
+  m_RenderMode: 0
+--- !u!114 &1140
+MonoBehaviour:
+  m_GameObject: {fileID: 1000}
+  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 3}
+  itemListContent: {fileID: 0}
+  itemEntryPrefab: {fileID: 0}
+  descriptionText: {fileID: 0}
+  targetDropdown: {fileID: 0}
+  useButton: {fileID: 0}
+  tooltipText: {fileID: 0}
+--- !u!1 &1001
+GameObject:
+  m_Name: ItemList
+  m_IsActive: 1
+  m_Layer: 5
+  m_Component:
+  - component: {fileID: 2241}
+  - component: {fileID: 1141}
+--- !u!224 &2241
+RectTransform:
+  m_GameObject: {fileID: 1001}
+  m_Father: {fileID: 2240}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!114 &1141
+ScrollRect:
+  m_GameObject: {fileID: 1001}
+  m_Horizontal: 0
+--- !u!1 &1002
+GameObject:
+  m_Name: Description
+  m_IsActive: 1
+  m_Layer: 5
+  m_Component:
+  - component: {fileID: 2242}
+  - component: {fileID: 1142}
+--- !u!224 &2242
+RectTransform:
+  m_GameObject: {fileID: 1002}
+  m_Father: {fileID: 2240}
+--- !u!114 &1142
+Text:
+  m_GameObject: {fileID: 1002}
+  m_Text: 
+--- !u!1 &1003
+GameObject:
+  m_Name: TargetDropdown
+  m_IsActive: 1
+  m_Layer: 5
+  m_Component:
+  - component: {fileID: 2243}
+  - component: {fileID: 1143}
+--- !u!224 &2243
+RectTransform:
+  m_GameObject: {fileID: 1003}
+  m_Father: {fileID: 2240}
+--- !u!114 &1143
+Dropdown:
+  m_GameObject: {fileID: 1003}
+--- !u!1 &1004
+GameObject:
+  m_Name: UseButton
+  m_IsActive: 1
+  m_Layer: 5
+  m_Component:
+  - component: {fileID: 2244}
+  - component: {fileID: 1144}
+--- !u!224 &2244
+RectTransform:
+  m_GameObject: {fileID: 1004}
+  m_Father: {fileID: 2240}
+--- !u!114 &1144
+Button:
+  m_GameObject: {fileID: 1004}
+--- !u!1 &1005
+GameObject:
+  m_Name: Tooltip
+  m_IsActive: 1
+  m_Layer: 5
+  m_Component:
+  - component: {fileID: 2245}
+  - component: {fileID: 1145}
+--- !u!224 &2245
+RectTransform:
+  m_GameObject: {fileID: 1005}
+  m_Father: {fileID: 2240}
+--- !u!114 &1145
+Text:
+  m_GameObject: {fileID: 1005}
+  m_Text: 

--- a/New Unity Project/Assets/Scripts/InventoryUI.cs
+++ b/New Unity Project/Assets/Scripts/InventoryUI.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+using MySql.Data.MySqlClient;
+using WinFormsApp2;
+
+public class InventoryUI : MonoBehaviour
+{
+    [SerializeField] private Transform itemListContent = null!;
+    [SerializeField] private GameObject itemEntryPrefab = null!;
+    [SerializeField] private Text descriptionText = null!;
+    [SerializeField] private Dropdown targetDropdown = null!;
+    [SerializeField] private Button useButton = null!;
+    [SerializeField] private Text tooltipText = null!;
+    [SerializeField] private int userId;
+
+    private InventoryItem? selectedItem;
+
+    private void Start()
+    {
+        InventoryService.Load(userId);
+        PopulateItems();
+        LoadTargets();
+        useButton.onClick.AddListener(OnUseClicked);
+        targetDropdown.onValueChanged.AddListener(_ => OnTargetChanged());
+    }
+
+    private void PopulateItems()
+    {
+        foreach (Transform child in itemListContent)
+        {
+            Destroy(child.gameObject);
+        }
+        foreach (var inv in InventoryService.Items)
+        {
+            var go = Instantiate(itemEntryPrefab, itemListContent);
+            var label = go.GetComponentInChildren<Text>();
+            string suffix = inv.Item.Stackable ? $" x{inv.Quantity}" : string.Empty;
+            label.text = inv.Item.Name + suffix;
+            var button = go.GetComponent<Button>();
+            var current = inv;
+            button.onClick.AddListener(() => OnItemSelected(current));
+
+            var trigger = go.GetComponent<EventTrigger>() ?? go.AddComponent<EventTrigger>();
+            var enter = new EventTrigger.Entry { eventID = EventTriggerType.PointerEnter };
+            enter.callback.AddListener(_ => tooltipText.text = DescribeItem(current.Item));
+            trigger.triggers.Add(enter);
+            var exit = new EventTrigger.Entry { eventID = EventTriggerType.PointerExit };
+            exit.callback.AddListener(_ => tooltipText.text = string.Empty);
+            trigger.triggers.Add(exit);
+        }
+        OnItemSelected(null);
+    }
+
+    private void OnItemSelected(InventoryItem? inv)
+    {
+        selectedItem = inv;
+        if (inv == null)
+        {
+            descriptionText.text = string.Empty;
+            useButton.interactable = false;
+            useButton.GetComponentInChildren<Text>().text = "Use";
+        }
+        else
+        {
+            descriptionText.text = DescribeItem(inv.Item);
+            bool isEquipment = inv.Item is Weapon || inv.Item is Armor || inv.Item is Trinket;
+            useButton.GetComponentInChildren<Text>().text = isEquipment ? "Equip" : "Use";
+            useButton.interactable = targetDropdown.options.Count > 0 && targetDropdown.value >= 0 &&
+                                    (isEquipment || inv.Item is HealingPotion || inv.Item is AbilityTome);
+        }
+    }
+
+    private void LoadTargets()
+    {
+        targetDropdown.ClearOptions();
+        var options = new List<string>();
+        using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+        conn.Open();
+        using var cmd = new MySqlCommand("SELECT name FROM characters WHERE account_id=@id AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn);
+        cmd.Parameters.AddWithValue("@id", userId);
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            options.Add(reader.GetString("name"));
+        }
+        targetDropdown.AddOptions(options);
+        OnTargetChanged();
+    }
+
+    private void OnTargetChanged()
+    {
+        var item = selectedItem?.Item;
+        bool isEquipment = item is Weapon || item is Armor || item is Trinket;
+        useButton.GetComponentInChildren<Text>().text = isEquipment ? "Equip" : "Use";
+        useButton.interactable = targetDropdown.options.Count > 0 && targetDropdown.value >= 0 &&
+                                (isEquipment || item is HealingPotion || item is AbilityTome);
+    }
+
+    private void OnUseClicked()
+    {
+        if (selectedItem == null || targetDropdown.value < 0) return;
+        string target = targetDropdown.options[targetDropdown.value].text;
+        Item item = selectedItem.Item;
+        if (item is HealingPotion potion)
+        {
+            using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using var cmd = new MySqlCommand("UPDATE characters SET current_hp = LEAST(max_hp, current_hp + @heal) WHERE account_id=@uid AND name=@name AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn);
+            cmd.Parameters.AddWithValue("@heal", potion.HealAmount);
+            cmd.Parameters.AddWithValue("@uid", userId);
+            cmd.Parameters.AddWithValue("@name", target);
+            cmd.ExecuteNonQuery();
+            InventoryService.RemoveItem(item);
+            PopulateItems();
+        }
+        else if (item is AbilityTome tome)
+        {
+            using var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            using var cmd = new MySqlCommand("INSERT IGNORE INTO character_abilities(character_id, ability_id) SELECT id, @aid FROM characters WHERE account_id=@uid AND name=@name", conn);
+            cmd.Parameters.AddWithValue("@aid", tome.AbilityId);
+            cmd.Parameters.AddWithValue("@uid", userId);
+            cmd.Parameters.AddWithValue("@name", target);
+            cmd.ExecuteNonQuery();
+            InventoryService.RemoveItem(item);
+            PopulateItems();
+        }
+        else if (item is Weapon || item is Armor || item is Trinket)
+        {
+            InventoryService.Equip(target, item.Slot!.Value, item);
+            InventoryService.RemoveItem(item);
+            PopulateItems();
+        }
+    }
+
+    private string DescribeItem(Item item)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(item.Description);
+        if (item is Weapon w)
+        {
+            sb.AppendLine($"Scaling - STR {w.StrScaling:P0}, DEX {w.DexScaling:P0}, INT {w.IntScaling:P0}");
+            sb.AppendLine($"Damage {w.MinMultiplier:0.##}x-{w.MaxMultiplier:0.##}x");
+            if (w.CritChanceBonus != 0) sb.AppendLine($"Crit Chance +{w.CritChanceBonus:P0}");
+            if (w.CritDamageBonus != 0) sb.AppendLine($"Crit Damage +{w.CritDamageBonus:P0}");
+        }
+        foreach (var kv in item.FlatBonuses)
+        {
+            sb.AppendLine($"+{kv.Value} {kv.Key}");
+        }
+        foreach (var kv in item.PercentBonuses)
+        {
+            sb.AppendLine($"+{kv.Value}% {kv.Key}");
+        }
+        return sb.ToString().Trim();
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add Unity InventoryUI script hooking into InventoryService for item selection, tooltips, and usage/equip actions
- Provide InventoryCanvas prefab with scrollable list, description area, target dropdown and Use/Equip button

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7be7e57a483339540acc96a0ab807