### PR TITLE
Add RPG scene and UI manager

### DIFF
--- a/New Unity Project/Assets.meta
+++ b/New Unity Project/Assets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 873bcd6b4b5a4f22a016fa4533f545e1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Scenes.meta
+++ b/New Unity Project/Assets/Scenes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7ac4d8669ddc4750b69006e21e40260c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Scenes/RPG.meta
+++ b/New Unity Project/Assets/Scenes/RPG.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f9de0cdc3ba4d8788121be135efa060
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Scenes/RPG/RPG.unity
+++ b/New Unity Project/Assets/Scenes/RPG/RPG.unity
@@ -1,0 +1,96 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: RPGManager
+  m_Component:
+  - component: {fileID: 4}
+  - component: {fileID: 11400001}
+  m_IsActive: 1
+--- !u!4 &4
+Transform:
+  m_GameObject: {fileID: 1}
+--- !u!114 &11400001
+MonoBehaviour:
+  m_GameObject: {fileID: 1}
+  m_Script: {fileID: 11500000, guid: f8f4ea4cadae47c1a9b4aa7ad034eb5f, type: 3}
+  partyListContent: {fileID: 22430010}
+  partyMemberPrefab: {fileID: 200000, guid: 6b93811573584c9ab2b8d1b6e6070762, type: 2}
+  goldText: {fileID: 11430020}
+  chatText: {fileID: 11430030}
+--- !u!1 &300000
+GameObject:
+  m_Name: Canvas
+  m_Component:
+  - component: {fileID: 22430000}
+  m_IsActive: 1
+  m_Children:
+  - {fileID: 300010}
+  - {fileID: 300020}
+  - {fileID: 300030}
+  - {fileID: 300040}
+--- !u!224 &22430000
+RectTransform:
+  m_GameObject: {fileID: 300000}
+--- !u!1 &300010
+GameObject:
+  m_Name: PartyList
+  m_Component:
+  - component: {fileID: 22430010}
+  m_IsActive: 1
+--- !u!224 &22430010
+RectTransform:
+  m_GameObject: {fileID: 300010}
+--- !u!1 &300020
+GameObject:
+  m_Name: GoldText
+  m_Component:
+  - component: {fileID: 22430020}
+  - component: {fileID: 11430020}
+  m_IsActive: 1
+--- !u!224 &22430020
+RectTransform:
+  m_GameObject: {fileID: 300020}
+--- !u!114 &11430020
+MonoBehaviour:
+  m_GameObject: {fileID: 300020}
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 3}
+  m_Text: Gold: 0
+--- !u!1 &300030
+GameObject:
+  m_Name: ChatText
+  m_Component:
+  - component: {fileID: 22430030}
+  - component: {fileID: 11430030}
+  m_IsActive: 1
+--- !u!224 &22430030
+RectTransform:
+  m_GameObject: {fileID: 300030}
+--- !u!114 &11430030
+MonoBehaviour:
+  m_GameObject: {fileID: 300030}
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 3}
+  m_Text: Chat
+--- !u!1 &300040
+GameObject:
+  m_Name: ActionButtons
+  m_Component:
+  - component: {fileID: 22430040}
+  m_IsActive: 1
+--- !u!224 &22430040
+RectTransform:
+  m_GameObject: {fileID: 300040}
+--- !u!1 &400000
+GameObject:
+  m_Name: EventSystem
+  m_Component:
+  - component: {fileID: 400001}
+  - component: {fileID: 400002}
+  m_IsActive: 1
+--- !u!4 &400001
+Transform:
+  m_GameObject: {fileID: 400000}
+--- !u!114 &400002
+MonoBehaviour:
+  m_GameObject: {fileID: 400000}
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 3}

--- a/New Unity Project/Assets/Scenes/RPG/RPG.unity.meta
+++ b/New Unity Project/Assets/Scenes/RPG/RPG.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9657dddb58b346c4b4e56be9e59b5d97
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Scripts.meta
+++ b/New Unity Project/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9da353c53bf948be9bfceefa72f0d6d9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Scripts/ColoredProgressBar.cs
+++ b/New Unity Project/Assets/Scripts/ColoredProgressBar.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class ColoredProgressBar : MonoBehaviour
+{
+    [SerializeField] private Image hpFill;
+    [SerializeField] private Image manaFill;
+
+    public void SetValue(float hpPercent, float manaPercent)
+    {
+        if (hpFill != null)
+        {
+            hpFill.fillAmount = Mathf.Clamp01(hpPercent);
+        }
+        if (manaFill != null)
+        {
+            manaFill.fillAmount = Mathf.Clamp01(manaPercent);
+        }
+    }
+}

