### PR TITLE
Load inventory asynchronously before entering RPG scene

### DIFF
--- a/New Unity Project/Assets/Scripts/LoginManager.cs
+++ b/New Unity Project/Assets/Scripts/LoginManager.cs
@@ -62,7 +62,7 @@ public class LoginManager : MonoBehaviour
                     int userId = Convert.ToInt32(rows[0]["id"]);
                     string updatePath = Path.Combine(Application.dataPath, "sql", "unity_login_update_last_seen.sql");
                     await DatabaseClientUnity.ExecuteAsync(File.ReadAllText(updatePath), new Dictionary<string, object?> { ["@id"] = userId });
-                    InventoryServiceUnity.Load(userId);
+                    await InventoryServiceUnity.LoadAsync(userId);
                     SceneManager.LoadScene("RPG");
                 }
                 else


### PR DESCRIPTION
## Summary
- Switch login handler to await inventory loading with `LoadAsync` before scene transition
- Keep `OnLoginClicked` method asynchronous and only load RPG scene after inventory finishes

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68ba439f56f8833384fa80c5aff7e50c