### PR TITLE
Use MySqlConnector in Unity client

### DIFF
--- a/New Unity Project/Assets/Scripts/DatabaseClientUnity.cs
+++ b/New Unity Project/Assets/Scripts/DatabaseClientUnity.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using UnityClient;
 using UnityEngine;
 
@@ -21,7 +21,7 @@ public static class DatabaseClientUnity
                 Debug.Log($"Database connection established on attempt {attempt + 1}");
                 return conn;
             }
-            catch (MySql.Data.MySqlClient.MySqlException) when (attempt < MaxRetries)
+            catch (MySqlException) when (attempt < MaxRetries)
             {
                 await Task.Delay(200 * (int)Math.Pow(2, attempt));
                 attempt++;


### PR DESCRIPTION
## Summary
- Switch Unity DatabaseClient to MySqlConnector to avoid MySqlPoolManager initialization failures

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: imported project Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ce8ed5ac8333958c3b803258ff7e