### PR TITLE
feat: integrate database-backed inventory in unity

### DIFF
--- a/New Unity Project/Assets/Scripts/DatabaseConfig.cs
+++ b/New Unity Project/Assets/Scripts/DatabaseConfig.cs
@@ -1,0 +1,14 @@
+namespace WinFormsApp2
+{
+    internal static class DatabaseConfig
+    {
+        private const string Host = "76.134.86.9";
+        private const string KimHost = "10.0.0.30";
+        private const string Username = "userclient";
+        private const string Password = "123321";
+        public static bool DebugMode { get; set; }
+        public static bool UseKimServer { get; set; }
+        public static string ConnectionString =>
+            $"Server={(UseKimServer ? KimHost : (DebugMode ? \"127.0.0.1\" : Host))};Database=accounts;User ID={Username};Password={Password};";
+    }
+}

--- a/New Unity Project/Assets/Scripts/DatabaseConfig.cs.meta
+++ b/New Unity Project/Assets/Scripts/DatabaseConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9cf0f724789342c9972bd28bd82c3b60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/New Unity Project/Assets/Scripts/InventoryServiceUnity.cs
+++ b/New Unity Project/Assets/Scripts/InventoryServiceUnity.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MySql.Data.MySqlClient;
+using WinFormsApp2;
+
+namespace WinFormsApp2
+{
+    /// <summary>
+    /// Unity-friendly inventory service that mirrors the data loading behaviour of the
+    /// original WinForms InventoryService. It retrieves item and equipment data from
+    /// the database and exposes it to Unity scripts.
+    /// </summary>
+    public static class InventoryServiceUnity
+    {
+        public static List<InventoryItem> Items { get; } = new();
+        private static readonly Dictionary<string, Dictionary<EquipmentSlot, Item?>> _equipment = new();
+        private static bool _loaded;
+        private static int _userId;
+
+        public static void Load(int userId, bool forceReload = false) =>
+            LoadAsync(userId, forceReload).ConfigureAwait(false).GetAwaiter().GetResult();
+
+        public static async Task LoadAsync(int userId, bool forceReload = false)
+        {
+            if (_loaded && _userId == userId && !forceReload) return;
+            _loaded = true;
+            _userId = userId;
+            Items.Clear();
+            _equipment.Clear();
+
+            await using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            await conn.OpenAsync().ConfigureAwait(false);
+
+            await using (MySqlCommand cmd = new MySqlCommand(
+                       "SELECT item_name, quantity FROM user_items WHERE account_id=@id", conn))
+            {
+                cmd.Parameters.AddWithValue("@id", userId);
+                await using var r = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
+                while (await r.ReadAsync().ConfigureAwait(false))
+                {
+                    string name = r.GetString("item_name");
+                    int qty = r.GetInt32("quantity");
+                    Item? item = CreateItem(name);
+                    if (item != null)
+                        Items.Add(new InventoryItem { Item = item, Quantity = qty });
+                }
+            }
+
+            await using (MySqlCommand cmd = new MySqlCommand(
+                       "SELECT character_name, slot, item_name FROM character_equipment WHERE account_id=@id", conn))
+            {
+                cmd.Parameters.AddWithValue("@id", userId);
+                await using var r = await cmd.ExecuteReaderAsync().ConfigureAwait(false);
+                while (await r.ReadAsync().ConfigureAwait(false))
+                {
+                    string charName = r.GetString("character_name");
+                    string slot = r.GetString("slot");
+                    string itemName = r.GetString("item_name");
+                    Item? item = CreateItem(itemName);
+                    if (item != null)
+                    {
+                        if (!_equipment.ContainsKey(charName))
+                            _equipment[charName] = new Dictionary<EquipmentSlot, Item?>();
+                        _equipment[charName][Enum.Parse<EquipmentSlot>(slot)] = item;
+                    }
+                }
+            }
+        }
+
+        public static Item? CreateItem(string name)
+        {
+            if (name == "Healing Potion")
+                return new HealingPotion { HealAmount = 20 };
+
+            if (name.StartsWith("Tome: "))
+            {
+                string abilityName = name.Substring(6);
+                using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+                conn.Open();
+                using MySqlCommand cmd = new MySqlCommand(
+                    "SELECT id, description FROM abilities WHERE name=@n", conn);
+                cmd.Parameters.AddWithValue("@n", abilityName);
+                using var r = cmd.ExecuteReader();
+                if (r.Read())
+                {
+                    int id = r.GetInt32("id");
+                    string desc = r.GetString("description");
+                    return new AbilityTome(id) { Name = name, Description = desc, Stackable = false };
+                }
+            }
+
+            return new Item { Name = name, Description = string.Empty, Stackable = true };
+        }
+
+        public static void AddItem(Item item, int qty = 1)
+        {
+            if (!item.Stackable)
+            {
+                Items.Add(new InventoryItem { Item = item, Quantity = qty });
+            }
+            else
+            {
+                var existing = Items.Find(i => i.Item.Name == item.Name);
+                if (existing == null)
+                    Items.Add(new InventoryItem { Item = item, Quantity = qty });
+                else
+                    existing.Quantity += qty;
+            }
+
+            if (_loaded)
+            {
+                using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+                conn.Open();
+                using MySqlCommand cmd = new MySqlCommand(
+                    "INSERT INTO user_items(account_id,item_name,quantity) VALUES(@id,@name,@qty) " +
+                    "ON DUPLICATE KEY UPDATE quantity=quantity+@qty", conn);
+                cmd.Parameters.AddWithValue("@id", _userId);
+                cmd.Parameters.AddWithValue("@name", item.Name);
+                cmd.Parameters.AddWithValue("@qty", qty);
+                cmd.ExecuteNonQuery();
+            }
+        }
+
+        public static void RemoveItem(Item item, int qty = 1)
+        {
+            var existing = Items.Find(i => i.Item.Name == item.Name);
+            if (existing == null) return;
+            existing.Quantity -= qty;
+            if (existing.Quantity <= 0) Items.Remove(existing);
+
+            if (_loaded)
+            {
+                using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+                conn.Open();
+                using MySqlCommand cmd = new MySqlCommand(
+                    "UPDATE user_items SET quantity=quantity-@qty WHERE account_id=@id AND item_name=@name", conn);
+                cmd.Parameters.AddWithValue("@qty", qty);
+                cmd.Parameters.AddWithValue("@id", _userId);
+                cmd.Parameters.AddWithValue("@name", item.Name);
+                cmd.ExecuteNonQuery();
+                using MySqlCommand del = new MySqlCommand(
+                    "DELETE FROM user_items WHERE account_id=@id AND item_name=@name AND quantity<=0", conn);
+                del.Parameters.AddWithValue("@id", _userId);
+                del.Parameters.AddWithValue("@name", item.Name);
+                del.ExecuteNonQuery();
+            }
+        }
+
+        public static Item? GetEquippedItem(string character, EquipmentSlot slot)
+        {
+            if (_equipment.TryGetValue(character, out var dict) && dict.TryGetValue(slot, out var item))
+                return item;
+            return null;
+        }
+
+        public static void Equip(string character, EquipmentSlot slot, Item? item)
+        {
+            if (!_equipment.ContainsKey(character))
+                _equipment[character] = new Dictionary<EquipmentSlot, Item?>();
+
+            if (_equipment[character].TryGetValue(slot, out var existing) && existing != null)
+                AddItem(existing);
+
+            if (item != null)
+                RemoveItem(item);
+
+            _equipment[character][slot] = item;
+            SaveEquipment(character, slot, item);
+        }
+
+        private static void SaveEquipment(string character, EquipmentSlot slot, Item? item)
+        {
+            if (!_loaded) return;
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            conn.Open();
+            if (item == null)
+            {
+                using MySqlCommand cmd = new MySqlCommand(
+                    "DELETE FROM character_equipment WHERE account_id=@id AND character_name=@c AND slot=@s", conn);
+                cmd.Parameters.AddWithValue("@id", _userId);
+                cmd.Parameters.AddWithValue("@c", character);
+                cmd.Parameters.AddWithValue("@s", slot.ToString());
+                cmd.ExecuteNonQuery();
+            }
+            else
+            {
+                using MySqlCommand cmd = new MySqlCommand(
+                    "REPLACE INTO character_equipment(account_id,character_name,slot,item_name) VALUES(@id,@c,@s,@n)", conn);
+                cmd.Parameters.AddWithValue("@id", _userId);
+                cmd.Parameters.AddWithValue("@c", character);
+                cmd.Parameters.AddWithValue("@s", slot.ToString());
+                cmd.Parameters.AddWithValue("@n", item.Name);
+                cmd.ExecuteNonQuery();
+            }
+        }
+    }
+}
+

