### PR TITLE
Remove duplicate Unity UI import

### DIFF
--- a/New Unity Project/Assets/Scripts/RPGManager.cs
+++ b/New Unity Project/Assets/Scripts/RPGManager.cs
@@ -8,7 +8,6 @@ using UnityEngine;
 using TMPro;
 using UnityEngine.UI;
 using WinFormsApp2;
-using UnityEngine.UI;
 
 public class RPGManager : MonoBehaviour
 {


### PR DESCRIPTION
## Summary
- Remove duplicate `using UnityEngine.UI` directive from RPGManager to avoid redundant import

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c32030d6ec83339b3b924e734971fc