### PR TITLE
Refactor inventory item usage to async DB client

### DIFF
--- a/unity_inventory_use_potion.sql
+++ b/unity_inventory_use_potion.sql
@@ -1,0 +1,3 @@
+-- Heal a character with a potion
+UPDATE characters SET current_hp = LEAST(max_hp, current_hp + @heal)
+WHERE account_id=@uid AND name=@name AND is_dead=0 AND in_arena=0 AND in_tavern=0;

--- a/unity_inventory_use_tome.sql
+++ b/unity_inventory_use_tome.sql
@@ -1,0 +1,3 @@
+-- Grant an ability to a character from a tome
+INSERT IGNORE INTO character_abilities(character_id, ability_id)
+SELECT id, @aid FROM characters WHERE account_id=@uid AND name=@name;


### PR DESCRIPTION
## Summary
- remove direct MySql usage from InventoryUI
- execute potion and tome effects via async DatabaseClientUnity using external SQL files
- add SQL scripts for potion and ability tome usage

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj -p:EnableWindowsTargeting=true` *(fails: Source file '/workspace/ygoCGPTE/WinFormsApp2.Tests/../WinFormsApp2/LootService.Probability.cs' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cf7b96a4833391719fb86d2451cf