--- a/New Unity Project/Assets/Scripts/ColoredProgressBar.cs.meta
+++ b/New Unity Project/Assets/Scripts/ColoredProgressBar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc074d1ce502472f96fb87e1be735f3d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Scripts/RPGManager.cs
+++ b/New Unity Project/Assets/Scripts/RPGManager.cs
@@ -1,0 +1,138 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class RPGManager : MonoBehaviour
+{
+    [Header("UI References")]
+    [SerializeField] private Transform partyListContent;
+    [SerializeField] private GameObject partyMemberPrefab;
+    [SerializeField] private Text goldText;
+    [SerializeField] private Text chatText;
+
+    private List<CharacterData> partyMembers = new List<CharacterData>();
+
+    private void Start()
+    {
+        LoadPartyMembers();
+        PopulatePartyList();
+        StartCoroutine(ChatLoop());
+        StartCoroutine(RegenLoop());
+    }
+
+    private void LoadPartyMembers()
+    {
+        partyMembers = CharacterDatabase.GetPartyMembers();
+        if (goldText != null)
+        {
+            goldText.text = $"Gold: {CharacterDatabase.GetGold()}";
+        }
+    }
+
+    private void PopulatePartyList()
+    {
+        if (partyListContent == null || partyMemberPrefab == null)
+        {
+            return;
+        }
+
+        foreach (Transform child in partyListContent)
+        {
+            Destroy(child.gameObject);
+        }
+
+        foreach (var member in partyMembers)
+        {
+            var go = GameObject.Instantiate(partyMemberPrefab, partyListContent);
+            go.name = member.Name;
+
+            var texts = go.GetComponentsInChildren<Text>();
+            foreach (var t in texts)
+            {
+                if (t.gameObject.name == "NameText")
+                {
+                    t.text = member.Name;
+                }
+            }
+
+            var bar = go.GetComponentInChildren<ColoredProgressBar>();
+            if (bar != null)
+            {
+                bar.SetValue(member.HP / (float)member.MaxHP, member.Mana / (float)member.MaxMana);
+            }
+        }
+    }
+
+    private IEnumerator ChatLoop()
+    {
+        while (true)
+        {
+            string msg = ChatService.FetchNewMessage();
+            if (!string.IsNullOrEmpty(msg) && chatText != null)
+            {
+                chatText.text += "\n" + msg;
+            }
+            yield return new WaitForSeconds(2f);
+        }
+    }
+
+    private IEnumerator RegenLoop()
+    {
+        while (true)
+        {
+            foreach (var member in partyMembers)
+            {
+                member.RegenTick();
+            }
+            PopulatePartyList();
+            yield return new WaitForSeconds(1f);
+        }
+    }
+}
+
+public class CharacterData
+{
+    public string Name;
+    public int HP;
+    public int MaxHP;
+    public int Mana;
+    public int MaxMana;
+
+    public void RegenTick()
+    {
+        HP = Mathf.Min(MaxHP, HP + 1);
+        Mana = Mathf.Min(MaxMana, Mana + 1);
+    }
+}
+
+public static class CharacterDatabase
+{
+    public static List<CharacterData> GetPartyMembers()
+    {
+        return new List<CharacterData>
+        {
+            new CharacterData { Name = "Hero", HP = 50, MaxHP = 100, Mana = 30, MaxMana = 50 },
+            new CharacterData { Name = "Mage", HP = 40, MaxHP = 60, Mana = 80, MaxMana = 100 }
+        };
+    }
+
+    public static int GetGold()
+    {
+        return 123;
+    }
+}
+
+public static class ChatService
+{
+    private static Queue<string> messages = new Queue<string>(new[] { "Welcome to the world!" });
+
+    public static string FetchNewMessage()
+    {
+        if (messages.Count > 0)
+        {
+            return messages.Dequeue();
+        }
+        return null;
+    }
+}

--- a/New Unity Project/Assets/Scripts/RPGManager.cs.meta
+++ b/New Unity Project/Assets/Scripts/RPGManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f8f4ea4cadae47c1a9b4aa7ad034eb5f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/UI.meta
+++ b/New Unity Project/Assets/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2b78bc38f2ed46a9b315a2fa514fa992
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/UI/ColoredProgressBar.prefab
+++ b/New Unity Project/Assets/UI/ColoredProgressBar.prefab
@@ -1,0 +1,69 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_Name: ColoredProgressBar
+  m_Component:
+  - component: {fileID: 22400001}
+  - component: {fileID: 11400001}
+  m_Layer: 5
+  m_IsActive: 1
+  m_Children:
+  - {fileID: 100010}
+  - {fileID: 100020}
+--- !u!224 &22400001
+RectTransform:
+  m_GameObject: {fileID: 100000}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!114 &11400001
+MonoBehaviour:
+  m_GameObject: {fileID: 100000}
+  m_Script: {fileID: 11500000, guid: cc074d1ce502472f96fb87e1be735f3d, type: 3}
+  hpFill: {fileID: 11400010}
+  manaFill: {fileID: 11400020}
+--- !u!1 &100010
+GameObject:
+  m_Name: HP
+  m_Component:
+  - component: {fileID: 22400010}
+  - component: {fileID: 11400010}
+  m_Layer: 5
+  m_IsActive: 1
+--- !u!224 &22400010
+RectTransform:
+  m_GameObject: {fileID: 100010}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!114 &11400010
+MonoBehaviour:
+  m_GameObject: {fileID: 100010}
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 3}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_Type: 3
+  m_FillMethod: 0
+  m_FillAmount: 1
+--- !u!1 &100020
+GameObject:
+  m_Name: Mana
+  m_Component:
+  - component: {fileID: 22400020}
+  - component: {fileID: 11400020}
+  m_Layer: 5
+  m_IsActive: 1
+--- !u!224 &22400020
+RectTransform:
+  m_GameObject: {fileID: 100020}
+  m_LocalPosition: {x: 0, y: -10, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!114 &11400020
+MonoBehaviour:
+  m_GameObject: {fileID: 100020}
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 3}
+  m_Color: {r: 0, g: 0, b: 1, a: 1}
+  m_Type: 3
+  m_FillMethod: 0
+  m_FillAmount: 1

