### PR TITLE
Remove duplicate username check in RegisterManager

### DIFF
--- a/New Unity Project/Assets/Scripts/RegisterManager.cs
+++ b/New Unity Project/Assets/Scripts/RegisterManager.cs
@@ -196,53 +196,6 @@ public class RegisterManager : MonoBehaviour
         };
         Debug.Log($"Register params - username: {user}, nickname: {nick}, hash: {passwordHash}");
 
-        string checkUserPath = Path.Combine(Application.dataPath, "sql", "unity_register_check_username.sql");
-        var userRows = await DatabaseClientUnity.QueryAsync(File.ReadAllText(checkUserPath),
-            new Dictionary<string, object?> { ["@username"] = user });
-        if (userRows.Count > 0 && Convert.ToInt32(userRows[0]["cnt"]) > 0)
-        {
-            Debug.Log("Username already exists");
-            return;
-            int rows = await DatabaseClientUnity.ExecuteAsync(File.ReadAllText(sqlPath), parameters);
-            Debug.Log($"Insert result: {rows}");
-            if (rows > 0)
-            {
-                string idPath = Path.Combine(Application.dataPath, "sql", "unity_register_get_id.sql");
-                var idRows = await DatabaseClientUnity.QueryAsync(File.ReadAllText(idPath), new Dictionary<string, object?> { ["@username"] = user });
-                long accountId = Convert.ToInt64(idRows[0]["id"]);
-
-                string ensureNodePath = Path.Combine(Application.dataPath, "sql", "unity_register_ensure_node.sql");
-                await DatabaseClientUnity.ExecuteAsync(File.ReadAllText(ensureNodePath), new Dictionary<string, object?>
-                {
-                    ["@node"] = "nodeRiverVillage",
-                    ["@name"] = "River Village"
-                });
-
-                string initTravelPath = Path.Combine(Application.dataPath, "sql", "unity_register_init_travel.sql");
-                await DatabaseClientUnity.ExecuteAsync(File.ReadAllText(initTravelPath), new Dictionary<string, object?>
-                {
-                    ["@accountId"] = accountId,
-                    ["@node"] = "nodeRiverVillage"
-                });
-
-                Debug.Log("Account created");
-                SceneManager.LoadScene("Login");
-            }
-            else
-            {
-                Debug.Log("No account created");
-            }
-        }
-
-        string checkNickPath = Path.Combine(Application.dataPath, "sql", "unity_register_check_nickname.sql");
-        var nickRows = await DatabaseClientUnity.QueryAsync(File.ReadAllText(checkNickPath),
-            new Dictionary<string, object?> { ["@nickname"] = nick });
-        if (nickRows.Count > 0 && Convert.ToInt32(nickRows[0]["cnt"]) > 0)
-        {
-            Debug.Log("Nickname already exists");
-            return;
-        }
-
         string insertPath = Path.Combine(Application.dataPath, "sql", "unity_register_insert.sql");
         int rows = await DatabaseClientUnity.ExecuteAsync(File.ReadAllText(insertPath), parameters);
         Debug.Log($"Insert result: {rows}");


### PR DESCRIPTION
## Summary
- Eliminate duplicated username and nickname existence checks in `RegisterManager.OnRegisterClicked`
- Streamline registration logic to validate once before inserting new accounts

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2c30c32c83338326c47ad6520c9a