### PR TITLE
Use Unity database config and log item usage

### DIFF
--- a/New Unity Project/Assets/Scripts/DatabaseClientUnity.cs
+++ b/New Unity Project/Assets/Scripts/DatabaseClientUnity.cs
@@ -2,8 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using MySqlConnector;
-
-using WinFormsApp2;
+using UnityClient;
 
 public static class DatabaseClientUnity
 {
@@ -16,7 +15,7 @@ public static class DatabaseClientUnity
         {
             try
             {
-                var conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+                var conn = new MySqlConnection(DatabaseConfigUnity.ConnectionString);
                 await conn.OpenAsync();
                 return conn;
             }

--- a/New Unity Project/Assets/Scripts/InventoryUI.cs
+++ b/New Unity Project/Assets/Scripts/InventoryUI.cs
@@ -6,6 +6,7 @@ using UnityEngine.EventSystems;
 using UnityEngine.UI;
 using TMPro;
 using WinFormsApp2;
+using UnityClient;
 using MySql.Data.MySqlClient;
 
 public class InventoryUI : MonoBehaviour
@@ -103,9 +104,10 @@ public class InventoryUI : MonoBehaviour
         if (selectedItem == null || targetDropdown.value < 0) return;
         string target = targetDropdown.options[targetDropdown.value].text;
         Item item = selectedItem.Item;
+        Debug.Log($"Using {item.Name} on {target}");
         if (item is HealingPotion potion)
         {
-            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfigUnity.ConnectionString);
             conn.Open();
             using MySqlCommand cmd = new MySqlCommand(
                 "UPDATE characters SET current_hp = LEAST(max_hp, current_hp + @heal) " +
@@ -113,13 +115,14 @@ public class InventoryUI : MonoBehaviour
             cmd.Parameters.AddWithValue("@heal", potion.HealAmount);
             cmd.Parameters.AddWithValue("@uid", userId);
             cmd.Parameters.AddWithValue("@name", target);
-            cmd.ExecuteNonQuery();
+            int result = cmd.ExecuteNonQuery();
+            Debug.Log($"SQL rows affected: {result} for {item.Name} on {target}");
             InventoryServiceUnity.RemoveItem(item);
             PopulateItems();
         }
         else if (item is AbilityTome tome)
         {
-            using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
+            using MySqlConnection conn = new MySqlConnection(DatabaseConfigUnity.ConnectionString);
             conn.Open();
             using MySqlCommand cmd = new MySqlCommand(
                 "INSERT IGNORE INTO character_abilities(character_id, ability_id) " +
@@ -127,7 +130,8 @@ public class InventoryUI : MonoBehaviour
             cmd.Parameters.AddWithValue("@aid", tome.AbilityId);
             cmd.Parameters.AddWithValue("@uid", userId);
             cmd.Parameters.AddWithValue("@name", target);
-            cmd.ExecuteNonQuery();
+            int result = cmd.ExecuteNonQuery();
+            Debug.Log($"SQL rows affected: {result} for {item.Name} on {target}");
             InventoryServiceUnity.RemoveItem(item);
             PopulateItems();
         }


### PR DESCRIPTION
## Summary
- switch DatabaseClientUnity to use DatabaseConfigUnity connection
- log selected item, target, and SQL result when using items in InventoryUI

## Testing
- ❌ `dotnet test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b674920c83338bc25b01c05582c2