### PR TITLE
Fix Inventory Canvas script reference and add meta files

### DIFF
--- a/New Unity Project/Assets/Prefabs.meta
+++ b/New Unity Project/Assets/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: db006f4e5e76438ca38a776b6a4a873f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Prefabs/InventoryCanvas.prefab
+++ b/New Unity Project/Assets/Prefabs/InventoryCanvas.prefab
@@ -23,7 +23,7 @@ Canvas:
 --- !u!114 &1140
 MonoBehaviour:
   m_GameObject: {fileID: 1000}
-  m_Script: {fileID: 11500000, guid: 00000000000000000000000000000000, type: 3}
+  m_Script: {fileID: 11500000, guid: 3218747909e641a3bd156916f24b91b5, type: 3}
   itemListContent: {fileID: 0}
   itemEntryPrefab: {fileID: 0}
   descriptionText: {fileID: 0}

--- a/New Unity Project/Assets/Prefabs/InventoryCanvas.prefab.meta
+++ b/New Unity Project/Assets/Prefabs/InventoryCanvas.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1c891e68ba104ceba9cdcabe8252357c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Scripts/InventoryUI.cs.meta
+++ b/New Unity Project/Assets/Scripts/InventoryUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3218747909e641a3bd156916f24b91b5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- point InventoryCanvas prefab to InventoryUI script
- add missing meta files for inventory UI assets

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c274999c83338250a7152287a9a4