### PR TITLE
Refresh FrameAnimator meta GUIDs

### DIFF
--- a/GDD.md
+++ b/GDD.md
@@ -1,5 +1,5 @@
 # Game Design Document (Living) — ygoCGPTE
-_Last updated: 2025-09-14 00:00 UTC • Document owner: Codex_
+_Last updated: 2025-09-14 00:01 UTC • Document owner: Codex_
 
 ## 0. Executive Snapshot
 - **Current Phase:** Porting Core Systems to Unity
@@ -15,6 +15,7 @@ _Last updated: 2025-09-14 00:00 UTC • Document owner: Codex_
   - Missing Windows Desktop SDK in CI — Owner: TBD, due 2025-09-18.
   - Incomplete mapping of legacy features — Owner: TBD, due 2025-09-25.
   - Popup window usage inconsistent across scenes — Owner: Codex, due 2025-09-27.
+    - GUID corruption in `.meta` files may break asset references — Owner: Codex, due 2025-09-14.
 - **Next Milestone:** Unity Prototype Build, 2025-10-01, exit criteria: player can start battle and load inventory from database.
 
 ## 1. Vision & Pillars
@@ -288,6 +289,7 @@ _Last updated: 2025-09-14 00:00 UTC • Document owner: Codex_
 - Popup windows not standardized across scenes (Possible/Low) — Owner: Codex — Mitigation: centralize prefab usage; Trigger: inconsistent UI messaging.
 - Sprite animation lists may be incomplete (Possible/Low) — Owner: TBD — Mitigation: context menu to append frames; Trigger: missing frames during play.
 - Waypoint queue may desync with NavMesh (Possible/Low) — Owner: TBD — Mitigation: monitor agent stalls and clear queue; Trigger: agent stops unexpectedly.
+- GUID corruption in `.meta` files may break asset references (Possible/Low) — Owner: Codex — Mitigation: regenerate or reset GUIDs; Trigger: assets reference missing scripts.
 
 ## 16. Changelog (Auto-Appended)
 - 2025-09-13: Created initial GDD skeleton covering all sections. — Codex
@@ -302,3 +304,4 @@ _Last updated: 2025-09-14 00:00 UTC • Document owner: Codex_
 - 2025-09-13: Added remote player state packets, WebSocket broadcasting, interpolation, and sync tests. — Codex
 - 2025-09-14: Documented tasks for FrameAnimator combat integration and navigation path preview line; referenced mapping table. — Codex
 
+- 2025-09-14: Regenerated Unity .meta GUIDs for FrameAnimator assets (FEAT-ANI-001) to prevent reference corruption. — Codex

--- a/New Unity Project/Assets/Scripts/Animations.meta
+++ b/New Unity Project/Assets/Scripts/Animations.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4cfa7042-0a97-4256-a5d1-13cb8f26d592
+guid: 23c26da710ff4bd1a150e3688dcaae21
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/New Unity Project/Assets/Scripts/Animations/FrameAnimator.cs.meta
+++ b/New Unity Project/Assets/Scripts/Animations/FrameAnimator.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 72074d38ce5da7b4ebebbe6d48d6ef18
+guid: 9a1ea29093164d19aec57d19cb200359

--- a/New Unity Project/Assets/Tests.meta
+++ b/New Unity Project/Assets/Tests.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 669b0295-1574-4505-bcfd-6e48f859cb6f
+guid: e49cde9446cd4651a2943c357a18f95a
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/New Unity Project/Assets/Tests/FrameAnimatorTests.cs.meta
+++ b/New Unity Project/Assets/Tests/FrameAnimatorTests.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e7049a39-9a0f-4d60-bb91-aa1cef534cc4
+guid: 4b556a5e80434372940f197b36fdadd3
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
## Summary
- Regenerated GUIDs for FrameAnimator-related .meta files to resolve Unity asset reference corruption.
- Documented GUID corruption risk and updated FEAT-ANI-001 changelog in the GDD.

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c604fa4d808333a04a43f9bb7f6e22