### PR TITLE
Add IsExternalInit stub and resolve Unity compile errors

### DIFF
--- a/New Unity Project/Assets/Scripts/GameModelStubs.cs
+++ b/New Unity Project/Assets/Scripts/GameModelStubs.cs
@@ -100,6 +100,17 @@ namespace WinFormsApp2
         }
     }
 
+    public class ArenaCoin : Item
+    {
+        public ArenaCoin()
+        {
+            Name = "Arena Coin";
+            Description = "A token earned in the battle arena. Sell for 200 gold.";
+            Stackable = true;
+            Price = 200;
+        }
+    }
+
     public class AbilityTome : Item
     {
         public int AbilityId { get; }

--- a/New Unity Project/Assets/Scripts/InventoryServiceUnity.cs
+++ b/New Unity Project/Assets/Scripts/InventoryServiceUnity.cs
@@ -76,15 +76,10 @@ namespace WinFormsApp2
                 string abilityName = name.Substring(6);
                 var ability = GetAbilityAsync(abilityName).GetAwaiter().GetResult();
                 if (ability != null)
-                    return new AbilityTome(ability.Value.id)
-                    {
-                        Name = name,
-                        Description = ability.Value.description,
-                        Stackable = false
-                    };
+                    return new AbilityTome(ability.Value.id, abilityName, ability.Value.description);
             }
 
-            return new Item { Name = name, Description = string.Empty, Stackable = true };
+            return new GenericItem { Name = name, Description = string.Empty, Stackable = true };
         }
 
         public static void AddItem(Item item, int qty = 1)
@@ -236,5 +231,7 @@ namespace WinFormsApp2
             public int id;
             public string description = string.Empty;
         }
+
+        private class GenericItem : Item { }
     }
 }

--- a/New Unity Project/Assets/Scripts/IsExternalInit.cs
+++ b/New Unity Project/Assets/Scripts/IsExternalInit.cs
@@ -1,0 +1,4 @@
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit {}
+}

--- a/New Unity Project/Assets/Scripts/IsExternalInit.cs.meta
+++ b/New Unity Project/Assets/Scripts/IsExternalInit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8059802234474a43a305ffe557a8b35a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/New Unity Project/Assets/Scripts/RegisterManager.cs
+++ b/New Unity Project/Assets/Scripts/RegisterManager.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using UnityEngine.Networking;
+using UnityEngine.EventSystems;
 using WinFormsApp2;
 
 public class RegisterManager : MonoBehaviour


### PR DESCRIPTION
## Summary
- add IsExternalInit stub so init-only properties compile in Unity
- import UnityEngine.EventSystems in RegisterManager for EventSystem usage
- stub ArenaCoin item and fix AbilityTome creation with a concrete fallback item

## Testing
- `dotnet test 'WinFormsApp2/BattleLands.sln'` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a900b9748333b5c4b2de4643d289