### PR TITLE
Use database queries for Unity shop

### DIFF
--- a/unity_shop_purchase.sql
+++ b/unity_shop_purchase.sql
@@ -1,0 +1,7 @@
+-- Purchase item and update inventory
+UPDATE users SET gold = gold - @price
+WHERE id = @userId AND gold >= @price;
+INSERT INTO inventory(user_id, item_id, quantity)
+VALUES(@userId, @itemId, 1)
+ON DUPLICATE KEY UPDATE quantity = quantity + 1;
+

--- a/unity_shop_sell.sql
+++ b/unity_shop_sell.sql
@@ -1,0 +1,7 @@
+-- Sell item and update inventory and gold
+UPDATE users SET gold = gold + (@price * @quantity) WHERE id=@userId;
+UPDATE inventory SET quantity = quantity - @quantity
+WHERE user_id=@userId AND item_id=@itemId;
+DELETE FROM inventory
+WHERE user_id=@userId AND item_id=@itemId AND quantity <= 0;
+

--- a/unity_shop_stock.sql
+++ b/unity_shop_stock.sql
@@ -1,0 +1,6 @@
+-- Fetch items for sale at a node
+SELECT s.item_id AS id, i.name, s.price
+FROM shop_stock s
+JOIN items i ON s.item_id = i.id
+WHERE s.node_id = @nodeId;
+


### PR DESCRIPTION
## Summary
- Switch ShopManager to DatabaseClientUnity for stock, purchase, and sell operations
- Add SQL files for shop stock, purchase, and sell queries
- Log item IDs, prices, and transaction results for debugging

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b675458883338f7c346aa22f4c5c