### PR TITLE
Fix chat coroutine and expose ChatService send

### DIFF
--- a/New Unity Project/Assets/Scripts/ChatService.cs
+++ b/New Unity Project/Assets/Scripts/ChatService.cs
@@ -70,7 +70,7 @@ namespace UnityClient
             }
         }
 
-        private static async Task SendMessageAsync(int senderId, int? recipientId, string message)
+        public static async Task SendMessageAsync(int senderId, int? recipientId, string message)
 
         {
             string sqlPath = Path.Combine(Application.dataPath, "sql", "unity_chat_send_message.sql");

--- a/New Unity Project/Assets/Scripts/RPGManager.cs
+++ b/New Unity Project/Assets/Scripts/RPGManager.cs
@@ -184,14 +184,10 @@ public class RPGManager : MonoBehaviour
     {
         while (true)
         {
-            try
+            var task = ChatService.GetMessagesAsync(_lastChatFetch, InventoryServiceUnity.AccountId);
+            yield return new WaitUntil(() => task.IsCompleted);
+            if (task.Exception == null)
             {
-                var task = ChatService.GetMessagesAsync(_lastChatFetch, InventoryServiceUnity.AccountId);
-                yield return new WaitUntil(() => task.IsCompleted);
-                if (task.Exception != null)
-                {
-                    throw task.Exception;
-                }
                 if (chatText != null)
                 {
                     foreach (var msg in task.Result)
@@ -201,9 +197,9 @@ public class RPGManager : MonoBehaviour
                 }
                 _lastChatFetch = DateTime.UtcNow;
             }
-            catch (Exception ex)
+            else
             {
-                Debug.LogError($"Failed to fetch chat messages: {ex}");
+                Debug.LogError($"Failed to fetch chat messages: {task.Exception}");
             }
             yield return new WaitForSeconds(2f);
         }


### PR DESCRIPTION
## Summary
- Prevent coroutine yield inside try by moving wait logic outside and logging task errors
- Make ChatService.SendMessageAsync public so RPGManager can call it

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c32f52a8248333969c8d2a5e516dd5