### PR TITLE
Remove MySql.Data dependency from Unity project

### DIFF
--- a/New Unity Project/Assets/Scripts/InventoryUI.cs
+++ b/New Unity Project/Assets/Scripts/InventoryUI.cs
@@ -8,7 +8,7 @@ using TMPro;
 using WinFormsApp2;
 
 using UnityClient;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 public class InventoryUI : MonoBehaviour
 {


### PR DESCRIPTION
## Summary
- switch Inventory UI script to MySqlConnector namespace, removing MySql.Data reference

## Testing
- `dotnet build WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cf7d70f083338e7039b9323d73ad