### PR TITLE
Refactor InventoryUI SQL queries into external scripts

### DIFF
--- a/New Unity Project/Assets/Scripts/InventoryUI.cs
+++ b/New Unity Project/Assets/Scripts/InventoryUI.cs
@@ -8,7 +8,7 @@ using TMPro;
 using WinFormsApp2;
 
 using UnityClient;
-using MySql.Data.MySqlClient;
+using System.IO;
 
 public class InventoryUI : MonoBehaviour
 {
@@ -108,30 +108,30 @@ public class InventoryUI : MonoBehaviour
         Debug.Log($"Using {item.Name} on {target}");
         if (item is HealingPotion potion)
         {
-            using MySqlConnection conn = new MySqlConnection(DatabaseConfigUnity.ConnectionString);
-            conn.Open();
-            using MySqlCommand cmd = new MySqlCommand(
-                "UPDATE characters SET current_hp = LEAST(max_hp, current_hp + @heal) " +
-                "WHERE account_id=@uid AND name=@name AND is_dead=0 AND in_arena=0 AND in_tavern=0", conn);
-            cmd.Parameters.AddWithValue("@heal", potion.HealAmount);
-            cmd.Parameters.AddWithValue("@uid", userId);
-            cmd.Parameters.AddWithValue("@name", target);
-            int result = cmd.ExecuteNonQuery();
+            string sqlPath = Path.Combine(AppContext.BaseDirectory, "unity_character_heal.sql");
+            var parameters = new Dictionary<string, object?>
+            {
+                ["@heal"] = potion.HealAmount,
+                ["@uid"] = userId,
+                ["@name"] = target
+            };
+            int result = DatabaseClientUnity.ExecuteAsync(File.ReadAllText(sqlPath), parameters)
+                .GetAwaiter().GetResult();
             Debug.Log($"SQL rows affected: {result} for {item.Name} on {target}");
             InventoryServiceUnity.RemoveItem(item);
             PopulateItems();
         }
         else if (item is AbilityTome tome)
         {
-            using MySqlConnection conn = new MySqlConnection(DatabaseConfigUnity.ConnectionString);
-            conn.Open();
-            using MySqlCommand cmd = new MySqlCommand(
-                "INSERT IGNORE INTO character_abilities(character_id, ability_id) " +
-                "SELECT id, @aid FROM characters WHERE account_id=@uid AND name=@name", conn);
-            cmd.Parameters.AddWithValue("@aid", tome.AbilityId);
-            cmd.Parameters.AddWithValue("@uid", userId);
-            cmd.Parameters.AddWithValue("@name", target);
-            int result = cmd.ExecuteNonQuery();
+            string sqlPath = Path.Combine(AppContext.BaseDirectory, "unity_learn_ability.sql");
+            var parameters = new Dictionary<string, object?>
+            {
+                ["@aid"] = tome.AbilityId,
+                ["@uid"] = userId,
+                ["@name"] = target
+            };
+            int result = DatabaseClientUnity.ExecuteAsync(File.ReadAllText(sqlPath), parameters)
+                .GetAwaiter().GetResult();
             Debug.Log($"SQL rows affected: {result} for {item.Name} on {target}");
             InventoryServiceUnity.RemoveItem(item);
             PopulateItems();

--- a/docs/ConnectionUsage.md
+++ b/docs/ConnectionUsage.md
@@ -10,3 +10,12 @@ All database queries flow through `DatabaseClientUnity`. This wrapper centralize
 
 Store each SQL statement in its own `.sql` file at the repository root. Load the file contents and pass
 it to `DatabaseClientUnity` rather than embedding raw SQL strings in code.
+
+### InventoryUI Scripts
+
+The `InventoryUI` component loads the following SQL files from the repository root at runtime:
+
+- `unity_character_heal.sql` – updates HP when a Healing Potion is used.
+- `unity_learn_ability.sql` – grants an ability when reading an Ability Tome.
+
+Each script is read with `File.ReadAllText` and executed through `DatabaseClientUnity.ExecuteAsync`.

--- a/unity_character_heal.sql
+++ b/unity_character_heal.sql
@@ -1,0 +1,3 @@
+-- Heals a character when consuming a healing potion
+UPDATE characters SET current_hp = LEAST(max_hp, current_hp + @heal)
+WHERE account_id=@uid AND name=@name AND is_dead=0 AND in_arena=0 AND in_tavern=0;

--- a/unity_learn_ability.sql
+++ b/unity_learn_ability.sql
@@ -1,0 +1,3 @@
+-- Grants an ability to a character when using a tome
+INSERT IGNORE INTO character_abilities(character_id, ability_id)
+SELECT id, @aid FROM characters WHERE account_id=@uid AND name=@name;


### PR DESCRIPTION
## Summary
- externalized healing potion and ability tome SQL queries from `InventoryUI`
- added `unity_character_heal.sql` and `unity_learn_ability.sql`
- documented new scripts in `docs/ConnectionUsage.md`

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: The imported project Microsoft.NET.Sdk.WindowsDesktop.targets was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cf7f969083339b90500346d9859a