### PR TITLE
Rebalance enemy health and creature stats

### DIFF
--- a/adjust_enemy_health_and_creature_stats.sql
+++ b/adjust_enemy_health_and_creature_stats.sql
@@ -1,0 +1,21 @@
+USE accounts;
+
+UPDATE npcs
+SET max_hp = CASE
+        WHEN level BETWEEN 1 AND 25 THEN CEIL(max_hp * 0.5)
+        WHEN level > 25 THEN CEIL(max_hp * 0.8)
+        ELSE max_hp
+    END,
+    current_hp = CASE
+        WHEN level BETWEEN 1 AND 25 THEN CEIL(current_hp * 0.5)
+        WHEN level > 25 THEN CEIL(current_hp * 0.8)
+        ELSE current_hp
+    END,
+    strength = CEIL(strength * 1.3),
+    dex = CEIL(dex * 1.3),
+    intelligence = CEIL(intelligence * 1.3);
+
+UPDATE characters
+SET strength = CEIL(strength * 1.3),
+    dex = CEIL(dex * 1.3),
+    intelligence = CEIL(intelligence * 1.3);


### PR DESCRIPTION
## Summary
- Reduce NPC health by 50% for levels 1-25 and by 20% for level 26 and above
- Boost strength, dexterity, and intelligence by 30% for all NPCs and player characters

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c02d8ba483339343c1a02791c0e2