### PR TITLE
Use DatabaseClientUnity for tavern recruitment

### DIFF
--- a/New Unity Project/Assets/Scripts/TavernManager.cs
+++ b/New Unity Project/Assets/Scripts/TavernManager.cs
@@ -1,27 +1,38 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using UnityEngine;
-using UnityEngine.Networking;
-using UnityClient;
 
 /// <summary>
-/// Handles recruiting and tavern interactions via server calls.
+/// Handles recruiting and tavern interactions via direct database calls.
 /// Mirrors TavernForm operations like fetching candidates and hiring.
 /// </summary>
 public class TavernManager : MonoBehaviour
 {
-    private string BaseUrl => DatabaseConfigUnity.ApiBaseUrl;
-
     /// <summary>
     /// Fetch recruit candidates for the account.
     /// </summary>
     public async Task<List<Recruit>> GetCandidatesAsync(int accountId)
     {
-        using var req = UnityWebRequest.Get($"{BaseUrl}/tavern/candidates?accountId={accountId}");
-        await req.SendWebRequest();
-        if (req.result != UnityWebRequest.Result.Success)
-            return new List<Recruit>();
-        return JsonUtility.FromJson<RecruitList>(req.downloadHandler.text).candidates;
+        string sqlPath = Path.Combine(AppContext.BaseDirectory, "unity_tavern_candidates.sql");
+        var rows = await DatabaseClientUnity.QueryAsync(
+            File.ReadAllText(sqlPath),
+            new Dictionary<string, object?> { ["@accountId"] = accountId });
+
+        var list = new List<Recruit>();
+        foreach (var row in rows)
+        {
+            list.Add(new Recruit
+            {
+                id = Convert.ToInt32(row["id"]),
+                name = Convert.ToString(row["name"]) ?? string.Empty,
+                level = Convert.ToInt32(row["level"])
+            });
+        }
+
+        Debug.Log($"Tavern candidates fetched: {list.Count}");
+        return list;
     }
 
     /// <summary>
@@ -29,12 +40,18 @@ public class TavernManager : MonoBehaviour
     /// </summary>
     public async Task<bool> HireAsync(int accountId, int recruitId)
     {
-        var form = new WWWForm();
-        form.AddField("accountId", accountId);
-        form.AddField("recruitId", recruitId);
-        using var req = UnityWebRequest.Post($"{BaseUrl}/tavern/hire", form);
-        await req.SendWebRequest();
-        return req.result == UnityWebRequest.Result.Success;
+        string sqlPath = Path.Combine(AppContext.BaseDirectory, "unity_tavern_hire.sql");
+        int affected = await DatabaseClientUnity.ExecuteAsync(
+            File.ReadAllText(sqlPath),
+            new Dictionary<string, object?>
+            {
+                ["@userId"] = accountId,
+                ["@recruitId"] = recruitId
+            });
+
+        bool success = affected > 0;
+        Debug.Log($"Hire recruit {recruitId} success: {success}");
+        return success;
     }
 
     [System.Serializable]
@@ -45,9 +62,4 @@ public class TavernManager : MonoBehaviour
         public int level;
     }
 
-    [System.Serializable]
-    private class RecruitList
-    {
-        public List<Recruit> candidates;
-    }
 }

--- a/unity_tavern_candidates.sql
+++ b/unity_tavern_candidates.sql
@@ -1,0 +1,5 @@
+-- Fetch recruit candidates available in the tavern
+SELECT id, name, level
+FROM characters
+WHERE in_tavern = 1
+  AND (account_id IS NULL OR account_id = 0);

--- a/unity_tavern_hire.sql
+++ b/unity_tavern_hire.sql
@@ -1,0 +1,6 @@
+-- Assign recruit to the player and remove from tavern
+UPDATE characters
+SET account_id = @userId,
+    in_tavern = 0
+WHERE id = @recruitId
+  AND in_tavern = 1;


### PR DESCRIPTION
## Summary
- fetch recruit candidates and hire them through DatabaseClientUnity instead of web requests
- add SQL scripts for candidate listing and hiring
- log candidate counts and hire success for debugging

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b67648208333a06e9c2dce79712f