### PR TITLE
Add username and nickname checks with travel initialization

### DIFF
--- a/New Unity Project/Assets/sql/unity_register_check_nickname.sql
+++ b/New Unity Project/Assets/sql/unity_register_check_nickname.sql
@@ -1,0 +1,2 @@
+-- Checks if nickname exists for Unity RegisterManager
+SELECT COUNT(1) AS cnt FROM accounts WHERE nickname=@nickname;

--- a/New Unity Project/Assets/sql/unity_register_check_nickname.sql.meta
+++ b/New Unity Project/Assets/sql/unity_register_check_nickname.sql.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ff4f03b32e414666baeb6b8eaece5586
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/New Unity Project/Assets/sql/unity_register_check_username.sql
+++ b/New Unity Project/Assets/sql/unity_register_check_username.sql
@@ -1,0 +1,2 @@
+-- Checks if username exists for Unity RegisterManager
+SELECT COUNT(1) AS cnt FROM accounts WHERE username=@username;

--- a/New Unity Project/Assets/sql/unity_register_check_username.sql.meta
+++ b/New Unity Project/Assets/sql/unity_register_check_username.sql.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 06a83a18dde3455d98b25bfefc37adaa
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/New Unity Project/Assets/sql/unity_register_ensure_node.sql
+++ b/New Unity Project/Assets/sql/unity_register_ensure_node.sql
@@ -1,0 +1,2 @@
+-- Ensures starting node exists for Unity RegisterManager
+INSERT IGNORE INTO nodes (id, name) VALUES (@node, @name);

--- a/New Unity Project/Assets/sql/unity_register_ensure_node.sql.meta
+++ b/New Unity Project/Assets/sql/unity_register_ensure_node.sql.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ce667e413c3e41bea0e2e4fef47ad7e0
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/New Unity Project/Assets/sql/unity_register_get_id.sql
+++ b/New Unity Project/Assets/sql/unity_register_get_id.sql
@@ -1,0 +1,2 @@
+-- Retrieves account id by username for Unity RegisterManager
+SELECT id FROM accounts WHERE username=@username;

--- a/New Unity Project/Assets/sql/unity_register_get_id.sql.meta
+++ b/New Unity Project/Assets/sql/unity_register_get_id.sql.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 88f6992c7bbc4a9eb5a32fcce82492d5
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/New Unity Project/Assets/sql/unity_register_init_travel.sql
+++ b/New Unity Project/Assets/sql/unity_register_init_travel.sql
@@ -1,0 +1,3 @@
+-- Initializes travel_state for a new account in Unity RegisterManager
+REPLACE INTO travel_state(account_id,current_node,destination_node,start_time,arrival_time,progress_seconds,faster_travel,travel_cost)
+VALUES (@accountId, @node, @node, NULL, NULL, 0, 0, 0);

--- a/New Unity Project/Assets/sql/unity_register_init_travel.sql.meta
+++ b/New Unity Project/Assets/sql/unity_register_init_travel.sql.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 83b38945cbb44693bc949bc39ae61704
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- check for existing username and nickname before creating accounts
- initialize starter node and travel state after registration

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e27d74fc8333b5a16d30e2b5eb60