### PR TITLE
Embed Unity client DB credentials

### DIFF
--- a/New Unity Project/Assets/Scripts/DatabaseConfigUnity.cs
+++ b/New Unity Project/Assets/Scripts/DatabaseConfigUnity.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 
 namespace UnityClient
@@ -14,10 +13,8 @@ namespace UnityClient
         public static bool DebugMode { get; set; }
         public static bool UseKimServer { get; set; }
 
-        private static string Username =>
-            Environment.GetEnvironmentVariable("DB_USERNAME") ?? string.Empty;
-        private static string Password =>
-            Environment.GetEnvironmentVariable("DB_PASSWORD") ?? string.Empty;
+        private const string Username = "userclient";
+        private const string Password = "123321";
 
         public static string ConnectionString =>
             $"Server={(UseKimServer ? Config.kimHost : (DebugMode ? "127.0.0.1" : Config.host))};" +

--- a/docs/ConnectionUsage.md
+++ b/docs/ConnectionUsage.md
@@ -3,7 +3,7 @@
 
 The Unity client uses direct MySQL access through the `MySql.Data` library. Connection settings, including database hosts and API endpoints, are stored in a `ServerConfig` ScriptableObject located in the `Assets/Resources` folder. Different builds can provide environment-specific copies of this asset.
 
-Database credentials are supplied at runtime via the `DB_USERNAME` and `DB_PASSWORD` environment variables. This keeps secrets out of source control while allowing secure configuration in deployment environments.
+Database credentials are defined directly in `DatabaseConfigUnity.cs`. The file embeds the username and password used by the client when constructing its MySQL connection string.
 
 All database queries flow through `DatabaseClientUnity`. This wrapper centralizes connection retries and parameter handling so services like `CharacterDatabase` and `ChatService` share the same access layer.
 


### PR DESCRIPTION
## Summary
- hardcode DB username/password in Unity `DatabaseConfigUnity` and drop environment variable usage
- document that credentials live in code rather than environment variables

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba30479a188333b98927196dfe9c02