### PR TITLE
Add remote player markers and manager

### DIFF
--- a/GDD.md
+++ b/GDD.md
@@ -183,10 +183,13 @@ _Last updated: 2025-09-14 01:42 UTC • Document owner: Codex_
   - TBD: Evaluate real-time networking framework. Owner: TBD, due 2025-10-15.
 
 #### Player State Sync
-- **Dependencies:** `player_position` table, `DatabaseClientUnity`
-- **Acceptance Criteria:** Uploader persists current position; downloader retrieves other players' positions.
+- **Dependencies:** `player_position` table, `DatabaseClientUnity`, NavMeshAgent
+- **Acceptance Criteria:**
+  - Uploader persists current position.
+  - Downloader retrieves other players' positions.
+  - RemotePlayerManager spawns markers for online players, sets destinations to next waypoints, and toggles online state each poll.
 - **Risks:** Stale or missing rows may desync remote markers.
-- **Progress:** In progress, 25% — Owner: Codex, due 2025-09-21
+- **Progress:** In progress, 50% — Owner: Codex, due 2025-09-21
 
 ## 5. Content
 - **Units/Characters/Items/Levels**
@@ -232,7 +235,7 @@ _Last updated: 2025-09-14 01:42 UTC • Document owner: Codex_
 | PictureBox animations | FrameAnimator component | In progress | Codex | Handles sprite-frame playback |
 
 | WorldMapForm | WorldMap scene + PlayerNavigator | In progress | Codex | Shift-click waypoints queue |
-| WorldMap remote party markers | RemotePlayer entities | In progress | Codex | WebSocket state sync with interpolation |
+| WorldMap remote party markers | RemotePlayer entities | In progress | Codex | NavMesh markers spawn and follow downloaded waypoints; WebSocket state sync with interpolation |
 | (New) Free camera navigation | FreeCameraController | In progress | Codex | WASD panning with smoothing |
 | TravelLogService | PlayerStateUploader/Downloader | In progress | Codex | Periodic SQL sync of player positions |
 
@@ -364,3 +367,4 @@ _Last updated: 2025-09-14 01:42 UTC • Document owner: Codex_
 - 2025-09-14: Regenerated Unity .meta GUIDs for FrameAnimator assets (FEAT-ANI-001) to prevent reference corruption. — Codex
 - 2025-09-14: Added WaypointNavAgent with queued NavMesh waypoints and shift-click clearing. — Codex
 - 2025-09-14: Added player_position schema and PlayerState upload/download services for world map sync. — Codex
+- 2025-09-14: Introduced RemotePlayerMarker prefab and manager for NavMesh waypoint syncing and online/offline tracking. — Codex

