### PR TITLE
Fix chat messages not loading on login

### DIFF
--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -16,7 +16,7 @@ namespace WinFormsApp2
         private int _playerGold;
         private readonly System.Windows.Forms.Timer _chatTimer = new System.Windows.Forms.Timer();
         private readonly System.Windows.Forms.Timer _regenTimer = new System.Windows.Forms.Timer();
-        private DateTime _lastMessage = DateTime.MinValue;
+        private DateTime _lastMessage = DateTime.UtcNow.AddMinutes(-5);
         private HashSet<string> _hiredMembers = new();
         private HashSet<string> _mercenaryMembers = new();
         private NavigationWindow? _navigationWindow;
@@ -41,6 +41,7 @@ namespace WinFormsApp2
             _regenTimer.Interval = 3000;
             _regenTimer.Tick += RegenTimer_Tick;
             _regenTimer.Start();
+            ChatTimer_Tick(null, EventArgs.Empty);
         }
 
         private async Task LoadPartyDataAsync()


### PR DESCRIPTION
## Summary
- initialize last chat message timestamp to 5 minutes ago
- trigger chat fetch immediately on RPG form load

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c363aa632c8333becc93092e40df36