### PR TITLE
Align Unity inventory SQL with WinForms and document mapping

### DIFF
--- a/New Unity Project/Assets/Scripts/InventoryServiceUnity.cs
+++ b/New Unity Project/Assets/Scripts/InventoryServiceUnity.cs
@@ -162,11 +162,11 @@ namespace WinFormsApp2
             var parameters = new Dictionary<string, object?>
             {
                 ["@id"] = _userId,
-                ["@character"] = character,
-                ["@slot"] = slot.ToString(),
-                ["@name"] = item?.Name
+                ["@c"] = character,
+                ["@s"] = slot.ToString(),
+                ["@n"] = item?.Name
             };
-            string sqlPath = Path.Combine(Application.dataPath, "sql", "unity_inventory_equip.sql");
+            string sqlPath = Path.Combine(Application.dataPath, "sql", "unity_inventory_save_equipment.sql");
             var statements = File.ReadAllText(sqlPath).Split(';', StringSplitOptions.RemoveEmptyEntries);
             foreach (var stmt in statements)
             {

--- a/New Unity Project/Assets/sql/unity_inventory_save_equipment.sql
+++ b/New Unity Project/Assets/sql/unity_inventory_save_equipment.sql
@@ -1,0 +1,5 @@
+-- Saves equipment for a character slot using REPLACE, matching WinForms InventoryService.SaveEquipment
+DELETE FROM character_equipment
+WHERE account_id=@id AND character_name=@c AND slot=@s AND @n IS NULL;
+REPLACE INTO character_equipment(account_id, character_name, slot, item_name)
+SELECT @id, @c, @s, @n FROM DUAL WHERE @n IS NOT NULL;

--- a/docs/UnitySqlMapping.md
+++ b/docs/UnitySqlMapping.md
@@ -1,0 +1,10 @@
+# Unity Inventory SQL Mapping
+
+This document maps each Unity inventory SQL file to the WinForms `InventoryService` method it mirrors.
+
+| Unity SQL file | Corresponding WinForms method |
+|---------------|--------------------------------|
+| `unity_inventory_load.sql` | `InventoryService.LoadAsync` (items and equipment retrieval) |
+| `unity_inventory_add.sql` | `InventoryService.AddItem` |
+| `unity_inventory_remove.sql` | `InventoryService.RemoveItem` |
+| `unity_inventory_save_equipment.sql` | `InventoryService.SaveEquipment` |


### PR DESCRIPTION
## Summary
- Add new `unity_inventory_save_equipment.sql` using REPLACE logic to mirror WinForms `InventoryService.SaveEquipment`
- Update `InventoryServiceUnity` to reference the new SQL file and parameters
- Document mapping of Unity inventory SQL files to corresponding WinForms methods

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e28845748333adf5a61fe7485eed