### PR TITLE
Switch to Unity database config for login and register

### DIFF
--- a/New Unity Project/Assets/Scripts/DatabaseConfigUnity.cs
+++ b/New Unity Project/Assets/Scripts/DatabaseConfigUnity.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace UnityClient
 {
-    internal static class DatabaseConfigUnity
+    public static class DatabaseConfigUnity
     {
         private const string DatabaseName = "accounts";
         private static ServerConfig _config;

--- a/New Unity Project/Assets/Scripts/LoginManager.cs
+++ b/New Unity Project/Assets/Scripts/LoginManager.cs
@@ -8,7 +8,7 @@ using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using TMPro;
 using UnityEngine.EventSystems;
-using WinFormsApp2;
+using UnityClient;
 
 public class LoginManager : MonoBehaviour
 {
@@ -43,8 +43,8 @@ public class LoginManager : MonoBehaviour
         if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
         {
             Debug.Log($"Login attempt for '{username}'");
-            DatabaseConfig.DebugMode = debugServerToggle != null && debugServerToggle.isOn;
-            DatabaseConfig.UseKimServer = kimServerToggle != null && kimServerToggle.isOn;
+            DatabaseConfigUnity.DebugMode = debugServerToggle != null && debugServerToggle.isOn;
+            DatabaseConfigUnity.UseKimServer = kimServerToggle != null && kimServerToggle.isOn;
 
             string hashed = HashPassword(password);
             string sqlPath = Path.Combine(Application.dataPath, "sql", "unity_direct_login.sql");

--- a/New Unity Project/Assets/Scripts/RegisterManager.cs
+++ b/New Unity Project/Assets/Scripts/RegisterManager.cs
@@ -8,7 +8,7 @@ using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using UnityEngine.EventSystems;
 using TMPro;
-using WinFormsApp2;
+using UnityClient;
 
 public class RegisterManager : MonoBehaviour
 {
@@ -169,8 +169,8 @@ public class RegisterManager : MonoBehaviour
             return;
         }
 
-        DatabaseConfig.DebugMode = debugServerToggle != null && debugServerToggle.isOn;
-        DatabaseConfig.UseKimServer = kimServerToggle != null && kimServerToggle.isOn;
+        DatabaseConfigUnity.DebugMode = debugServerToggle != null && debugServerToggle.isOn;
+        DatabaseConfigUnity.UseKimServer = kimServerToggle != null && kimServerToggle.isOn;
 
         string passwordHash = HashPassword(pass);
         var parameters = new Dictionary<string, object?>


### PR DESCRIPTION
## Summary
- Use `DatabaseConfigUnity` for login and registration configuration flags
- Expose `DatabaseConfigUnity` publicly so `DebugMode` and `UseKimServer` can be set from Unity scripts
- Confirm `DatabaseClientUnity` builds connections using the updated config

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e273b500833383f6a01d2183c569