### PR TITLE
Simplify chat message retrieval

### DIFF
--- a/New Unity Project/Assets/Scripts/ChatService.cs
+++ b/New Unity Project/Assets/Scripts/ChatService.cs
@@ -16,17 +16,12 @@ namespace UnityClient
             public DateTime SentAt { get; set; }
         }
 
-        public static async Task<List<ChatMessage>> GetMessagesAsync(DateTime since, int userId)
+        public static async Task<List<ChatMessage>> GetMessagesAsync()
         {
-            string sqlPath = Path.Combine(Application.dataPath, "sql", "unity_chat_fetch_visible_messages.sql");
+            string sqlPath = Path.Combine(Application.dataPath, "sql", "unity_chat_fetch_all_messages.sql");
             try
             {
-                var parameters = new Dictionary<string, object?>
-                {
-                    ["@since"] = since,
-                    ["@uid"] = userId
-                };
-                var rows = await DatabaseClientUnity.QueryAsync(File.ReadAllText(sqlPath), parameters);
+                var rows = await DatabaseClientUnity.QueryAsync(File.ReadAllText(sqlPath));
                 var messages = new List<ChatMessage>();
                 foreach (var row in rows)
                 {

--- a/New Unity Project/Assets/Scripts/RPGManager.cs
+++ b/New Unity Project/Assets/Scripts/RPGManager.cs
@@ -25,7 +25,6 @@ public class RPGManager : MonoBehaviour
 
     private List<CharacterData> partyMembers = new List<CharacterData>();
     private List<CharacterData> hiredCompanions = new List<CharacterData>();
-    private DateTime _lastChatFetch = DateTime.UtcNow.AddMinutes(-5);
     private GameObject _selectedBlock;
 
     private async void Start()
@@ -184,7 +183,7 @@ public class RPGManager : MonoBehaviour
     {
         while (true)
         {
-            var task = ChatService.GetMessagesAsync(_lastChatFetch, InventoryServiceUnity.AccountId);
+            var task = ChatService.GetMessagesAsync();
             yield return new WaitUntil(() => task.IsCompleted);
             if (task.Exception == null)
             {
@@ -195,7 +194,6 @@ public class RPGManager : MonoBehaviour
                         chatText.text += $"\n{msg.Sender}: {msg.Message}";
                     }
                 }
-                _lastChatFetch = DateTime.UtcNow;
             }
             else
             {
@@ -214,7 +212,7 @@ public class RPGManager : MonoBehaviour
         await ChatService.SendMessageAsync(InventoryServiceUnity.AccountId, null, message);
         chatInput.text = string.Empty;
 
-        var messages = await ChatService.GetMessagesAsync(_lastChatFetch, InventoryServiceUnity.AccountId);
+        var messages = await ChatService.GetMessagesAsync();
         if (chatText != null)
         {
             foreach (var msg in messages)
@@ -222,7 +220,6 @@ public class RPGManager : MonoBehaviour
                 chatText.text += $"\n{msg.Sender}: {msg.Message}";
             }
         }
-        _lastChatFetch = DateTime.UtcNow;
     }
 
     private IEnumerator RegenLoop()

--- a/New Unity Project/Assets/sql/unity_chat_fetch_all_messages.sql
+++ b/New Unity Project/Assets/sql/unity_chat_fetch_all_messages.sql
@@ -1,0 +1,5 @@
+SELECT c.sender_id, u.nickname AS sender, c.message, c.sent_at, r.nickname AS recipient
+FROM chat_messages c
+JOIN users u ON c.sender_id = u.id
+LEFT JOIN users r ON c.recipient_id = r.id
+ORDER BY c.sent_at;

--- a/WinFormsApp2/ChatService.cs
+++ b/WinFormsApp2/ChatService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using MySql.Data.MySqlClient;
 
 namespace WinFormsApp2
@@ -14,19 +15,13 @@ namespace WinFormsApp2
 
     public static class ChatService
     {
-        public static List<ChatMessage> GetMessages(DateTime since, int userId)
+        public static List<ChatMessage> GetMessages()
         {
             var list = new List<ChatMessage>();
             using MySqlConnection conn = new MySqlConnection(DatabaseConfig.ConnectionString);
             conn.Open();
-            using MySqlCommand cmd = new MySqlCommand(@"SELECT c.sender_id, u.nickname sender, c.message, c.sent_at, r.nickname recipient
-                FROM chat_messages c
-                JOIN users u ON c.sender_id=u.id
-                LEFT JOIN users r ON c.recipient_id=r.id
-                WHERE c.sent_at > @since AND (c.recipient_id IS NULL OR c.sender_id=@uid OR c.recipient_id=@uid)
-                ORDER BY c.sent_at", conn);
-            cmd.Parameters.AddWithValue("@since", since);
-            cmd.Parameters.AddWithValue("@uid", userId);
+            string sql = File.ReadAllText("fetch_all_chat_messages.sql");
+            using MySqlCommand cmd = new MySqlCommand(sql, conn);
             using var reader = cmd.ExecuteReader();
             while (reader.Read())
             {

--- a/WinFormsApp2/RPGForm.cs
+++ b/WinFormsApp2/RPGForm.cs
@@ -16,7 +16,6 @@ namespace WinFormsApp2
         private int _playerGold;
         private readonly System.Windows.Forms.Timer _chatTimer = new System.Windows.Forms.Timer();
         private readonly System.Windows.Forms.Timer _regenTimer = new System.Windows.Forms.Timer();
-        private DateTime _lastMessage = DateTime.UtcNow.AddMinutes(-5);
         private HashSet<string> _hiredMembers = new();
         private HashSet<string> _mercenaryMembers = new();
         private NavigationWindow? _navigationWindow;
@@ -412,12 +411,11 @@ namespace WinFormsApp2
         private void ChatTimer_Tick(object? sender, EventArgs e)
         {
             ChatService.UpdateLastSeen(_userId);
-            var messages = ChatService.GetMessages(_lastMessage, _userId);
+            var messages = ChatService.GetMessages();
             foreach (var m in messages)
             {
                 string prefix = m.Recipient == null ? string.Empty : $"[PM to {m.Recipient}] ";
                 txtChatDisplay.AppendText($"[{m.SentAt:HH:mm:ss}] {m.Sender}: {prefix}{m.Message}\r\n");
-                _lastMessage = m.SentAt;
             }
             lstOnline.DataSource = ChatService.GetOnlinePlayers();
             lstFriends.DataSource = FriendService.GetFriends(_userId);

--- a/fetch_all_chat_messages.sql
+++ b/fetch_all_chat_messages.sql
@@ -1,0 +1,5 @@
+SELECT c.sender_id, u.nickname AS sender, c.message, c.sent_at, r.nickname AS recipient
+FROM chat_messages c
+JOIN users u ON c.sender_id = u.id
+LEFT JOIN users r ON c.recipient_id = r.id
+ORDER BY c.sent_at;


### PR DESCRIPTION
## Summary
- Add `fetch_all_chat_messages.sql` and Unity equivalent to pull every chat record
- Update WinForms and Unity chat services to use simple fetch-all query
- Remove incremental chat tracking from form and manager

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: NETSDK1100: To build a project targeting Windows on this operating system, set the EnableWindowsTargeting property to true)*

------
https://chatgpt.com/codex/tasks/task_e_68c36c95d7e883338c01bbb2d93c8453