### PR TITLE
Add Unity UI skeletons for WinForms screens

### DIFF
--- a/New Unity Project/Assets/Scenes/Arena.unity
+++ b/New Unity Project/Assets/Scenes/Arena.unity
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  m_Layer: 0
+  m_Name: ArenaRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/New Unity Project/Assets/Scenes/Battle.unity
+++ b/New Unity Project/Assets/Scenes/Battle.unity
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  m_Layer: 0
+  m_Name: BattleRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/New Unity Project/Assets/Scenes/Mailbox.unity
+++ b/New Unity Project/Assets/Scenes/Mailbox.unity
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  m_Layer: 0
+  m_Name: MailboxRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/New Unity Project/Assets/Scenes/MainRPG.unity
+++ b/New Unity Project/Assets/Scenes/MainRPG.unity
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  m_Layer: 0
+  m_Name: MainRPGRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/New Unity Project/Assets/Scenes/Shop.unity
+++ b/New Unity Project/Assets/Scenes/Shop.unity
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  m_Layer: 0
+  m_Name: ShopRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/New Unity Project/Assets/Scenes/Tavern.unity
+++ b/New Unity Project/Assets/Scenes/Tavern.unity
@@ -1,0 +1,32 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2}
+  m_Layer: 0
+  m_Name: TavernRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/New Unity Project/Assets/Scripts/UI/ArenaPanel.cs
+++ b/New Unity Project/Assets/Scripts/UI/ArenaPanel.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using WinFormsApp2;
+
+/// <summary>
+/// Unity UI wrapper for arena interactions.
+/// </summary>
+public class ArenaPanel : MonoBehaviour
+{
+    public void OnDeposit()
+    {
+        // Placeholder: deposit/withdraw team logic using InventoryService
+    }
+
+    public void OnChallenge()
+    {
+        // Placeholder: challenge logic that would invoke BattleForm
+    }
+
+    public void BackToMain() => SceneManager.LoadScene("MainRPG");
+}

--- a/New Unity Project/Assets/Scripts/UI/BattlePanel.cs
+++ b/New Unity Project/Assets/Scripts/UI/BattlePanel.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using WinFormsApp2;
+
+/// <summary>
+/// Simplified Unity wrapper for battle interactions.
+/// </summary>
+public class BattlePanel : MonoBehaviour
+{
+    public void StartBattle()
+    {
+        // Placeholder: launch a battle using BattleForm logic
+    }
+
+    public void BackToMain() => SceneManager.LoadScene("MainRPG");
+}

--- a/New Unity Project/Assets/Scripts/UI/MailboxPanel.cs
+++ b/New Unity Project/Assets/Scripts/UI/MailboxPanel.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using WinFormsApp2;
+
+/// <summary>
+/// Unity UI wrapper for viewing mail messages.
+/// </summary>
+public class MailboxPanel : MonoBehaviour
+{
+    private List<MailItem> _mail = new();
+
+    void Start()
+    {
+        LoadMail();
+    }
+
+    public void Refresh() => LoadMail();
+
+    private void LoadMail()
+    {
+        // Placeholder uses account id 0; actual game would supply the logged in id.
+        _mail = MailService.GetUnread(0);
+    }
+
+    public void BackToMain() => SceneManager.LoadScene("MainRPG");
+}

--- a/New Unity Project/Assets/Scripts/UI/MainRPGNavigation.cs
+++ b/New Unity Project/Assets/Scripts/UI/MainRPGNavigation.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+/// <summary>
+/// Navigation controller for the main RPG interface.  Buttons in the main scene
+/// call these methods to load the matching sub-scenes.
+/// </summary>
+public class MainRPGNavigation : MonoBehaviour
+{
+    public void OpenShop() => SceneManager.LoadScene("Shop");
+    public void OpenTavern() => SceneManager.LoadScene("Tavern");
+    public void OpenArena() => SceneManager.LoadScene("Arena");
+    public void OpenMailbox() => SceneManager.LoadScene("Mailbox");
+    public void OpenBattle() => SceneManager.LoadScene("Battle");
+}

--- a/New Unity Project/Assets/Scripts/UI/ShopPanel.cs
+++ b/New Unity Project/Assets/Scripts/UI/ShopPanel.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using WinFormsApp2;
+
+/// <summary>
+/// Simple Unity UI layer that mirrors the WinForms ShopForm behaviour.
+/// It relies on existing inventory and loot services to populate the shop
+/// and perform buy/sell actions.
+/// </summary>
+public class ShopPanel : MonoBehaviour
+{
+    private List<Item> _shopItems = new();
+
+    void Start()
+    {
+        // Load stock using the existing loot pool service
+        _shopItems = LootPool.GetShopStock("default");
+        InventoryService.Load(InventoryService.Items.Count); // ensure inventory ready
+    }
+
+    public void OnBuy(int index)
+    {
+        if (index < 0 || index >= _shopItems.Count) return;
+        var proto = _shopItems[index];
+        var item = InventoryService.CreateItem(proto.Name);
+        if (item != null)
+        {
+            InventoryService.AddItem(item);
+        }
+    }
+
+    public void OnSell(string itemName)
+    {
+        // Placeholder: full selling logic would mirror ShopForm.BtnSell_Click
+        var inv = InventoryService.Items.FirstOrDefault(i => i.Item.Name == itemName);
+        if (inv != null)
+        {
+            InventoryService.RemoveItem(inv.Item, 1);
+        }
+    }
+
+    public void BackToMain() => SceneManager.LoadScene("MainRPG");
+}

--- a/New Unity Project/Assets/Scripts/UI/TavernPanel.cs
+++ b/New Unity Project/Assets/Scripts/UI/TavernPanel.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using WinFormsApp2;
+
+/// <summary>
+/// Unity UI wrapper for TavernForm interactions.
+/// </summary>
+public class TavernPanel : MonoBehaviour
+{
+    public void OnRecruit()
+    {
+        // Placeholder for recruit logic using TavernService
+        TavernService.NotifyPartyHired(0);
+    }
+
+    public void OnJoinParty()
+    {
+        // Placeholder: open join party flow
+    }
+
+    public void BackToMain() => SceneManager.LoadScene("MainRPG");
+}


### PR DESCRIPTION
## Summary
- Add Unity scenes and panels for Shop, Tavern, Arena, Mailbox, Battle
- Implement main RPG navigation script to open scenes
- Stub panel scripts reuse existing service classes

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7be7ef93883339000b11b5f86df3d