### PR TITLE
Use DatabaseClientUnity for direct Unity login

### DIFF
--- a/unity_direct_login.sql
+++ b/unity_direct_login.sql
@@ -1,0 +1,2 @@
+-- Query used by Unity LoginManager for direct database authentication
+SELECT id, nickname FROM accounts WHERE username = @username AND password_hash = @passwordHash;


### PR DESCRIPTION
## Summary
- Replace UnityWebRequest-based login with DatabaseClientUnity.QueryAsync
- Add SQL query for direct Unity login

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b66d3724833392ea065f087521fc