### PR TITLE
Fix Unity stubs and missing service references

### DIFF
--- a/New Unity Project/Assets/Scripts/LoginManager.cs
+++ b/New Unity Project/Assets/Scripts/LoginManager.cs
@@ -176,7 +176,7 @@ public class LoginManager : MonoBehaviour
                 await DatabaseClientUnity.ExecuteAsync(
                     "UPDATE accounts SET last_seen = NOW() WHERE id = @id",
                     new Dictionary<string, object?> { ["@id"] = userId });
-                InventoryService.Load(userId);
+                InventoryServiceUnity.Load(userId);
                 SceneManager.LoadScene("RPG");
             }
         }

--- a/New Unity Project/Assets/Scripts/MySqlStubs.cs
+++ b/New Unity Project/Assets/Scripts/MySqlStubs.cs
@@ -11,7 +11,7 @@ namespace MySql.Data.MySqlClient
         public Task OpenAsync() => Task.CompletedTask;
         public void Close() { }
         public void Dispose() { }
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => default;
     }
 
     public class MySqlParameterCollection
@@ -30,14 +30,14 @@ namespace MySql.Data.MySqlClient
         public MySqlDataReader ExecuteReader() => new MySqlDataReader();
         public Task<MySqlDataReader> ExecuteReaderAsync() => Task.FromResult(new MySqlDataReader());
         public void Dispose() { }
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => default;
     }
 
     public class MySqlDataReader : IDisposable, IAsyncDisposable
     {
         public int FieldCount => 0;
         public void Dispose() { }
-        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => default;
         public bool Read() => false;
         public Task<bool> ReadAsync() => Task.FromResult(false);
         public string GetString(string name) => string.Empty;

--- a/New Unity Project/Assets/Scripts/TavernServiceUnity.cs
+++ b/New Unity Project/Assets/Scripts/TavernServiceUnity.cs
@@ -1,0 +1,14 @@
+using WinFormsApp2;
+
+namespace WinFormsApp2
+{
+    /// <summary>
+    /// Unity stub for TavernService; provides no-op notification methods
+    /// so UI scripts can compile without the server-side implementation.
+    /// </summary>
+    public static class TavernService
+    {
+        public static void NotifyPartyHired(int ownerId) { }
+        public static void NotifyPartyReturned(int ownerId) { }
+    }
+}

--- a/New Unity Project/Assets/Scripts/TavernServiceUnity.cs.meta
+++ b/New Unity Project/Assets/Scripts/TavernServiceUnity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3688c36c91b43dfbd82d6f325035cac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Replace ValueTask.CompletedTask with default in MySql stubs for compatibility
- Load inventory via InventoryServiceUnity after login
- Add TavernService stub for Unity UI

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj -c Release` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b89b925b7083339cdb019d562096a5