### PR TITLE
Add runtime camera setup for scenes and prefab

### DIFF
--- a/New Unity Project/Assets/Prefabs/MainCamera.prefab
+++ b/New Unity Project/Assets/Prefabs/MainCamera.prefab
@@ -1,0 +1,40 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1000
+GameObject:
+  m_Name: MainCamera
+  m_TagString: MainCamera
+  m_IsActive: 1
+  m_Layer: 0
+  m_Component:
+  - component: {fileID: 4000}
+  - component: {fileID: 2000}
+  - component: {fileID: 8100}
+--- !u!4 &4000
+Transform:
+  m_GameObject: {fileID: 1000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Father: {fileID: 0}
+--- !u!20 &2000
+Camera:
+  m_GameObject: {fileID: 1000}
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 1}
+  m_ProjectionMatrixMode: 0
+  m_TargetDisplay: 0
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip: 0.3
+  far clip: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+--- !u!81 &8100
+AudioListener:
+  m_GameObject: {fileID: 1000}

--- a/New Unity Project/Assets/Prefabs/MainCamera.prefab.meta
+++ b/New Unity Project/Assets/Prefabs/MainCamera.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3882991b9b4e4e8992066839287b57a7
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/New Unity Project/Assets/Scripts/SceneSetup.cs
+++ b/New Unity Project/Assets/Scripts/SceneSetup.cs
@@ -1,0 +1,67 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+/// <summary>
+/// Ensures that every scene has a Main Camera and EventSystem. Any Canvas
+/// components present in the scene will reference the main camera when
+/// required.
+/// </summary>
+public static class SceneSetup
+{
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+    private static void EnsureSceneObjects()
+    {
+        EnsureCamera();
+        EnsureEventSystem();
+        ConfigureCanvases();
+    }
+
+    private static void EnsureCamera()
+    {
+        if (Camera.main != null)
+            return;
+
+        var camGO = new GameObject("Main Camera");
+        camGO.tag = "MainCamera";
+        camGO.AddComponent<Camera>();
+        camGO.AddComponent<AudioListener>();
+    }
+
+    private static void EnsureEventSystem()
+    {
+        if (Object.FindObjectOfType<EventSystem>() != null)
+            return;
+
+        var es = new GameObject("EventSystem");
+        es.AddComponent<EventSystem>();
+        es.AddComponent<StandaloneInputModule>();
+    }
+
+    private static void ConfigureCanvases()
+    {
+        var mainCamera = Camera.main;
+        if (mainCamera == null)
+            return;
+
+        var canvases = Object.FindObjectsOfType<Canvas>();
+        if (canvases.Length == 0)
+        {
+            var canvasGO = GameObject.Find("Canvas") ?? new GameObject("Canvas");
+            var canvas = canvasGO.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceCamera;
+            canvas.worldCamera = mainCamera;
+            canvases = new[] { canvas };
+        }
+
+        foreach (var canvas in canvases)
+        {
+            if ((canvas.renderMode == RenderMode.ScreenSpaceCamera ||
+                 canvas.renderMode == RenderMode.WorldSpace) &&
+                canvas.worldCamera == null)
+            {
+                canvas.worldCamera = mainCamera;
+            }
+        }
+    }
+}
+

--- a/New Unity Project/Assets/Scripts/SceneSetup.cs.meta
+++ b/New Unity Project/Assets/Scripts/SceneSetup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1bbd53a60d8c424f934864bc9ee2bf8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- ensure every scene has a main camera, event system, and canvas camera wiring at runtime
- add a reusable `MainCamera` prefab

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c8eb784083339872ebff7ba3b0a5