### PR TITLE
Add IsExternalInit stub for Unity

### DIFF
--- a/New Unity Project/Assets/Scripts/IsExternalInit.cs
+++ b/New Unity Project/Assets/Scripts/IsExternalInit.cs
@@ -1,0 +1,4 @@
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit {}
+}

--- a/New Unity Project/Assets/Scripts/IsExternalInit.cs.meta
+++ b/New Unity Project/Assets/Scripts/IsExternalInit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8059802234474a43a305ffe557a8b35a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add IsExternalInit stub so init-only properties compile in Unity

## Testing
- `dotnet test 'WinFormsApp2/BattleLands.sln'` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a900b9748333b5c4b2de4643d289