### PR TITLE
Use DatabaseClientUnity for registration

### DIFF
--- a/unity_register_user.sql
+++ b/unity_register_user.sql
@@ -1,0 +1,3 @@
+-- Inserts a new account for Unity RegisterManager
+INSERT INTO accounts (username, nickname, password_hash, gold, last_seen)
+VALUES (@username, @nickname, @passwordHash, 300, NOW());


### PR DESCRIPTION
## Summary
- replace REST request in RegisterManager with direct DatabaseClientUnity call
- log registration parameters, insert result, and errors
- add SQL script to create new account from Unity

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b66eec9c83338a0ad94c5a62b1bd