### PR TITLE
Make SendMessageAsync public

### DIFF
--- a/New Unity Project/Assets/Scripts/ChatService.cs
+++ b/New Unity Project/Assets/Scripts/ChatService.cs
@@ -67,7 +67,7 @@ public static class ChatService
             return null;
         } }
 
-    private static async Task SendMessageAsync(int senderId, int? recipientId, string message)
+    public static async Task SendMessageAsync(int senderId, int? recipientId, string message)
     {
         string sqlPath = Path.Combine(Application.dataPath, "sql", "unity_chat_send_message.sql");
         try


### PR DESCRIPTION
## Summary
- expose ChatService.SendMessageAsync so callers can await it

## Testing
- `dotnet test`
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3202ed9008333bdb9924fbba79e30