--- a/New Unity Project/Assets/UI/ColoredProgressBar.prefab.meta
+++ b/New Unity Project/Assets/UI/ColoredProgressBar.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 14e90da7df674aad961b025a26c2c8be
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/UI/PartyMemberItem.prefab
+++ b/New Unity Project/Assets/UI/PartyMemberItem.prefab
@@ -1,0 +1,104 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &200000
+GameObject:
+  m_Name: PartyMemberItem
+  m_Component:
+  - component: {fileID: 22420000}
+  m_Layer: 5
+  m_IsActive: 1
+  m_Children:
+  - {fileID: 200010}
+  - {fileID: 200020}
+--- !u!224 &22420000
+RectTransform:
+  m_GameObject: {fileID: 200000}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!1 &200010
+GameObject:
+  m_Name: NameText
+  m_Component:
+  - component: {fileID: 22420010}
+  - component: {fileID: 11420010}
+  m_Layer: 5
+  m_IsActive: 1
+--- !u!224 &22420010
+RectTransform:
+  m_GameObject: {fileID: 200010}
+  m_LocalPosition: {x: 0, y: 10, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!114 &11420010
+MonoBehaviour:
+  m_GameObject: {fileID: 200010}
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 3}
+  m_Text: Name
+--- !u!1 &200020
+GameObject:
+  m_Name: Bars
+  m_Component:
+  - component: {fileID: 22420020}
+  - component: {fileID: 11420001}
+  m_Layer: 5
+  m_IsActive: 1
+  m_Children:
+  - {fileID: 200030}
+  - {fileID: 200040}
+--- !u!224 &22420020
+RectTransform:
+  m_GameObject: {fileID: 200020}
+  m_LocalPosition: {x: 0, y: -5, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!114 &11420001
+MonoBehaviour:
+  m_GameObject: {fileID: 200020}
+  m_Script: {fileID: 11500000, guid: cc074d1ce502472f96fb87e1be735f3d, type: 3}
+  hpFill: {fileID: 11420030}
+  manaFill: {fileID: 11420040}
+--- !u!1 &200030
+GameObject:
+  m_Name: HP
+  m_Component:
+  - component: {fileID: 22420030}
+  - component: {fileID: 11420030}
+  m_Layer: 5
+  m_IsActive: 1
+--- !u!224 &22420030
+RectTransform:
+  m_GameObject: {fileID: 200030}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!114 &11420030
+MonoBehaviour:
+  m_GameObject: {fileID: 200030}
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 3}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_Type: 3
+  m_FillMethod: 0
+  m_FillAmount: 1
+--- !u!1 &200040
+GameObject:
+  m_Name: Mana
+  m_Component:
+  - component: {fileID: 22420040}
+  - component: {fileID: 11420040}
+  m_Layer: 5
+  m_IsActive: 1
+--- !u!224 &22420040
+RectTransform:
+  m_GameObject: {fileID: 200040}
+  m_LocalPosition: {x: 0, y: -10, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!114 &11420040
+MonoBehaviour:
+  m_GameObject: {fileID: 200040}
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 3}
+  m_Color: {r: 0, g: 0, b: 1, a: 1}
+  m_Type: 3
+  m_FillMethod: 0
+  m_FillAmount: 1

--- a/New Unity Project/Assets/UI/PartyMemberItem.prefab.meta
+++ b/New Unity Project/Assets/UI/PartyMemberItem.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6b93811573584c9ab2b8d1b6e6070762
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add RPG UI scene with party list, gold, chat and action buttons
- Implement RPGManager for party member listing, chat polling and regen
- Create ColoredProgressBar prefab and script for HP/Mana bars

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7be7f4cf0833386d42519629672cd