### PR TITLE
Use shared Base64 password hashing in Unity login and register flows

### DIFF
--- a/New Unity Project/Assets/Scripts/LoginManager.cs
+++ b/New Unity Project/Assets/Scripts/LoginManager.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Security.Cryptography;
-using System.Text;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
@@ -46,7 +44,7 @@ public class LoginManager : MonoBehaviour
             DatabaseConfig.DebugMode = debugServerToggle != null && debugServerToggle.isOn;
             DatabaseConfig.UseKimServer = kimServerToggle != null && kimServerToggle.isOn;
 
-            string hashed = HashPassword(password);
+            string hashed = PasswordHasher.HashPassword(password);
             string sqlPath = Path.Combine(Application.dataPath, "sql", "unity_direct_login.sql");
             Debug.Log("Executing login query");
             try
@@ -74,20 +72,6 @@ public class LoginManager : MonoBehaviour
         }
     }
 
-    private string HashPassword(string password)
-    {
-        using (var sha = SHA256.Create())
-        {
-            byte[] bytes = Encoding.UTF8.GetBytes(password);
-            byte[] hash = sha.ComputeHash(bytes);
-            var builder = new StringBuilder();
-            foreach (byte b in hash)
-            {
-                builder.Append(b.ToString("x2"));
-            }
-            return builder.ToString();
-        }
-    }
 
     private void OnCreateAccountClicked()
     {

--- a/New Unity Project/Assets/Scripts/PasswordHasher.cs
+++ b/New Unity Project/Assets/Scripts/PasswordHasher.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace WinFormsApp2
+{
+    public static class PasswordHasher
+    {
+        public static string HashPassword(string password)
+        {
+            using SHA256 sha = SHA256.Create();
+            byte[] bytes = Encoding.UTF8.GetBytes(password);
+            byte[] hash = sha.ComputeHash(bytes);
+            return Convert.ToBase64String(hash);
+        }
+    }
+}

--- a/New Unity Project/Assets/Scripts/RegisterManager.cs
+++ b/New Unity Project/Assets/Scripts/RegisterManager.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Security.Cryptography;
-using System.Text;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
@@ -172,7 +170,7 @@ public class RegisterManager : MonoBehaviour
         DatabaseConfig.DebugMode = debugServerToggle != null && debugServerToggle.isOn;
         DatabaseConfig.UseKimServer = kimServerToggle != null && kimServerToggle.isOn;
 
-        string passwordHash = HashPassword(pass);
+        string passwordHash = PasswordHasher.HashPassword(pass);
         var parameters = new Dictionary<string, object?>
         {
             ["@username"] = user,
@@ -202,16 +200,4 @@ public class RegisterManager : MonoBehaviour
         }
     }
 
-    private string HashPassword(string password)
-    {
-        using var sha = SHA256.Create();
-        byte[] bytes = Encoding.UTF8.GetBytes(password);
-        byte[] hash = sha.ComputeHash(bytes);
-        var builder = new StringBuilder();
-        foreach (byte b in hash)
-        {
-            builder.Append(b.ToString("x2"));
-        }
-        return builder.ToString();
-    }
 }

--- a/update_test_account_password.sql
+++ b/update_test_account_password.sql
@@ -1,0 +1,4 @@
+-- Updates the stored password hash for the default test account.
+UPDATE accounts
+SET password_hash = 'n4bQgYhMfWWaL+qgxVrQFaO/TxsrC4Is0V1sFbDwCgg='
+WHERE username = 'test';


### PR DESCRIPTION
## Summary
- centralize SHA256 hashing with Base64 output in `PasswordHasher`
- update login and registration scripts to use shared hasher
- add SQL script updating test account to new hash format

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj -p:EnableWindowsTargeting=true` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e274402883339cf6387be3db9af8