### PR TITLE
Use database client for chat messages

### DIFF
--- a/unity_chat_messages.sql
+++ b/unity_chat_messages.sql
@@ -1,0 +1,4 @@
+SELECT message
+FROM chat_messages
+ORDER BY id DESC
+LIMIT 50;


### PR DESCRIPTION
## Summary
- Replace UnityWebRequest with DatabaseClientUnity in chat service
- Add SQL query for retrieving chat messages
- Log count of messages fetched and any database errors

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b678a9248333b2c0a52dc72215c3