### PR TITLE
Expose UI references for custom layouts

### DIFF
--- a/New Unity Project/Assets/Scripts/ColoredProgressBar.cs
+++ b/New Unity Project/Assets/Scripts/ColoredProgressBar.cs
@@ -3,8 +3,8 @@ using UnityEngine.UI;
 
 public class ColoredProgressBar : MonoBehaviour
 {
-    [SerializeField] private Image hpFill;
-    [SerializeField] private Image manaFill;
+    public Image hpFill;
+    public Image manaFill;
 
     public void SetValue(float hpPercent, float manaPercent)
     {

--- a/New Unity Project/Assets/Scripts/InventoryUI.cs
+++ b/New Unity Project/Assets/Scripts/InventoryUI.cs
@@ -9,12 +9,12 @@ using MySql.Data.MySqlClient;
 
 public class InventoryUI : MonoBehaviour
 {
-    [SerializeField] private List<GameObject> itemEntrySlots = new();
-    [SerializeField] private Text descriptionText = null!;
-    [SerializeField] private Dropdown targetDropdown = null!;
-    [SerializeField] private Button useButton = null!;
-    [SerializeField] private Text tooltipText = null!;
-    [SerializeField] private int userId;
+    public List<GameObject> itemEntrySlots = new();
+    public Text descriptionText = null!;
+    public Dropdown targetDropdown = null!;
+    public Button useButton = null!;
+    public Text tooltipText = null!;
+    public int userId;
 
     private InventoryItem? selectedItem;
 

--- a/New Unity Project/Assets/Scripts/LoginManager.cs
+++ b/New Unity Project/Assets/Scripts/LoginManager.cs
@@ -5,7 +5,6 @@ using System.Text;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
-using UnityEngine.EventSystems;
 using WinFormsApp2;
 
 public class LoginManager : MonoBehaviour
@@ -19,127 +18,10 @@ public class LoginManager : MonoBehaviour
 
     private void Start()
     {
-        if (usernameField == null || passwordField == null ||
-            debugServerToggle == null || kimServerToggle == null ||
-            loginButton == null || createAccountButton == null)
-        {
-            CreateDefaultUI();
-        }
-
         if (loginButton != null)
             loginButton.onClick.AddListener(OnLoginClicked);
         if (createAccountButton != null)
             createAccountButton.onClick.AddListener(OnCreateAccountClicked);
-    }
-
-    private void CreateDefaultUI()
-    {
-        var canvasGO = new GameObject("Canvas", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
-        var canvas = canvasGO.GetComponent<Canvas>();
-        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
-
-        if (FindObjectOfType<EventSystem>() == null)
-        {
-            new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
-        }
-
-        usernameField = CreateInputField(canvas.transform, "Username", new Vector2(0, 60));
-        passwordField = CreateInputField(canvas.transform, "Password", new Vector2(0, 0));
-        debugServerToggle = CreateToggle(canvas.transform, "Debug Server", new Vector2(-80, -60));
-        kimServerToggle = CreateToggle(canvas.transform, "Kim Server", new Vector2(80, -60));
-        loginButton = CreateButton(canvas.transform, "Login", new Vector2(-60, -120));
-        createAccountButton = CreateButton(canvas.transform, "Create Account", new Vector2(60, -120));
-    }
-
-    private InputField CreateInputField(Transform parent, string placeholder, Vector2 position)
-    {
-        var go = new GameObject(placeholder + "Input", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(InputField));
-        var rt = go.GetComponent<RectTransform>();
-        rt.SetParent(parent);
-        rt.sizeDelta = new Vector2(160, 30);
-        rt.anchoredPosition = position;
-
-        var textGO = new GameObject("Text", typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
-        var textRT = textGO.GetComponent<RectTransform>();
-        textRT.SetParent(go.transform);
-        textRT.anchorMin = new Vector2(0, 0);
-        textRT.anchorMax = new Vector2(1, 1);
-        textRT.offsetMin = Vector2.zero;
-        textRT.offsetMax = Vector2.zero;
-        var text = textGO.GetComponent<Text>();
-        text.text = "";
-        text.color = Color.black;
-
-        var placeholderGO = new GameObject("Placeholder", typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
-        var placeholderRT = placeholderGO.GetComponent<RectTransform>();
-        placeholderRT.SetParent(go.transform);
-        placeholderRT.anchorMin = new Vector2(0, 0);
-        placeholderRT.anchorMax = new Vector2(1, 1);
-        placeholderRT.offsetMin = Vector2.zero;
-        placeholderRT.offsetMax = Vector2.zero;
-        var placeholderText = placeholderGO.GetComponent<Text>();
-        placeholderText.text = placeholder;
-        placeholderText.color = new Color(0.5f, 0.5f, 0.5f);
-
-        var input = go.GetComponent<InputField>();
-        input.textComponent = text;
-        input.placeholder = placeholderText;
-        return input;
-    }
-
-    private Toggle CreateToggle(Transform parent, string label, Vector2 position)
-    {
-        var go = new GameObject(label + "Toggle", typeof(RectTransform), typeof(CanvasRenderer), typeof(Toggle));
-        var rt = go.GetComponent<RectTransform>();
-        rt.SetParent(parent);
-        rt.sizeDelta = new Vector2(160, 20);
-        rt.anchoredPosition = position;
-
-        var bg = new GameObject("Background", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
-        var bgRT = bg.GetComponent<RectTransform>();
-        bgRT.SetParent(go.transform);
-        bgRT.sizeDelta = new Vector2(20, 20);
-        bgRT.anchoredPosition = new Vector2(-70, 0);
-        var checkmark = new GameObject("Checkmark", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
-        var cmRT = checkmark.GetComponent<RectTransform>();
-        cmRT.SetParent(bg.transform);
-        cmRT.sizeDelta = new Vector2(20, 20);
-
-        var textGO = new GameObject("Label", typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
-        var textRT = textGO.GetComponent<RectTransform>();
-        textRT.SetParent(go.transform);
-        textRT.anchoredPosition = new Vector2(10, 0);
-        var text = textGO.GetComponent<Text>();
-        text.text = label;
-        text.color = Color.black;
-
-        var toggle = go.GetComponent<Toggle>();
-        toggle.graphic = checkmark.GetComponent<Image>();
-        toggle.targetGraphic = bg.GetComponent<Image>();
-        return toggle;
-    }
-
-    private Button CreateButton(Transform parent, string label, Vector2 position)
-    {
-        var go = new GameObject(label + "Button", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button));
-        var rt = go.GetComponent<RectTransform>();
-        rt.SetParent(parent);
-        rt.sizeDelta = new Vector2(120, 30);
-        rt.anchoredPosition = position;
-
-        var textGO = new GameObject("Text", typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
-        var textRT = textGO.GetComponent<RectTransform>();
-        textRT.SetParent(go.transform);
-        textRT.anchorMin = new Vector2(0, 0);
-        textRT.anchorMax = new Vector2(1, 1);
-        textRT.offsetMin = Vector2.zero;
-        textRT.offsetMax = Vector2.zero;
-        var text = textGO.GetComponent<Text>();
-        text.text = label;
-        text.alignment = TextAnchor.MiddleCenter;
-        text.color = Color.black;
-
-        return go.GetComponent<Button>();
     }
 
     private void OnDestroy()

--- a/New Unity Project/Assets/Scripts/RPGManager.cs
+++ b/New Unity Project/Assets/Scripts/RPGManager.cs
@@ -10,9 +10,9 @@ using UnityEngine.UI;
 public class RPGManager : MonoBehaviour
 {
     [Header("UI References")]
-    [SerializeField] private List<GameObject> partyMemberEntries = new();
-    [SerializeField] private Text goldText;
-    [SerializeField] private Text chatText;
+    public List<GameObject> partyMemberEntries = new();
+    public Text goldText;
+    public Text chatText;
 
     private List<CharacterData> partyMembers = new List<CharacterData>();
 

--- a/New Unity Project/Assets/Scripts/RegisterManager.cs
+++ b/New Unity Project/Assets/Scripts/RegisterManager.cs
@@ -4,7 +4,6 @@ using System.Security.Cryptography;
 using System.Text;
 using MySql.Data.MySqlClient;
 using UnityEngine;
-using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using WinFormsApp2;
@@ -21,13 +20,6 @@ public class RegisterManager : MonoBehaviour
 
     private void Start()
     {
-        if (usernameField == null || nicknameField == null || passwordField == null ||
-            confirmPasswordField == null || debugServerToggle == null || kimServerToggle == null ||
-            registerButton == null)
-        {
-            CreateDefaultUI();
-        }
-
         if (registerButton != null)
             registerButton.onClick.AddListener(OnRegisterClicked);
     }
@@ -36,119 +28,6 @@ public class RegisterManager : MonoBehaviour
     {
         if (registerButton != null)
             registerButton.onClick.RemoveListener(OnRegisterClicked);
-    }
-
-    private void CreateDefaultUI()
-    {
-        var canvasGO = new GameObject("Canvas", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
-        var canvas = canvasGO.GetComponent<Canvas>();
-        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
-
-        if (FindObjectOfType<EventSystem>() == null)
-        {
-            new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
-        }
-
-        usernameField = CreateInputField(canvas.transform, "Username", new Vector2(0, 90));
-        nicknameField = CreateInputField(canvas.transform, "Nickname", new Vector2(0, 50));
-        passwordField = CreateInputField(canvas.transform, "Password", new Vector2(0, 10));
-        passwordField.contentType = InputField.ContentType.Password;
-        confirmPasswordField = CreateInputField(canvas.transform, "Confirm Password", new Vector2(0, -30));
-        confirmPasswordField.contentType = InputField.ContentType.Password;
-        debugServerToggle = CreateToggle(canvas.transform, "Debug Server", new Vector2(-80, -70));
-        kimServerToggle = CreateToggle(canvas.transform, "Kim Server", new Vector2(80, -70));
-        registerButton = CreateButton(canvas.transform, "Register", new Vector2(0, -120));
-    }
-
-    private InputField CreateInputField(Transform parent, string placeholder, Vector2 position)
-    {
-        var go = new GameObject(placeholder + "Input", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(InputField));
-        var rt = go.GetComponent<RectTransform>();
-        rt.SetParent(parent);
-        rt.sizeDelta = new Vector2(200, 30);
-        rt.anchoredPosition = position;
-
-        var textGO = new GameObject("Text", typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
-        var textRT = textGO.GetComponent<RectTransform>();
-        textRT.SetParent(go.transform);
-        textRT.anchorMin = new Vector2(0, 0);
-        textRT.anchorMax = new Vector2(1, 1);
-        textRT.offsetMin = Vector2.zero;
-        textRT.offsetMax = Vector2.zero;
-        var text = textGO.GetComponent<Text>();
-        text.text = "";
-        text.color = Color.black;
-
-        var placeholderGO = new GameObject("Placeholder", typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
-        var placeholderRT = placeholderGO.GetComponent<RectTransform>();
-        placeholderRT.SetParent(go.transform);
-        placeholderRT.anchorMin = new Vector2(0, 0);
-        placeholderRT.anchorMax = new Vector2(1, 1);
-        placeholderRT.offsetMin = Vector2.zero;
-        placeholderRT.offsetMax = Vector2.zero;
-        var placeholderText = placeholderGO.GetComponent<Text>();
-        placeholderText.text = placeholder;
-        placeholderText.color = new Color(0.5f, 0.5f, 0.5f);
-
-        var input = go.GetComponent<InputField>();
-        input.textComponent = text;
-        input.placeholder = placeholderText;
-        return input;
-    }
-
-    private Toggle CreateToggle(Transform parent, string label, Vector2 position)
-    {
-        var go = new GameObject(label + "Toggle", typeof(RectTransform), typeof(CanvasRenderer), typeof(Toggle));
-        var rt = go.GetComponent<RectTransform>();
-        rt.SetParent(parent);
-        rt.sizeDelta = new Vector2(160, 20);
-        rt.anchoredPosition = position;
-
-        var bg = new GameObject("Background", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
-        var bgRT = bg.GetComponent<RectTransform>();
-        bgRT.SetParent(go.transform);
-        bgRT.sizeDelta = new Vector2(20, 20);
-        bgRT.anchoredPosition = new Vector2(-70, 0);
-        var checkmark = new GameObject("Checkmark", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
-        var cmRT = checkmark.GetComponent<RectTransform>();
-        cmRT.SetParent(bg.transform);
-        cmRT.sizeDelta = new Vector2(20, 20);
-
-        var textGO = new GameObject("Label", typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
-        var textRT = textGO.GetComponent<RectTransform>();
-        textRT.SetParent(go.transform);
-        textRT.anchoredPosition = new Vector2(10, 0);
-        var text = textGO.GetComponent<Text>();
-        text.text = label;
-        text.color = Color.black;
-
-        var toggle = go.GetComponent<Toggle>();
-        toggle.graphic = checkmark.GetComponent<Image>();
-        toggle.targetGraphic = bg.GetComponent<Image>();
-        return toggle;
-    }
-
-    private Button CreateButton(Transform parent, string label, Vector2 position)
-    {
-        var go = new GameObject(label + "Button", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button));
-        var rt = go.GetComponent<RectTransform>();
-        rt.SetParent(parent);
-        rt.sizeDelta = new Vector2(120, 30);
-        rt.anchoredPosition = position;
-
-        var textGO = new GameObject("Text", typeof(RectTransform), typeof(CanvasRenderer), typeof(Text));
-        var textRT = textGO.GetComponent<RectTransform>();
-        textRT.SetParent(go.transform);
-        textRT.anchorMin = new Vector2(0, 0);
-        textRT.anchorMax = new Vector2(1, 1);
-        textRT.offsetMin = Vector2.zero;
-        textRT.offsetMax = Vector2.zero;
-        var text = textGO.GetComponent<Text>();
-        text.text = label;
-        text.alignment = TextAnchor.MiddleCenter;
-        text.color = Color.black;
-
-        return go.GetComponent<Button>();
     }
 
     private void OnRegisterClicked()

--- a/New Unity Project/Assets/Scripts/SceneSetup.cs
+++ b/New Unity Project/Assets/Scripts/SceneSetup.cs
@@ -44,15 +44,6 @@ public static class SceneSetup
             return;
 
         var canvases = Object.FindObjectsOfType<Canvas>();
-        if (canvases.Length == 0)
-        {
-            var canvasGO = GameObject.Find("Canvas") ?? new GameObject("Canvas");
-            var canvas = canvasGO.AddComponent<Canvas>();
-            canvas.renderMode = RenderMode.ScreenSpaceCamera;
-            canvas.worldCamera = mainCamera;
-            canvases = new[] { canvas };
-        }
-
         foreach (var canvas in canvases)
         {
             if ((canvas.renderMode == RenderMode.ScreenSpaceCamera ||


### PR DESCRIPTION
## Summary
- Expose UI component references in gameplay scripts
- Remove automatic UI creation from login and registration managers
- Simplify scene setup to only configure existing canvases

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a1bfe6ac8333aad3469f5479f1dd