### PR TITLE
Handle exceptions in ChatLoop

### DIFF
--- a/New Unity Project/Assets/Scripts/RPGManager.cs
+++ b/New Unity Project/Assets/Scripts/RPGManager.cs
@@ -185,16 +185,27 @@ public class RPGManager : MonoBehaviour
     {
         while (true)
         {
-            var task = ChatService.GetMessagesAsync(_lastChatFetch, InventoryServiceUnity.AccountId);
-            yield return new WaitUntil(() => task.IsCompleted);
-            if (chatText != null)
+            try
             {
-                foreach (var msg in task.Result)
+                var task = ChatService.GetMessagesAsync(_lastChatFetch, InventoryServiceUnity.AccountId);
+                yield return new WaitUntil(() => task.IsCompleted);
+                if (task.Exception != null)
                 {
-                    chatText.text += $"\n{msg.Sender}: {msg.Message}";
+                    throw task.Exception;
                 }
+                if (chatText != null)
+                {
+                    foreach (var msg in task.Result)
+                    {
+                        chatText.text += $"\n{msg.Sender}: {msg.Message}";
+                    }
+                }
+                _lastChatFetch = DateTime.UtcNow;
             }
-            _lastChatFetch = DateTime.UtcNow;
+            catch (Exception ex)
+            {
+                Debug.LogError($"Failed to fetch chat messages: {ex}");
+            }
             yield return new WaitForSeconds(2f);
         }
     }


### PR DESCRIPTION
## Summary
- Wrap chat polling in try/catch to avoid crashes when ChatService fails

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: MSB4019 missing Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_68c32032f8ec833381ebe9386d481b51