### PR TITLE
Fix DatabaseConfig connection string syntax

### DIFF
--- a/New Unity Project/Assets/Scripts/DatabaseConfig.cs
+++ b/New Unity Project/Assets/Scripts/DatabaseConfig.cs
@@ -9,7 +9,7 @@ namespace WinFormsApp2
         public static bool DebugMode { get; set; }
         public static bool UseKimServer { get; set; }
         public static string ConnectionString =>
-            $"Server={(UseKimServer ? KimHost : (DebugMode ? \"127.0.0.1\" : Host))};Database=accounts;User ID={Username};Password={Password};";
-
+            $"Server={(UseKimServer ? KimHost : (DebugMode ? "127.0.0.1" : Host))};Database=accounts;User ID={Username};" +
+            $"Password={Password};";
     }
 }


### PR DESCRIPTION
## Summary
- clean up DatabaseConfig so the connection string is built on a single interpolated expression and avoid compiler errors

## Testing
- `csc 'New Unity Project/Assets/Scripts/DatabaseConfig.cs'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d0c7bbec8333ae9200ad24c2a114