### PR TITLE
Add stubs for Unity scripts and remove duplicate ChatService

### DIFF
--- a/New Unity Project/Assets/Scripts/GameModelStubs.cs
+++ b/New Unity Project/Assets/Scripts/GameModelStubs.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+
+namespace WinFormsApp2
+{
+    public enum EquipmentSlot
+    {
+        Weapon,
+        LeftHand,
+        RightHand,
+        Body,
+        Legs,
+        Head,
+        Trinket
+    }
+
+    public class Item
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public bool Stackable { get; set; } = true;
+        public EquipmentSlot? Slot { get; set; }
+        public Dictionary<string, int> FlatBonuses { get; } = new();
+        public Dictionary<string, int> PercentBonuses { get; } = new();
+    }
+
+    public class InventoryItem
+    {
+        public Item Item { get; set; } = new Item();
+        public int Quantity { get; set; }
+    }
+
+    public class Weapon : Item
+    {
+        public double StrScaling { get; set; }
+        public double DexScaling { get; set; }
+        public double IntScaling { get; set; }
+        public double MinMultiplier { get; set; }
+        public double MaxMultiplier { get; set; }
+        public double CritChanceBonus { get; set; }
+        public double CritDamageBonus { get; set; }
+    }
+
+    public class Armor : Item { }
+
+    public class Trinket : Item
+    {
+        public Dictionary<string, double> Effects { get; } = new();
+    }
+
+    public class HealingPotion : Item
+    {
+        public int HealAmount { get; set; }
+    }
+
+    public class AbilityTome : Item
+    {
+        public int AbilityId { get; }
+        public AbilityTome() {}
+        public AbilityTome(int id) { AbilityId = id; }
+    }
+
+    public static class LootPool
+    {
+        public static List<Item> GetShopStock(string pool) => new();
+    }
+
+    public class MailItem
+    {
+        public int Id { get; set; }
+        public string Subject { get; set; } = string.Empty;
+        public string Body { get; set; } = string.Empty;
+        public DateTime SentAt { get; set; }
+    }
+
+    public static class MailService
+    {
+        public static List<MailItem> GetUnread(int accountId) => new();
+        public static void SendMail(int? senderId, int recipientId, string subject, string body) { }
+    }
+}

--- a/New Unity Project/Assets/Scripts/MySqlStubs.cs
+++ b/New Unity Project/Assets/Scripts/MySqlStubs.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace MySql.Data.MySqlClient
+{
+    public class MySqlConnection : IDisposable, IAsyncDisposable
+    {
+        public MySqlConnection(string connectionString) { }
+        public void Open() { }
+        public Task OpenAsync() => Task.CompletedTask;
+        public void Close() { }
+        public void Dispose() { }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    public class MySqlParameterCollection
+    {
+        public void AddWithValue(string parameterName, object? value) { }
+    }
+
+    public class MySqlCommand : IDisposable, IAsyncDisposable
+    {
+        public MySqlCommand(string commandText, MySqlConnection connection) { Parameters = new MySqlParameterCollection(); }
+        public MySqlParameterCollection Parameters { get; }
+        public long LastInsertedId { get; set; }
+        public int ExecuteNonQuery() => 0;
+        public Task<int> ExecuteNonQueryAsync() => Task.FromResult(0);
+        public object? ExecuteScalar() => null;
+        public MySqlDataReader ExecuteReader() => new MySqlDataReader();
+        public Task<MySqlDataReader> ExecuteReaderAsync() => Task.FromResult(new MySqlDataReader());
+        public void Dispose() { }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    public class MySqlDataReader : IDisposable, IAsyncDisposable
+    {
+        public int FieldCount => 0;
+        public void Dispose() { }
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public bool Read() => false;
+        public Task<bool> ReadAsync() => Task.FromResult(false);
+        public string GetString(string name) => string.Empty;
+        public int GetInt32(string name) => 0;
+        public DateTime GetDateTime(string name) => DateTime.MinValue;
+        public bool IsDBNull(int ordinal) => true;
+        public Task<bool> IsDBNullAsync(int ordinal) => Task.FromResult(true);
+        public string GetName(int i) => string.Empty;
+        public object? GetValue(int i) => null;
+        public void Close() { }
+    }
+
+    public class MySqlException : Exception
+    {
+        public MySqlException() { }
+    }
+}
+
+namespace MySqlConnector
+{
+    using MySql.Data.MySqlClient;
+
+    public class MySqlConnection : MySql.Data.MySqlClient.MySqlConnection
+    {
+        public MySqlConnection(string cs) : base(cs) { }
+    }
+
+    public class MySqlCommand : MySql.Data.MySqlClient.MySqlCommand
+    {
+        public MySqlCommand(string cmdText, MySqlConnection conn) : base(cmdText, conn) { }
+    }
+
+    public class MySqlDataReader : MySql.Data.MySqlClient.MySqlDataReader { }
+
+    public class MySqlException : Exception
+    {
+        public MySqlException() { }
+    }
+}

--- a/New Unity Project/Assets/Scripts/RPGManager.cs
+++ b/New Unity Project/Assets/Scripts/RPGManager.cs
@@ -147,13 +147,3 @@ public static class CharacterDatabase
         return rows.Count > 0 && rows[0].TryGetValue("gold", out var g) ? Convert.ToInt32(g) : 0;
     }
 }
-
-public static class ChatService
-{
-    public static string? FetchNewMessage()
-    {
-        string sqlPath = Path.Combine(AppContext.BaseDirectory, "fetch_latest_chat_message.sql");
-        var rows = DatabaseClientUnity.QueryAsync(File.ReadAllText(sqlPath)).GetAwaiter().GetResult();
-        return rows.Count > 0 ? Convert.ToString(rows[0]["message"]) : null;
-    }
-}


### PR DESCRIPTION
## Summary
- remove duplicate `ChatService` definition from `RPGManager`
- add lightweight model stubs for items, inventory, equipment, and mail used by Unity scripts
- stub out minimal `MySql` connector classes so Unity code compiles without external packages

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d5dac7d483338db21716ce3580a6