### PR TITLE
Implement arena challenge and deposit logic

### DIFF
--- a/New Unity Project/Assets/Scripts/UI/ArenaPanel.cs
+++ b/New Unity Project/Assets/Scripts/UI/ArenaPanel.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using UnityEngine;
 using WinFormsApp2;
 
@@ -6,14 +7,60 @@ using WinFormsApp2;
 /// </summary>
 public class ArenaPanel : MonoBehaviour
 {
+    private bool _deposited;
+
     public void OnDeposit()
     {
-        // Placeholder: deposit/withdraw team logic using InventoryServiceUnity
+        // Simple deposit/withdraw logic using the shared inventory service.
+        // Depositing will consume an "Arena Coin" if present, withdrawing will add one back.
+        InventoryServiceUnity.Load(1); // ensure inventory is loaded
+        if (_deposited)
+        {
+            // Withdraw: return a coin to the player's inventory.
+            InventoryServiceUnity.AddItem(new ArenaCoin());
+            Debug.Log("Team withdrawn from arena.");
+            _deposited = false;
+        }
+        else
+        {
+            var coin = InventoryServiceUnity.Items.FirstOrDefault(i => i.Item.Name == "Arena Coin");
+            if (coin == null)
+            {
+                Debug.LogWarning("No Arena Coin available to deposit.");
+                return;
+            }
+            InventoryServiceUnity.RemoveItem(coin.Item);
+            Debug.Log("Team deposited to arena.");
+            _deposited = true;
+        }
     }
 
-    public void OnChallenge()
+    public async void OnChallenge()
     {
-        // Placeholder: challenge logic that would invoke BattleForm
+        // Challenge the arena using the ArenaManager and report the outcome to the player.
+        var mgr = FindObjectOfType<ArenaManager>();
+        if (mgr == null)
+        {
+            Debug.LogError("ArenaManager not found.");
+            return;
+        }
+
+        string? result = null;
+        try
+        {
+            result = await mgr.ChallengeAsync(1);
+        }
+        catch (System.Exception ex)
+        {
+            Debug.LogError($"Challenge failed: {ex.Message}");
+        }
+
+        if (string.IsNullOrEmpty(result))
+            Debug.LogError("No result returned from arena challenge.");
+        else
+            Debug.Log($"Battle result: {result}");
+
+        BackToMain();
     }
 
     public void BackToMain() => MainRPGNavigation.OpenMain();


### PR DESCRIPTION
## Summary
- Implement deposit/withdraw behavior on the arena panel via inventory service
- Hook arena challenge button to ArenaManager and display results

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a13910088333ae4408ab06bf6b20