### PR TITLE
Add Unity database configuration and shared query layer

### DIFF
--- a/New Unity Project/Assets/Scripts/DatabaseClientUnity.cs
+++ b/New Unity Project/Assets/Scripts/DatabaseClientUnity.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MySqlConnector;
+
+namespace UnityClient
+{
+    public static class DatabaseClientUnity
+    {
+        private const int MaxRetries = 3;
+
+        private static async Task<MySqlConnection> OpenConnectionAsync()
+        {
+            int attempt = 0;
+            while (true)
+            {
+                try
+                {
+                    var conn = new MySqlConnection(DatabaseConfigUnity.ConnectionString);
+                    await conn.OpenAsync();
+                    return conn;
+                }
+                catch (MySqlException) when (attempt < MaxRetries)
+                {
+                    await Task.Delay(200 * (int)Math.Pow(2, attempt));
+                    attempt++;
+                }
+            }
+        }
+
+        public static async Task<List<Dictionary<string, object?>>> QueryAsync(string sql, Dictionary<string, object?>? parameters = null)
+        {
+            await using var conn = await OpenConnectionAsync();
+            await using var cmd = new MySqlCommand(sql, conn);
+            AddParameters(cmd, parameters);
+            var results = new List<Dictionary<string, object?>>();
+            await using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                var row = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+                for (int i = 0; i < reader.FieldCount; i++)
+                {
+                    row[reader.GetName(i)] = await reader.IsDBNullAsync(i) ? null : reader.GetValue(i);
+                }
+                results.Add(row);
+            }
+            return results;
+        }
+
+        public static async Task<int> ExecuteAsync(string sql, Dictionary<string, object?>? parameters = null)
+        {
+            await using var conn = await OpenConnectionAsync();
+            await using var cmd = new MySqlCommand(sql, conn);
+            AddParameters(cmd, parameters);
+            return await cmd.ExecuteNonQueryAsync();
+        }
+
+        private static void AddParameters(MySqlCommand cmd, Dictionary<string, object?>? parameters)
+        {
+            if (parameters == null) return;
+            foreach (var kvp in parameters)
+            {
+                cmd.Parameters.AddWithValue(kvp.Key, kvp.Value ?? DBNull.Value);
+            }
+        }
+    }
+}

--- a/New Unity Project/Assets/Scripts/DatabaseConfigUnity.cs
+++ b/New Unity Project/Assets/Scripts/DatabaseConfigUnity.cs
@@ -1,0 +1,14 @@
+namespace UnityClient
+{
+    internal static class DatabaseConfigUnity
+    {
+        private const string Host = "76.134.86.9";
+        private const string KimHost = "10.0.0.30";
+        private const string Username = "userclient";
+        private const string Password = "123321";
+        public static bool DebugMode { get; set; }
+        public static bool UseKimServer { get; set; }
+        public static string ConnectionString =>
+            $"Server={(UseKimServer ? KimHost : (DebugMode ? "127.0.0.1" : Host))};Database=accounts;User ID={Username};Password={Password};";
+    }
+}

--- a/docs/ConnectionUsage.md
+++ b/docs/ConnectionUsage.md
@@ -1,0 +1,13 @@
+# Database Connection Usage
+
+The Unity client uses direct MySQL access through the `MySqlConnector` library.
+Connection settings are managed by `DatabaseConfigUnity`, which exposes debug and Kim server toggles
+for switching between local, Kim, and production servers.
+
+All database queries flow through `DatabaseClientUnity`. This wrapper centralizes connection retries
+and parameter handling so services like `CharacterDatabase` and `ChatService` share the same access layer.
+
+## Adding Queries
+
+Store each SQL statement in its own `.sql` file at the repository root. Load the file contents and pass
+it to `DatabaseClientUnity` rather than embedding raw SQL strings in code.

--- a/fetch_latest_chat_message.sql
+++ b/fetch_latest_chat_message.sql
@@ -1,0 +1,1 @@
+SELECT message FROM chat_messages ORDER BY id DESC LIMIT 1;

--- a/get_gold.sql
+++ b/get_gold.sql
@@ -1,0 +1,1 @@
+SELECT gold FROM accounts WHERE id = @id;

--- a/get_party_members.sql
+++ b/get_party_members.sql
@@ -1,0 +1,3 @@
+SELECT name, hp, max_hp, mana, max_mana
+FROM characters
+WHERE is_party_member = 1;


### PR DESCRIPTION
## Summary
- add `DatabaseConfigUnity` with debug and Kim server toggles for direct MySQL access
- introduce `DatabaseClientUnity` to centralize query execution
- load Character and Chat data through shared client using SQL stored in dedicated files
- document database connection usage and SQL conventions

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c8ed4ad8833388f87b0e7f41a134