### PR TITLE
Add logging and Unity config to DatabaseClientUnity

### DIFF
--- a/New Unity Project/Assets/Scripts/DatabaseClientUnity.cs
+++ b/New Unity Project/Assets/Scripts/DatabaseClientUnity.cs
@@ -3,7 +3,8 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using MySqlConnector;
 
-using WinFormsApp2;
+using UnityClient;
+using UnityEngine;
 
 public static class DatabaseClientUnity
 {
@@ -16,8 +17,10 @@ public static class DatabaseClientUnity
         {
             try
             {
-                var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+                Debug.Log($"Attempting to open MySQL connection (Attempt {attempt + 1})");
+                var conn = new MySqlConnection(DatabaseConfigUnity.ConnectionString);
                 await conn.OpenAsync();
+                Debug.Log($"Database connection established on attempt {attempt + 1}");
                 return conn;
             }
             catch (MySqlException) when (attempt < MaxRetries)
@@ -31,6 +34,7 @@ public static class DatabaseClientUnity
     public static async Task<List<Dictionary<string, object?>>> QueryAsync(string sql, Dictionary<string, object?>? parameters = null)
     {
         await using var conn = await OpenConnectionAsync();
+        Debug.Log($"Executing SQL query: {sql}");
         await using var cmd = new MySqlCommand(sql, conn);
         AddParameters(cmd, parameters);
         var results = new List<Dictionary<string, object?>>();
@@ -44,15 +48,19 @@ public static class DatabaseClientUnity
             }
             results.Add(row);
         }
+        Debug.Log($"Query returned {results.Count} rows.");
         return results;
     }
 
     public static async Task<int> ExecuteAsync(string sql, Dictionary<string, object?>? parameters = null)
     {
         await using var conn = await OpenConnectionAsync();
+        Debug.Log($"Executing SQL command: {sql}");
         await using var cmd = new MySqlCommand(sql, conn);
         AddParameters(cmd, parameters);
-        return await cmd.ExecuteNonQueryAsync();
+        var rows = await cmd.ExecuteNonQueryAsync();
+        Debug.Log($"Command affected {rows} rows.");
+        return rows;
     }
 
     private static void AddParameters(MySqlCommand cmd, Dictionary<string, object?>? parameters)


### PR DESCRIPTION
## Summary
- switch DatabaseClientUnity to UnityClient namespace and config
- add Debug.Log statements for connection attempts, queries, and commands

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b66c01408333a06137f6bf65f130