--- a/New Unity Project/Assets/Scripts/InventoryServiceUnity.cs.meta
+++ b/New Unity Project/Assets/Scripts/InventoryServiceUnity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ff3bfbdcdaa4ed987e09339d93643d2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/New Unity Project/Assets/Scripts/UI/ArenaPanel.cs
+++ b/New Unity Project/Assets/Scripts/UI/ArenaPanel.cs
@@ -9,7 +9,7 @@ public class ArenaPanel : MonoBehaviour
 {
     public void OnDeposit()
     {
-        // Placeholder: deposit/withdraw team logic using InventoryService
+        // Placeholder: deposit/withdraw team logic using InventoryServiceUnity
     }
 
     public void OnChallenge()

--- a/New Unity Project/Assets/Scripts/UI/ShopPanel.cs
+++ b/New Unity Project/Assets/Scripts/UI/ShopPanel.cs
@@ -17,27 +17,27 @@ public class ShopPanel : MonoBehaviour
     {
         // Load stock using the existing loot pool service
         _shopItems = LootPool.GetShopStock("default");
-        InventoryService.Load(InventoryService.Items.Count); // ensure inventory ready
+        InventoryServiceUnity.Load(InventoryServiceUnity.Items.Count); // ensure inventory ready
     }
 
     public void OnBuy(int index)
     {
         if (index < 0 || index >= _shopItems.Count) return;
         var proto = _shopItems[index];
-        var item = InventoryService.CreateItem(proto.Name);
+        var item = InventoryServiceUnity.CreateItem(proto.Name);
         if (item != null)
         {
-            InventoryService.AddItem(item);
+            InventoryServiceUnity.AddItem(item);
         }
     }
 
     public void OnSell(string itemName)
     {
         // Placeholder: full selling logic would mirror ShopForm.BtnSell_Click
-        var inv = InventoryService.Items.FirstOrDefault(i => i.Item.Name == itemName);
+        var inv = InventoryServiceUnity.Items.FirstOrDefault(i => i.Item.Name == itemName);
         if (inv != null)
         {
-            InventoryService.RemoveItem(inv.Item, 1);
+            InventoryServiceUnity.RemoveItem(inv.Item, 1);
         }
     }
 

--- a/unity_inventory_updates.sql
+++ b/unity_inventory_updates.sql
@@ -1,0 +1,14 @@
+-- Healing potion usage
+UPDATE characters SET current_hp = LEAST(max_hp, current_hp + @heal)
+WHERE account_id=@uid AND name=@name AND is_dead=0 AND in_arena=0 AND in_tavern=0;
+
+-- Ability tome usage
+INSERT IGNORE INTO character_abilities(character_id, ability_id)
+SELECT id, @aid FROM characters WHERE account_id=@uid AND name=@name;
+
+-- Equip item
+REPLACE INTO character_equipment(account_id, character_name, slot, item_name)
+VALUES (@uid, @character, @slot, @item);
+
+-- Unequip item
+DELETE FROM character_equipment WHERE account_id=@uid AND character_name=@character AND slot=@slot;


### PR DESCRIPTION
## Summary
- add `InventoryServiceUnity` to load and manage inventory using MySQL
- wire up Unity inventory UI and shop to use the new service
- support healing potions, ability tomes, and equipment with database updates
- include SQL reference script for item usage queries

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c8e65388833391f114852e2fd738