### PR TITLE
feat: add waypoint nav agent with queue

### DIFF
--- a/GDD.md
+++ b/GDD.md
@@ -99,14 +99,21 @@ _Last updated: 2025-09-14 00:01 UTC • Document owner: Codex_
   City interaction panel appears when entering city radius.
 - **Technical notes**
   Utilizes NavMeshAgent with a queued `Vector3` path and emits `QueueEmptied`.
-
   PlayerNavigator checks `CityNode` triggers to toggle `CityInteraction` UI.
-
+- **Dependencies**
+  - Unity NavMesh
+  - Unity input system
+- **Acceptance Criteria**
+  - Shift+Left Click enqueues NavMesh hit point.
+  - Shift+Right Click clears the queue and resets the agent.
+  - Idle agent consumes queued waypoints sequentially.
+- **Risks**
+  - Shift-click input may conflict with UI focus, preventing waypoint capture.
 - **Tasks**
   - Add path preview line — Owner: TBD, Estimate: 1d, Dependencies: FEAT-WM-001, Acceptance: preview line renders for queued waypoints, Progress: 0% (due 2025-09-30).
 - **Legacy reference**
   - WorldMapForm → WorldMap scene + PlayerNavigator (see mapping table).
-- **Progress:** In progress, 35% (commit TBD — Owner: Codex, due 2025-09-14).
+ - **Progress:** In progress, 45% (commit TBD — Owner: Codex, due 2025-09-14).
 - **Open decisions:**
   - TBD: Authenticate WebSocket connections. Owner: TBD, due 2025-09-30.
 
@@ -289,6 +296,7 @@ _Last updated: 2025-09-14 00:01 UTC • Document owner: Codex_
 - Popup windows not standardized across scenes (Possible/Low) — Owner: Codex — Mitigation: centralize prefab usage; Trigger: inconsistent UI messaging.
 - Sprite animation lists may be incomplete (Possible/Low) — Owner: TBD — Mitigation: context menu to append frames; Trigger: missing frames during play.
 - Waypoint queue may desync with NavMesh (Possible/Low) — Owner: TBD — Mitigation: monitor agent stalls and clear queue; Trigger: agent stops unexpectedly.
+- Shift-click input may conflict with UI elements (Possible/Low) — Owner: TBD — Mitigation: require map focus; Trigger: waypoints fail to enqueue.
 - GUID corruption in `.meta` files may break asset references (Possible/Low) — Owner: Codex — Mitigation: regenerate or reset GUIDs; Trigger: assets reference missing scripts.
 
 ## 16. Changelog (Auto-Appended)
@@ -305,3 +313,4 @@ _Last updated: 2025-09-14 00:01 UTC • Document owner: Codex_
 - 2025-09-14: Documented tasks for FrameAnimator combat integration and navigation path preview line; referenced mapping table. — Codex
 
 - 2025-09-14: Regenerated Unity .meta GUIDs for FrameAnimator assets (FEAT-ANI-001) to prevent reference corruption. — Codex
+- 2025-09-14: Added WaypointNavAgent with queued NavMesh waypoints and shift-click clearing. — Codex

--- a/New Unity Project/Assets/Scripts/Player.meta
+++ b/New Unity Project/Assets/Scripts/Player.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 33b85ad35eb944a3953a309c2c40d03e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/New Unity Project/Assets/Scripts/Player/WaypointNavAgent.cs
+++ b/New Unity Project/Assets/Scripts/Player/WaypointNavAgent.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace Player
+{
+    /// <summary>
+    /// Handles queued waypoint navigation using shift-click inputs.
+    /// </summary>
+    [RequireComponent(typeof(NavMeshAgent))]
+    public class WaypointNavAgent : MonoBehaviour
+    {
+        private readonly Queue<Vector3> waypoints = new Queue<Vector3>();
+        private NavMeshAgent agent;
+
+        private void Awake()
+        {
+            agent = GetComponent<NavMeshAgent>();
+        }
+
+        private void Update()
+        {
+            HandleInput();
+            ProcessMovement();
+        }
+
+        private void HandleInput()
+        {
+            bool shiftHeld = Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift);
+            if (!shiftHeld) return;
+
+            if (Input.GetMouseButtonDown(0))
+            {
+                Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+                if (Physics.Raycast(ray, out RaycastHit hit))
+                {
+                    if (NavMesh.SamplePosition(hit.point, out NavMeshHit navHit, 1f, NavMesh.AllAreas))
+                    {
+                        waypoints.Enqueue(navHit.position);
+                    }
+                }
+            }
+            else if (Input.GetMouseButtonDown(1))
+            {
+                waypoints.Clear();
+                agent.ResetPath();
+            }
+        }
+
+        private void ProcessMovement()
+        {
+            if (agent.pathPending) return;
+
+            if (!agent.hasPath && waypoints.Count > 0)
+            {
+                agent.SetDestination(waypoints.Peek());
+            }
+            else if (agent.remainingDistance <= agent.stoppingDistance)
+            {
+                if (waypoints.Count > 0)
+                {
+                    waypoints.Dequeue();
+                    if (waypoints.Count > 0)
+                    {
+                        agent.SetDestination(waypoints.Peek());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/New Unity Project/Assets/Scripts/Player/WaypointNavAgent.cs.meta
+++ b/New Unity Project/Assets/Scripts/Player/WaypointNavAgent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93cac63753324a74a27897d81e2ef1a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add `WaypointNavAgent` for shift-click waypoint queuing and clearing
- document world map navigation dependencies and risks

## Testing
- `dotnet test WinFormsApp2.Tests/WinFormsApp2.Tests.csproj` *(fails: missing Microsoft.NET.Sdk.WindowsDesktop)*

------
https://chatgpt.com/codex/tasks/task_e_68c61bc261e88333b5115455eb9c1cb2