### PR TITLE
Limit chat history to 25 messages and resize scroll on login/send

### DIFF
--- a/GDD.md
+++ b/GDD.md
@@ -1,5 +1,5 @@
 # Game Design Document (Living) — ygoCGPTE
-_Last updated: 2025-09-13 15:53 UTC • Document owner: Codex_
+_Last updated: 2025-09-13 16:56 UTC • Document owner: Codex_
 
 ## 0. Executive Snapshot
 - **Current Phase:** Porting Core Systems to Unity
@@ -113,12 +113,12 @@ _Last updated: 2025-09-13 15:53 UTC • Document owner: Codex_
 - **Rules & Data**
   Chat via MySQL tables.
 - **UX notes**
-  Chat window scrollback (auto-scroll implemented).
+  Chat window scrollback; shows last 25 messages; scroll resizes only on login or when sending a message.
 - **Technical notes**
   `ChatService` to be rewritten for Unity.
 - **Owner:** TBD
 - **Dependencies:** ChatService backend, ScrollRect hookup
-- **Progress:** In progress, 8% ([PR #288](https://github.com/bullshag/ygoCGPTE/pull/288))
+  - **Progress:** In progress, 10% ([PR #288](https://github.com/bullshag/ygoCGPTE/pull/288))
 - **Acceptance criteria:** Send/receive chat messages; auto-scroll to latest message on login
 - **Risks:** Message flow still unverified may block broader networking features
 - **Open decisions:**
@@ -161,7 +161,7 @@ _Last updated: 2025-09-13 15:53 UTC • Document owner: Codex_
 
 | Legacy Feature | Unity Equivalent | Status | Owner | Notes |
 |---|---|---|---|---|
-| ChatService | Chat UI & service script | In progress | TBD | Auto-scroll on login verified; send/receive pending |
+| ChatService | Chat UI & service script | In progress | TBD | Auto-scroll on login/send; shows 25 latest messages; send/receive pending |
 | InventoryForm | InventoryUI | Not started | TBD | Requires `unity_inventory_load.sql` |
 | BattleForm | BattleScene | In progress | TBD | Basic scene scaffold |
 | ShopForm | ShopUI | Not started | TBD | Pricing logic TBD |
@@ -249,3 +249,5 @@ _Last updated: 2025-09-13 15:53 UTC • Document owner: Codex_
 - 2025-09-13: Created initial GDD skeleton covering all sections. — Codex
 - 2025-09-13: Updated Networking progress and ChatService migration status after chat auto-scroll work (PR #288). — Codex
 - 2025-09-13: Verified chatScrollRect wiring and documented auto-scroll on login. — Codex
+- 2025-09-13: Enabled dynamic chat content resizing when new messages arrive. — Codex
+- 2025-09-13: Restricted chat view to 25 messages and resized scroll only on login/send. — Codex

--- a/New Unity Project/Assets/Scripts/ChatService.cs
+++ b/New Unity Project/Assets/Scripts/ChatService.cs
@@ -18,7 +18,7 @@ namespace UnityClient
 
         public static async Task<List<ChatMessage>> GetMessagesAsync()
         {
-            string sqlPath = Path.Combine(Application.dataPath, "sql", "unity_chat_fetch_all_messages.sql");
+            string sqlPath = Path.Combine(Application.dataPath, "sql", "unity_chat_fetch_recent_messages.sql");
             try
             {
                 var rows = await DatabaseClientUnity.QueryAsync(File.ReadAllText(sqlPath));

--- a/New Unity Project/Assets/Scripts/RPGManager.cs
+++ b/New Unity Project/Assets/Scripts/RPGManager.cs
@@ -11,6 +11,7 @@ using WinFormsApp2;
 using UnityEngine.UIElements;
 using Image = UnityEngine.UI.Image;
 using Button = UnityEngine.UI.Button;
+using System.Text;
 
 public class RPGManager : MonoBehaviour
 {
@@ -35,6 +36,14 @@ public class RPGManager : MonoBehaviour
     {
         await LoadPartyMembersAsync();
         PopulatePartyList();
+
+        var initialMessages = await ChatService.GetMessagesAsync();
+        if (chatText != null)
+        {
+            chatText.text = BuildChatText(initialMessages);
+            UpdateChatContentSize();
+        }
+
         if (chatInput != null)
         {
             chatInput.onSubmit.AddListener(_ => SendChatMessage());
@@ -193,11 +202,7 @@ public class RPGManager : MonoBehaviour
             {
                 if (chatText != null)
                 {
-                    chatText.text = string.Empty;
-                    foreach (var msg in task.Result)
-                    {
-                        chatText.text += $"\n{msg.Sender}: {msg.Message}";
-                    }
+                    chatText.text = BuildChatText(task.Result);
                 }
             }
             else
@@ -205,8 +210,6 @@ public class RPGManager : MonoBehaviour
                 Debug.LogError($"Failed to fetch chat messages: {task.Exception}");
             }
 
-            Canvas.ForceUpdateCanvases();
-            chatScrollRect.verticalNormalizedPosition = 0f;
             yield return new WaitForSeconds(2f);
         }
     }
@@ -223,16 +226,33 @@ public class RPGManager : MonoBehaviour
         var messages = await ChatService.GetMessagesAsync();
         if (chatText != null)
         {
-            chatText.text = string.Empty;
-            foreach (var msg in messages)
-            {
-                chatText.text += $"\n{msg.Sender}: {msg.Message}";
-            }
+            chatText.text = BuildChatText(messages);
+            UpdateChatContentSize();
         }
-            Canvas.ForceUpdateCanvases();
-            chatScrollRect.verticalNormalizedPosition = 0f;
-        Canvas.ForceUpdateCanvases();
+    }
 
+    private string BuildChatText(List<ChatService.ChatMessage> messages)
+    {
+        if (messages == null) return string.Empty;
+        int start = Math.Max(0, messages.Count - 25);
+        StringBuilder sb = new();
+        for (int i = start; i < messages.Count; i++)
+        {
+            var msg = messages[i];
+            sb.Append('\n').Append(msg.Sender).Append(": ").Append(msg.Message);
+        }
+        return sb.ToString();
+    }
+
+    private void UpdateChatContentSize()
+    {
+        if (chatText == null || chatScrollRect == null) return;
+        Canvas.ForceUpdateCanvases();
+        LayoutRebuilder.ForceRebuildLayoutImmediate(chatText.rectTransform);
+        float preferredHeight = chatText.preferredHeight;
+        chatText.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, preferredHeight);
+        chatScrollRect.content.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, preferredHeight);
+        chatScrollRect.verticalNormalizedPosition = 0f;
     }
 
     private IEnumerator RegenLoop()

--- a/New Unity Project/Assets/sql/unity_chat_fetch_recent_messages.sql
+++ b/New Unity Project/Assets/sql/unity_chat_fetch_recent_messages.sql
@@ -1,0 +1,10 @@
+SELECT *
+FROM (
+    SELECT c.sender_id, u.nickname AS sender, c.message, c.sent_at, r.nickname AS recipient
+    FROM chat_messages c
+    JOIN users u ON c.sender_id = u.id
+    LEFT JOIN users r ON c.recipient_id = r.id
+    ORDER BY c.sent_at DESC
+    LIMIT 25
+) recent
+ORDER BY recent.sent_at;

--- a/New Unity Project/Assets/sql/unity_chat_fetch_recent_messages.sql.meta
+++ b/New Unity Project/Assets/sql/unity_chat_fetch_recent_messages.sql.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dfda28787ace4541ab7effc9a88001ab
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- fetch only 25 most recent chat messages and show them in chat
- resize chat scroll content only after initial login and when sending a message
- document chat fetch limit and resize behavior in GDD

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c59c252f5c83339c9c75a9eeb419b5