### PR TITLE
Use database client for arena challenges

### DIFF
--- a/unity_arena_challenge.sql
+++ b/unity_arena_challenge.sql
@@ -1,0 +1,4 @@
+-- Updates arena state and logs battles initiated from ArenaManager
+UPDATE characters SET in_arena=1 WHERE account_id=@accountId;
+INSERT INTO arena_battle_logs(attacker_id, defender_id, log)
+VALUES(@accountId, @opponentId, @log);


### PR DESCRIPTION
## Summary
- Replace arena challenge HTTP call with DatabaseClientUnity
- Log challenge start, opponent selection, and result
- Add SQL script to mark arena state and log battles

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b679c4f883339990f2fa84052578