### PR TITLE
Add city node interaction triggers and docs

### DIFF
--- a/GDD.md
+++ b/GDD.md
@@ -1,5 +1,5 @@
 # Game Design Document (Living) — ygoCGPTE
-_Last updated: 2025-09-13 19:05 UTC • Document owner: Codex_
+_Last updated: 2025-09-13 19:10 UTC • Document owner: Codex_
 
 ## 0. Executive Snapshot
 - **Current Phase:** Porting Core Systems to Unity
@@ -9,7 +9,7 @@ _Last updated: 2025-09-13 19:05 UTC • Document owner: Codex_
   - Establish Unity project structure and packages.
   - Define core gameplay loop skeleton.
   - Validate MySQL connectivity from Unity client.
-  - Implement world map waypoint navigation with directional animations.
+  - Implement world map waypoint navigation with directional animations and city interaction triggers.
 - **Top Risks & Blocks (max 5):**
   - Undefined Unity version — Owner: TBD, due 2025-09-20.
   - Missing Windows Desktop SDK in CI — Owner: TBD, due 2025-09-18.
@@ -88,11 +88,14 @@ _Last updated: 2025-09-13 19:05 UTC • Document owner: Codex_
   Move player character across the world map.
 - **Rules & Data**
   Shift+Right Click sets destination; Shift+Left Click queues waypoint.
+  Entering a city radius enables the city interaction panel.
 - **UX notes**
   Directional animations reflect travel direction.
+  City interaction panel appears when entering city radius.
 - **Technical notes**
   Utilizes NavMeshAgent with a queued `Vector3` path and emits `QueueEmptied`.
-- **Progress:** In progress, 25% (commit TBD — Owner: Codex, due 2025-09-14).
+  PlayerNavigator checks `CityNode` triggers to toggle `CityInteraction` UI.
+- **Progress:** In progress, 35% (commit TBD — Owner: Codex, due 2025-09-14).
 - **Open decisions:**
   - TBD: Add path preview line. Owner: TBD, due 2025-09-30.
 
@@ -105,7 +108,7 @@ _Last updated: 2025-09-13 19:05 UTC • Document owner: Codex_
   Requires pixel font `Thaleah_PixelFont`.
 - **Technical notes**
   Built with Unity UGUI.
-- **Progress:** In progress, 8% (popup window prefab integrated).
+- **Progress:** In progress, 10% (popup window prefab and city interaction panel).
 - **Open decisions:**
   - TBD: Finalize navigation flow. Owner: TBD, due 2025-09-25.
 
@@ -182,7 +185,7 @@ _Last updated: 2025-09-13 19:05 UTC • Document owner: Codex_
 | BattleForm | BattleScene | In progress | TBD | Basic scene scaffold |
 | ShopForm | ShopUI | Not started | TBD | Pricing logic TBD |
 | PictureBox animations | FrameAnimator component | In progress | Codex | Handles sprite-frame playback |
-| WorldMapForm | WorldMap scene + PlayerNavigator | In progress | Codex | Shift-click waypoints queue |
+| WorldMapForm | WorldMap scene + PlayerNavigator | In progress | Codex | Shift-click waypoints queue; city nodes trigger interaction panel |
 
 - **Migration order:**
   1. Set up database access layer (acceptance: Unity reads `create_user.sql`).
@@ -241,6 +244,7 @@ _Last updated: 2025-09-13 19:05 UTC • Document owner: Codex_
 | FEAT-UI-002 | Implement popup window prefab | feature | Codex | 1d | SYS-ARCH-001 | Popup shows login errors with OK dismissal | Done | PR TBD | Should |
 | FEAT-ANI-001 | Sprite Frame Animator component | feature | Codex | 2d | SYS-ARCH-001 | Lists animate per state at frameRate with tests | Done | PR TBD | Should |
 | FEAT-WM-001 | World map shift-click navigation | feature | Codex | 2d | SYS-ARCH-001 | Shift+Right sets destination; Shift+Left queues waypoint; agent animates per direction | Done | PR TBD | Should |
+| FEAT-WM-002 | City node interaction panel | feature | Codex | 1d | FEAT-WM-001 | CityInteraction panel toggles when entering/exiting CityNode radius | Done | PR TBD | Should |
 
 ## 13. Non-Goals & Constraints
 - No mobile or console ports in current scope.
