### PR TITLE
Use Users schema for Unity login

### DIFF
--- a/New Unity Project/Assets/Scripts/LoginManager.cs
+++ b/New Unity Project/Assets/Scripts/LoginManager.cs
@@ -47,7 +47,8 @@ public class LoginManager : MonoBehaviour
             DatabaseConfig.UseKimServer = kimServerToggle != null && kimServerToggle.isOn;
 
             string hashed = HashPassword(password);
-            string sqlPath = Path.Combine(Application.dataPath, "sql", "unity_direct_login.sql");
+            string sqlPath = Path.Combine(Application.dataPath, "sql", "unity_login_users.sql");
+            // Previous login query (unity_direct_login.sql) used the legacy accounts schema
             Debug.Log("Executing login query");
             try
             {

--- a/New Unity Project/Assets/sql/unity_login_users.sql
+++ b/New Unity Project/Assets/sql/unity_login_users.sql
@@ -1,0 +1,2 @@
+-- Query used by Unity LoginManager to authenticate users against the Users table
+SELECT id, nickname FROM Users WHERE Username = @username AND PasswordHash = @passwordHash;

--- a/New Unity Project/Assets/sql/unity_login_users.sql.meta
+++ b/New Unity Project/Assets/sql/unity_login_users.sql.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5dacf16b5fda483ab5b0aa9ae177943e
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add Users-based login query for Unity
- point LoginManager at new Users query file

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e2782f4c8333ba28f946c862cce2