### PR TITLE
Use MySql.Data client in Unity

### DIFF
--- a/New Unity Project/Assets/Scripts/DatabaseClientUnity.cs
+++ b/New Unity Project/Assets/Scripts/DatabaseClientUnity.cs
@@ -21,7 +21,7 @@ public static class DatabaseClientUnity
                 Debug.Log($"Database connection established on attempt {attempt + 1}");
                 return conn;
             }
-            catch (MySql.Data.MySqlClient.MySqlException) when (attempt < MaxRetries)
+            catch (MySqlException) when (attempt < MaxRetries)
             {
                 await Task.Delay(200 * (int)Math.Pow(2, attempt));
                 attempt++;


### PR DESCRIPTION
## Summary
- Revert Unity DatabaseClient to use `MySql.Data.MySqlClient` for database connections

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ce8ed5ac8333958c3b803258ff7e