### PR TITLE
Add async services for party and chat data

### DIFF
--- a/New Unity Project/Assets/Scripts/CharacterService.cs
+++ b/New Unity Project/Assets/Scripts/CharacterService.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Networking;
+
+public static class CharacterService
+{
+    private const string BaseUrl = "http://localhost:8080";
+
+    [System.Serializable]
+    private class PartyResponse
+    {
+        public List<CharacterData> party;
+    }
+
+    [System.Serializable]
+    private class GoldResponse
+    {
+        public int gold;
+    }
+
+    public static async Task<List<CharacterData>> GetPartyMembersAsync()
+    {
+        using UnityWebRequest request = UnityWebRequest.Get($"{BaseUrl}/party");
+        await request.SendWebRequest();
+        if (request.result != UnityWebRequest.Result.Success)
+        {
+            Debug.LogError($"Failed to fetch party members: {request.error}");
+            return new List<CharacterData>();
+        }
+        var json = request.downloadHandler.text;
+        PartyResponse resp = JsonUtility.FromJson<PartyResponse>(json);
+        return resp != null && resp.party != null ? resp.party : new List<CharacterData>();
+    }
+
+    public static async Task<int> GetGoldAsync()
+    {
+        using UnityWebRequest request = UnityWebRequest.Get($"{BaseUrl}/gold");
+        await request.SendWebRequest();
+        if (request.result != UnityWebRequest.Result.Success)
+        {
+            Debug.LogError($"Failed to fetch gold: {request.error}");
+            return 0;
+        }
+        var json = request.downloadHandler.text;
+        GoldResponse resp = JsonUtility.FromJson<GoldResponse>(json);
+        return resp != null ? resp.gold : 0;
+    }
+}

--- a/New Unity Project/Assets/Scripts/ChatService.cs
+++ b/New Unity Project/Assets/Scripts/ChatService.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Networking;
+
+public static class ChatService
+{
+    private const string BaseUrl = "http://localhost:8080";
+
+    [System.Serializable]
+    private class ChatResponse
+    {
+        public List<string> messages;
+    }
+
+    public static async Task<List<string>> FetchMessagesAsync()
+    {
+        using UnityWebRequest request = UnityWebRequest.Get($"{BaseUrl}/chat/messages");
+        await request.SendWebRequest();
+        if (request.result != UnityWebRequest.Result.Success)
+        {
+            Debug.LogError($"Failed to fetch chat messages: {request.error}");
+            return new List<string>();
+        }
+        var json = request.downloadHandler.text;
+        ChatResponse resp = JsonUtility.FromJson<ChatResponse>(json);
+        return resp != null && resp.messages != null ? resp.messages : new List<string>();
+    }
+}

--- a/unity_party_chat_queries.sql
+++ b/unity_party_chat_queries.sql
@@ -1,0 +1,21 @@
+-- Fetch party members for a player
+SELECT c.name, c.hp, c.max_hp, c.mana, c.max_mana
+FROM party_members pm
+JOIN characters c ON pm.character_id = c.id
+WHERE pm.user_id = ?;
+
+-- Fetch gold for a player
+SELECT gold
+FROM users
+WHERE id = ?;
+
+-- Fetch recent chat messages visible to a player
+SELECT s.nickname AS sender,
+       r.nickname AS recipient,
+       m.message,
+       m.sent_at
+FROM chat_messages m
+JOIN users s ON m.sender_id = s.id
+LEFT JOIN users r ON m.recipient_id = r.id
+WHERE m.sent_at > ?
+ORDER BY m.sent_at;


### PR DESCRIPTION
## Summary
- Replace stubbed data access in `RPGManager` with async calls
- Add `CharacterService` and `ChatService` for party, gold, and chat retrieval
- Store associated SQL queries in `unity_party_chat_queries.sql`

## Testing
- ⚠️ `dotnet build WinFormsApp2/BattleLands.sln` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c8e718ac8333adf7db98794d9c4a