### PR TITLE
Use DatabaseClientUnity for mailbox

### DIFF
--- a/unity_mailbox_mark_read.sql
+++ b/unity_mailbox_mark_read.sql
@@ -1,0 +1,3 @@
+-- Mark a mailbox message as read
+UPDATE mailbox SET is_read=1 WHERE id=@messageId;
+

--- a/unity_mailbox_unread.sql
+++ b/unity_mailbox_unread.sql
@@ -1,0 +1,3 @@
+-- Retrieve unread mail for a user
+SELECT id, sender_id, subject, body FROM mailbox WHERE user_id=@accountId AND is_read=0 ORDER BY created DESC;
+


### PR DESCRIPTION
## Summary
- replace HTTP mailbox calls with database queries and logging
- add SQL queries for unread messages and marking messages read

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b677708c833380bf12a3d390c56b