### PR TITLE
Remove password hashing for Unity login and registration

### DIFF
--- a/New Unity Project/Assets/Scripts/RegisterManager.cs
+++ b/New Unity Project/Assets/Scripts/RegisterManager.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Security.Cryptography;
-using System.Text;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
@@ -188,17 +186,15 @@ public class RegisterManager : MonoBehaviour
             return;
         }
 
-        string passwordHash = HashPassword(pass);
-
         var parameters = new Dictionary<string, object?>
         {
             ["@username"] = user,
             ["@nickname"] = nick,
-            ["@passwordHash"] = passwordHash
+            ["@password"] = pass
         };
-        Debug.Log($"Register params - username: {user}, nickname: {nick}, hash: {passwordHash}");
+        Debug.Log($"Register params - username: {user}, nickname: {nick}");
 
-        string insertPath = Path.Combine(Application.dataPath, "sql", "unity_register_insert.sql");
+        string insertPath = Path.Combine(Application.dataPath, "sql", "unity_register_insert_plain.sql");
         int rows = await DatabaseClientUnity.ExecuteAsync(File.ReadAllText(insertPath), parameters);
         Debug.Log($"Insert result: {rows}");
         if (rows > 0)
@@ -222,11 +218,4 @@ public class RegisterManager : MonoBehaviour
         }
     }
 
-    private string HashPassword(string password)
-    {
-        using var sha = SHA256.Create();
-        byte[] bytes = Encoding.UTF8.GetBytes(password);
-        byte[] hash = sha.ComputeHash(bytes);
-        return Convert.ToBase64String(hash);
-    }
 }

--- a/New Unity Project/Assets/sql/unity_login_select_user_plain.sql
+++ b/New Unity Project/Assets/sql/unity_login_select_user_plain.sql
@@ -1,0 +1,2 @@
+-- Query used by Unity LoginManager to authenticate users without hashing
+SELECT id, nickname FROM Users WHERE Username = @username AND PasswordHash = @password;

--- a/New Unity Project/Assets/sql/unity_login_select_user_plain.sql.meta
+++ b/New Unity Project/Assets/sql/unity_login_select_user_plain.sql.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 41d021dc23ca4729988f4d74e14eb27d
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/New Unity Project/Assets/sql/unity_register_insert_plain.sql
+++ b/New Unity Project/Assets/sql/unity_register_insert_plain.sql
@@ -1,0 +1,3 @@
+-- Inserts a new account without hashing the password
+INSERT INTO Users (Username, Nickname, PasswordHash, Gold, last_seen)
+VALUES (@username, @nickname, @password, 300, NOW());

--- a/New Unity Project/Assets/sql/unity_register_insert_plain.sql.meta
+++ b/New Unity Project/Assets/sql/unity_register_insert_plain.sql.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c0ee7d379c5b4917a3f7912c0c7fc658
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Drop password hashing from Unity's LoginManager and RegisterManager to use plain passwords
- Add new SQL scripts for login and registration that match WinForms query format
- Reference InventoryServiceUnity in LoginManager to load inventory after login

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba34798668833388ee31982074a8dd