### PR TITLE
Ensure chat scroll content grows with messages

### DIFF
--- a/GDD.md
+++ b/GDD.md
@@ -1,5 +1,5 @@
 # Game Design Document (Living) — ygoCGPTE
-_Last updated: 2025-09-13 15:53 UTC • Document owner: Codex_
+_Last updated: 2025-09-13 16:31 UTC • Document owner: Codex_
 
 ## 0. Executive Snapshot
 - **Current Phase:** Porting Core Systems to Unity
@@ -113,12 +113,12 @@ _Last updated: 2025-09-13 15:53 UTC • Document owner: Codex_
 - **Rules & Data**
   Chat via MySQL tables.
 - **UX notes**
-  Chat window scrollback (auto-scroll implemented).
+  Chat window scrollback; content grows with messages (auto-scroll implemented).
 - **Technical notes**
   `ChatService` to be rewritten for Unity.
 - **Owner:** TBD
 - **Dependencies:** ChatService backend, ScrollRect hookup
-- **Progress:** In progress, 8% ([PR #288](https://github.com/bullshag/ygoCGPTE/pull/288))
+- **Progress:** In progress, 9% ([PR #288](https://github.com/bullshag/ygoCGPTE/pull/288))
 - **Acceptance criteria:** Send/receive chat messages; auto-scroll to latest message on login
 - **Risks:** Message flow still unverified may block broader networking features
 - **Open decisions:**
@@ -161,7 +161,7 @@ _Last updated: 2025-09-13 15:53 UTC • Document owner: Codex_
 
 | Legacy Feature | Unity Equivalent | Status | Owner | Notes |
 |---|---|---|---|---|
-| ChatService | Chat UI & service script | In progress | TBD | Auto-scroll on login verified; send/receive pending |
+| ChatService | Chat UI & service script | In progress | TBD | Auto-scroll on login verified; content resizes with messages; send/receive pending |
 | InventoryForm | InventoryUI | Not started | TBD | Requires `unity_inventory_load.sql` |
 | BattleForm | BattleScene | In progress | TBD | Basic scene scaffold |
 | ShopForm | ShopUI | Not started | TBD | Pricing logic TBD |
@@ -249,3 +249,4 @@ _Last updated: 2025-09-13 15:53 UTC • Document owner: Codex_
 - 2025-09-13: Created initial GDD skeleton covering all sections. — Codex
 - 2025-09-13: Updated Networking progress and ChatService migration status after chat auto-scroll work (PR #288). — Codex
 - 2025-09-13: Verified chatScrollRect wiring and documented auto-scroll on login. — Codex
+- 2025-09-13: Enabled dynamic chat content resizing when new messages arrive. — Codex

--- a/New Unity Project/Assets/Scripts/RPGManager.cs
+++ b/New Unity Project/Assets/Scripts/RPGManager.cs
@@ -205,8 +205,7 @@ public class RPGManager : MonoBehaviour
                 Debug.LogError($"Failed to fetch chat messages: {task.Exception}");
             }
 
-            Canvas.ForceUpdateCanvases();
-            chatScrollRect.verticalNormalizedPosition = 0f;
+            UpdateChatContentSize();
             yield return new WaitForSeconds(2f);
         }
     }
@@ -229,10 +228,18 @@ public class RPGManager : MonoBehaviour
                 chatText.text += $"\n{msg.Sender}: {msg.Message}";
             }
         }
-            Canvas.ForceUpdateCanvases();
-            chatScrollRect.verticalNormalizedPosition = 0f;
-        Canvas.ForceUpdateCanvases();
+        UpdateChatContentSize();
+    }
 
+    private void UpdateChatContentSize()
+    {
+        if (chatText == null || chatScrollRect == null) return;
+        Canvas.ForceUpdateCanvases();
+        LayoutRebuilder.ForceRebuildLayoutImmediate(chatText.rectTransform);
+        float preferredHeight = chatText.preferredHeight;
+        chatText.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, preferredHeight);
+        chatScrollRect.content.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, preferredHeight);
+        chatScrollRect.verticalNormalizedPosition = 0f;
     }
 
     private IEnumerator RegenLoop()


### PR DESCRIPTION
## Summary
- grow chat content and text objects dynamically as messages are added
- document chat content resizing in GDD

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c59c252f5c83339c9c75a9eeb419b5