--- a/New Unity Project/Assets/Prefabs/RemotePlayerMarker.prefab
+++ b/New Unity Project/Assets/Prefabs/RemotePlayerMarker.prefab
@@ -1,0 +1,44 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1000
+GameObject:
+  m_Name: RemotePlayerMarker
+  m_TagString: Untagged
+  m_IsActive: 1
+  m_Layer: 0
+  m_Component:
+  - component: {fileID: 4000}
+  - component: {fileID: 7000}
+  - component: {fileID: 11400000}
+--- !u!4 &4000
+Transform:
+  m_GameObject: {fileID: 1000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Father: {fileID: 0}
+--- !u!195 &7000
+NavMeshAgent:
+  m_GameObject: {fileID: 1000}
+  m_Enabled: 1
+  serializedVersion: 4
+  m_AgentTypeID: 0
+  m_Radius: 0.5
+  m_Speed: 3.5
+  m_Acceleration: 8
+  m_AngularSpeed: 120
+  m_StoppingDistance: 0
+  m_AutoTraverseOffMeshLink: 1
+  m_AutoBraking: 1
+  m_AutoRepath: 1
+  m_Height: 2
+  m_BaseOffset: 0
+  m_WalkableMask: 4294967295
+  m_ObstacleAvoidanceType: 0
+  m_AvoidancePriority: 50
+--- !u!114 &11400000
+MonoBehaviour:
+  m_GameObject: {fileID: 1000}
+  m_Script: {fileID: 11500000, guid: 85c88aa21ded4e418d79a78418640e9a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/New Unity Project/Assets/Prefabs/RemotePlayerMarker.prefab.meta
+++ b/New Unity Project/Assets/Prefabs/RemotePlayerMarker.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3528c74a371c49d881486b53c77fb64b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Scripts/Player/RemotePlayerManager.cs
+++ b/New Unity Project/Assets/Scripts/Player/RemotePlayerManager.cs
@@ -1,0 +1,75 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Networking;
+
+namespace Player
+{
+    /// <summary>
+    /// Spawns and updates <see cref="RemotePlayerMarker"/> instances for other online players.
+    /// </summary>
+    public class RemotePlayerManager : MonoBehaviour
+    {
+        [SerializeField] private RemotePlayerMarker markerPrefab;
+        [SerializeField] private PlayerStateDownloader downloader;
+        [SerializeField] private float syncInterval = 1f;
+
+        private readonly Dictionary<int, RemotePlayerMarker> markers = new();
+        private float nextSyncTime;
+
+        private void Awake()
+        {
+            if (!downloader)
+            {
+                downloader = FindObjectOfType<PlayerStateDownloader>();
+            }
+        }
+
+        private void Update()
+        {
+            if (Time.time >= nextSyncTime)
+            {
+                nextSyncTime = Time.time + syncInterval;
+                SyncMarkers();
+            }
+
+            foreach (var marker in markers.Values)
+            {
+                var agent = marker.Agent;
+                marker.transform.position = agent.transform.position;
+            }
+        }
+
+        private void SyncMarkers()
+        {
+            var onlineIds = new HashSet<int>(downloader.OtherPlayers.Keys);
+
+            foreach (var kvp in downloader.OtherPlayers)
+            {
+                int id = kvp.Key;
+                var state = kvp.Value;
+
+                if (!markers.TryGetValue(id, out var marker))
+                {
+                    marker = Instantiate(markerPrefab, state.Position, Quaternion.identity, transform);
+                    marker.Initialize(id);
+                    markers.Add(id, marker);
+                }
+
+                marker.IsOnline = true;
+
+                if (state.IsTraveling && state.NextWaypoint.HasValue)
+                {
+                    marker.Agent.SetDestination(state.NextWaypoint.Value);
+                }
+            }
+
+            foreach (var pair in markers)
+            {
+                if (!onlineIds.Contains(pair.Key))
+                {
+                    pair.Value.IsOnline = false;
+                }
+            }
+        }
+    }
+}

--- a/New Unity Project/Assets/Scripts/Player/RemotePlayerManager.cs.meta
+++ b/New Unity Project/Assets/Scripts/Player/RemotePlayerManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7edd528dde3e4a2fab660a2ac11afb08
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/New Unity Project/Assets/Scripts/Player/RemotePlayerMarker.cs
+++ b/New Unity Project/Assets/Scripts/Player/RemotePlayerMarker.cs
@@ -1,0 +1,42 @@
+using UnityEngine;
+using UnityEngine.AI;
+
+namespace Player
+{
+    /// <summary>
+    /// Simple component used to identify and control remote player markers.
+    /// </summary>
+    [RequireComponent(typeof(NavMeshAgent))]
+    public class RemotePlayerMarker : MonoBehaviour
+    {
+        private NavMeshAgent agent;
+
+        /// <summary>
+        /// Identifier provided by the server for this remote player.
+        /// </summary>
+        public int PlayerId { get; private set; }
+
+        /// <summary>
+        /// True when the player has a current row in the download results.
+        /// </summary>
+        public bool IsOnline { get; set; }
+
+        /// <summary>
+        /// Exposes the NavMeshAgent for movement control.
+        /// </summary>
+        public NavMeshAgent Agent => agent;
+
+        private void Awake()
+        {
+            agent = GetComponent<NavMeshAgent>();
+        }
+
+        /// <summary>
+        /// Initializes the marker with its player identifier.
+        /// </summary>
+        public void Initialize(int playerId)
+        {
+            PlayerId = playerId;
+        }
+    }
+}

--- a/New Unity Project/Assets/Scripts/Player/RemotePlayerMarker.cs.meta
+++ b/New Unity Project/Assets/Scripts/Player/RemotePlayerMarker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 85c88aa21ded4e418d79a78418640e9a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- Add RemotePlayerMarker prefab with NavMeshAgent and identifying component
- Implement RemotePlayerManager to spawn and sync markers for online players
- Document remote player marker synchronization in GDD

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68c61e3c82a08333b0d49808158705a7