@@ -278,3 +282,4 @@ _Last updated: 2025-09-13 19:05 UTC • Document owner: Codex_
 - 2025-09-13: Added popup window prefab and integrated into login screen for invalid credential messages. — Codex
 - 2025-09-13: Introduced FrameAnimator component with context menus and tests to manage sprite animations. — Codex
 - 2025-09-13: Added PlayerNavigator with shift-click waypoints and NavMesh queue for world map movement. — Codex
+- 2025-09-13: Implemented CityNodeData and city interaction triggers with UI panel toggling. — Codex

--- a/New Unity Project/Assets/Docs.meta
+++ b/New Unity Project/Assets/Docs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5c78a50e-d16a-4321-a070-7a4058f31cd2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/New Unity Project/Assets/Docs/CityNodes.md
+++ b/New Unity Project/Assets/Docs/CityNodes.md
@@ -1,0 +1,9 @@
+# City Nodes
+
+City nodes define interactive areas for cities on the world map.
+
+## Requirements
+- GameObject is tagged `CityNode`.
+- `CityNodeData` component attached with a radius and city ID.
+- `SphereCollider` set as trigger with radius matching `CityNodeData`.
+- When the player enters the radius, `CityInteraction` UI panel enables; it disables on exit.

--- a/New Unity Project/Assets/Docs/CityNodes.md.meta
+++ b/New Unity Project/Assets/Docs/CityNodes.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0e9a8cc1-b454-4a38-9b6a-8eada0926d1b
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/New Unity Project/Assets/Scripts/WorldMap/CityNodeData.cs
+++ b/New Unity Project/Assets/Scripts/WorldMap/CityNodeData.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+/// <summary>
+/// Holds metadata for a city node and ensures a trigger collider with the given radius.
+/// </summary>
+[RequireComponent(typeof(SphereCollider))]
+public class CityNodeData : MonoBehaviour
+{
+    [SerializeField] private float radius = 5f;
+    [SerializeField] private string cityId = string.Empty;
+
+    private SphereCollider sphere;
+
+    private void Awake()
+    {
+        ApplyRadius();
+    }
+
+    private void OnValidate()
+    {
+        ApplyRadius();
+    }
+
+    private void ApplyRadius()
+    {
+        if (!sphere)
+        {
+            sphere = GetComponent<SphereCollider>();
+        }
+        sphere.isTrigger = true;
+        sphere.radius = radius;
+    }
+
+    /// <summary>
+    /// Identifier for the city represented by this node.
+    /// </summary>
+    public string CityId => cityId;
+}

--- a/New Unity Project/Assets/Scripts/WorldMap/CityNodeData.cs.meta
+++ b/New Unity Project/Assets/Scripts/WorldMap/CityNodeData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31852454-3796-4cb3-a1e7-9ef145058bc2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/New Unity Project/Assets/Scripts/WorldMap/PlayerNavigator.cs
+++ b/New Unity Project/Assets/Scripts/WorldMap/PlayerNavigator.cs
@@ -11,6 +11,7 @@ public class PlayerNavigator : MonoBehaviour
 {
     [SerializeField] private NavMeshAgent agent;
     [SerializeField] private FrameAnimator frameAnimator;
+    [SerializeField] private GameObject cityInteractionPanel;
 
     private readonly Queue<Vector3> waypoints = new Queue<Vector3>();
     private FrameAnimator.AnimationState currentAnimState = FrameAnimator.AnimationState.Idle;
@@ -132,6 +133,22 @@ public class PlayerNavigator : MonoBehaviour
         {
             frameAnimator?.SetState(state);
             currentAnimState = state;
+        }
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("CityNode"))
+        {
+            cityInteractionPanel?.SetActive(true);
+        }
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (other.CompareTag("CityNode"))
+        {
+            cityInteractionPanel?.SetActive(false);
         }
     }
 }

--- a/New Unity Project/ProjectSettings/TagManager.asset
+++ b/New Unity Project/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 3
-  tags: []
+  tags:
+  - CityNode
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
## Summary
- tag city nodes and define `CityNodeData` component with radius/city ID
- toggle CityInteraction panel when entering or exiting city nodes
- document city node setup and update TagManager

## Testing
- `dotnet test WinFormsApp2/BattleLands.sln` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c128fef48333a165e6d5027f5c0a