### PR TITLE
Use preplaced UI elements

### DIFF
--- a/New Unity Project/Assets/Scripts/InventoryUI.cs
+++ b/New Unity Project/Assets/Scripts/InventoryUI.cs
@@ -9,8 +9,7 @@ using MySql.Data.MySqlClient;
 
 public class InventoryUI : MonoBehaviour
 {
-    [SerializeField] private Transform itemListContent = null!;
-    [SerializeField] private GameObject itemEntryPrefab = null!;
+    [SerializeField] private List<GameObject> itemEntrySlots = new();
     [SerializeField] private Text descriptionText = null!;
     [SerializeField] private Dropdown targetDropdown = null!;
     [SerializeField] private Button useButton = null!;
@@ -30,27 +29,34 @@ public class InventoryUI : MonoBehaviour
 
     private void PopulateItems()
     {
-        foreach (Transform child in itemListContent)
+        for (int i = 0; i < itemEntrySlots.Count; i++)
         {
-            Destroy(child.gameObject);
-        }
-        foreach (var inv in InventoryServiceUnity.Items)
-        {
-            var go = Instantiate(itemEntryPrefab, itemListContent);
-            var label = go.GetComponentInChildren<Text>();
-            string suffix = inv.Item.Stackable ? $" x{inv.Quantity}" : string.Empty;
-            label.text = inv.Item.Name + suffix;
-            var button = go.GetComponent<Button>();
-            var current = inv;
-            button.onClick.AddListener(() => OnItemSelected(current));
+            var go = itemEntrySlots[i];
+            if (i < InventoryServiceUnity.Items.Count)
+            {
+                go.SetActive(true);
+                var inv = InventoryServiceUnity.Items[i];
+                var label = go.GetComponentInChildren<Text>();
+                string suffix = inv.Item.Stackable ? $" x{inv.Quantity}" : string.Empty;
+                label.text = inv.Item.Name + suffix;
+                var button = go.GetComponent<Button>();
+                var current = inv;
+                button.onClick.RemoveAllListeners();
+                button.onClick.AddListener(() => OnItemSelected(current));
 
-            var trigger = go.GetComponent<EventTrigger>() ?? go.AddComponent<EventTrigger>();
-            var enter = new EventTrigger.Entry { eventID = EventTriggerType.PointerEnter };
-            enter.callback.AddListener(_ => tooltipText.text = DescribeItem(current.Item));
-            trigger.triggers.Add(enter);
-            var exit = new EventTrigger.Entry { eventID = EventTriggerType.PointerExit };
-            exit.callback.AddListener(_ => tooltipText.text = string.Empty);
-            trigger.triggers.Add(exit);
+                var trigger = go.GetComponent<EventTrigger>() ?? go.AddComponent<EventTrigger>();
+                trigger.triggers.Clear();
+                var enter = new EventTrigger.Entry { eventID = EventTriggerType.PointerEnter };
+                enter.callback.AddListener(_ => tooltipText.text = DescribeItem(current.Item));
+                trigger.triggers.Add(enter);
+                var exit = new EventTrigger.Entry { eventID = EventTriggerType.PointerExit };
+                exit.callback.AddListener(_ => tooltipText.text = string.Empty);
+                trigger.triggers.Add(exit);
+            }
+            else
+            {
+                go.SetActive(false);
+            }
         }
         OnItemSelected(null);
     }

--- a/New Unity Project/Assets/Scripts/RPGManager.cs
+++ b/New Unity Project/Assets/Scripts/RPGManager.cs
@@ -10,8 +10,7 @@ using UnityEngine.UI;
 public class RPGManager : MonoBehaviour
 {
     [Header("UI References")]
-    [SerializeField] private Transform partyListContent;
-    [SerializeField] private GameObject partyMemberPrefab;
+    [SerializeField] private List<GameObject> partyMemberEntries = new();
     [SerializeField] private Text goldText;
     [SerializeField] private Text chatText;
 
@@ -37,34 +36,38 @@ public class RPGManager : MonoBehaviour
 
     private void PopulatePartyList()
     {
-        if (partyListContent == null || partyMemberPrefab == null)
+        if (partyMemberEntries == null || partyMemberEntries.Count == 0)
         {
             return;
         }
 
-        foreach (Transform child in partyListContent)
+        for (int i = 0; i < partyMemberEntries.Count; i++)
         {
-            Destroy(child.gameObject);
-        }
-
-        foreach (var member in partyMembers)
-        {
-            var go = GameObject.Instantiate(partyMemberPrefab, partyListContent);
-            go.name = member.Name;
-
-            var texts = go.GetComponentsInChildren<Text>();
-            foreach (var t in texts)
+            var go = partyMemberEntries[i];
+            if (i < partyMembers.Count)
             {
-                if (t.gameObject.name == "NameText")
+                go.SetActive(true);
+                var member = partyMembers[i];
+                go.name = member.Name;
+
+                var texts = go.GetComponentsInChildren<Text>();
+                foreach (var t in texts)
                 {
-                    t.text = member.Name;
+                    if (t.gameObject.name == "NameText")
+                    {
+                        t.text = member.Name;
+                    }
+                }
+
+                var bar = go.GetComponentInChildren<ColoredProgressBar>();
+                if (bar != null)
+                {
+                    bar.SetValue(member.HP / (float)member.MaxHP, member.Mana / (float)member.MaxMana);
                 }
             }
-
-            var bar = go.GetComponentInChildren<ColoredProgressBar>();
-            if (bar != null)
+            else
             {
-                bar.SetValue(member.HP / (float)member.MaxHP, member.Mana / (float)member.MaxMana);
+                go.SetActive(false);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Remove runtime UI instantiation in `RPGManager` and `InventoryUI`
- Reference preplaced UI elements via serialized lists

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b89e4dc58883339019530509819f5e