### PR TITLE
Remove unused MySqlConnector package from Unity project

### DIFF
--- a/New Unity Project/Assets/packages.config
+++ b/New Unity Project/Assets/packages.config
@@ -9,7 +9,6 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="8.0.2" />
   <package id="Microsoft.Extensions.Logging.Abstractions" version="8.0.2" />
   <package id="MySql.Data" version="9.4.0" manuallyInstalled="true" />
-  <package id="MySqlConnector" version="2.4.0" manuallyInstalled="true" />
   <package id="System.Configuration.ConfigurationManager" version="8.0.0" />
   <package id="System.Diagnostics.DiagnosticSource" version="8.0.1" />
   <package id="System.IO.Pipelines" version="9.0.0" />


### PR DESCRIPTION
## Summary
- remove MySqlConnector package entry from Unity project's `packages.config`

## Testing
- `nuget restore 'New Unity Project/Assets/packages.config'` *(fails: command not found)*
- `dotnet restore 'New Unity Project'` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cb7ed3fc8333bc02d05d0e562a9d