### PR TITLE
Add area tooltip controller

### DIFF
--- a/GDD.md
+++ b/GDD.md
@@ -98,10 +98,12 @@ _Last updated: 2025-09-14 02:23 UTC • Document owner: Codex_
   Directional and idle animations reflect agent movement state.
   City interaction panel appears when entering city radius.
   Waypoint markers show queued clicks and a path line previews the route.
+  Area tooltips appear over interactable locations, showing the area name with Info/Enter actions while the player remains inside the trigger.
 - **Technical notes**
   Utilizes NavMeshAgent with a queued `Vector3` path and emits `QueueEmptied`.
   PlayerNavigator instantiates waypoint marker prefabs and updates a LineRenderer for path preview.
   PlayerNavigator checks `CityNode` triggers to toggle `CityInteraction` UI.
+  AreaTooltip enforces trigger colliders, updates TMP labels, and orchestrates show/idle/hide animator states with UnityEvents for buttons.
 - **Dependencies**
   - Unity NavMesh
   - Unity input system
@@ -110,13 +112,15 @@ _Last updated: 2025-09-14 02:23 UTC • Document owner: Codex_
   - Shift+Right Click clears the queue and resets the agent.
   - Idle animation plays when the agent is stationary.
   - Idle agent consumes queued waypoints sequentially.
+  - Area tooltip animator plays show → idle while player remains inside trigger and hide when they exit.
 - **Risks**
   - Shift-click input may conflict with UI focus, preventing waypoint capture.
 - **Tasks**
   - Add path preview line — Owner: Codex, Estimate: 1d, Dependencies: FEAT-WM-001, Acceptance: preview line renders for queued waypoints, Progress: 100% (due 2025-09-30).
+  - Implement area tooltip interactions — Owner: Codex, Estimate: 1d, Dependencies: FEAT-WM-001, Acceptance: Tooltip displays area name, plays show/idle/hide states, and invokes Info/Enter events, Progress: 100% (due 2025-09-16).
 - **Legacy reference**
   - WorldMapForm → WorldMap scene + PlayerNavigator (see mapping table).
- - **Progress:** In progress, 70% (commit TBD — Owner: Codex, due 2025-09-14).
+- **Progress:** In progress, 80% (commit TBD — Owner: Codex, due 2025-09-16).
 - **Open decisions:**
   - TBD: Authenticate WebSocket connections. Owner: TBD, due 2025-09-30.
 
@@ -262,6 +266,7 @@ _Last updated: 2025-09-14 02:23 UTC • Document owner: Codex_
 
 | WorldMapForm | WorldMap scene + PlayerNavigator | In progress | Codex | Shift-click waypoints queue |
 | WorldMap remote party markers | RemotePlayer entities | In progress | Codex | NavMesh markers spawn and follow downloaded waypoints; WebSocket state sync with interpolation |
+| WorldMap location tooltip | AreaTooltip prefab controller | Complete | Codex | Collider-driven show/idle/hide animations with area name and button events |
 | (New) Free camera navigation | FreeCameraController | In progress | Codex | WASD panning with smoothing |
 | TravelLogService | PlayerStateUploader/Downloader | In progress | Codex | Periodic SQL sync of player positions |
 
@@ -356,6 +361,7 @@ _Last updated: 2025-09-14 02:23 UTC • Document owner: Codex_
 | FEAT-WM-002 | City node interaction panel | feature | Codex | 1d | FEAT-WM-001 | CityInteraction panel toggles when entering/exiting CityNode radius | Done | 100% | PR TBD | Should |
 | FEAT-CBT-002 | Integrate FrameAnimator with battle actions | feature | TBD | 2d | FEAT-ANI-001, FEAT-CBT-001 | Attack and damage sequences play via FrameAnimator | To Do | 0% | - | Should |
 | FEAT-WM-003 | Navigation path preview line | feature | Codex | 1d | FEAT-WM-001 | Queued waypoints display a preview line | Done | 100% | PR TBD | Should |
+| FEAT-WM-004 | Area tooltip interactions | feature | Codex | 1d | FEAT-WM-001 | Tooltip shows area name, plays show/idle/hide states, and raises Info/Enter events | Done | 100% | PR TBD | Should |
 | FEAT-CAM-001 | Free camera controller | feature | Codex | 1d | FEAT-WM-001 | WASD pans camera with smoothing | In Progress | 10% | - | Should |
 | FEAT-NET-001 | Player state upload service | feature | Codex | 1d | player_position table | Uploader posts position every second | Done | 100% | - | Should |
 | FEAT-NET-002 | Player state download service | feature | Codex | 1d | player_position table, FEAT-NET-001 | Downloader fetches other players' positions | Done | 100% | - | Should |
@@ -418,4 +424,5 @@ _Last updated: 2025-09-14 02:23 UTC • Document owner: Codex_
 - 2025-09-14: Added waypoint marker prefab and path preview line rendering for queued waypoints. — Codex
 
 - 2025-09-16: Authored `recreate_accounts_tables.sql` to rebuild the accounts schema and captured maintenance guidance in the GDD. — Codex
+- 2025-09-16: Added AreaTooltip controller for world map location overlays and documented collider-driven show/idle/hide flow. — Codex
 

--- a/New Unity Project/Assets/Scripts/UI/AreaTooltip.cs
+++ b/New Unity Project/Assets/Scripts/UI/AreaTooltip.cs
@@ -1,0 +1,319 @@
+using System.Collections;
+using TMPro;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.UI;
+
+/// <summary>
+/// Controls the visibility and interaction logic for an area tooltip prefab.
+/// </summary>
+[RequireComponent(typeof(Collider))]
+public class AreaTooltip : MonoBehaviour
+{
+    [Header("Configuration")]
+    [SerializeField]
+    private string areaName = "TBD";
+
+    [SerializeField]
+    private string playerTag = "Player";
+
+    [Header("UI References")]
+    [SerializeField]
+    private TMP_Text areaNameLabel = null!;
+
+    [SerializeField]
+    private Button infoButton = null!;
+
+    [SerializeField]
+    private Button enterButton = null!;
+
+    [SerializeField]
+    private Animator tooltipAnimator = null!;
+
+    [Header("Animator States")]
+    [Tooltip("State name for the show animation.")]
+    [SerializeField]
+    private string showStateName = "Show";
+
+    [Tooltip("Trigger name that plays the show animation.")]
+    [SerializeField]
+    private string showTriggerName = "Show";
+
+    [Tooltip("State name for the idle animation.")]
+    [SerializeField]
+    private string idleStateName = "Idle";
+
+    [Tooltip("Animator cross-fade duration when switching to idle.")]
+    [SerializeField]
+    private float idleCrossFadeDuration = 0.1f;
+
+    [Tooltip("Trigger name that plays the hide animation.")]
+    [SerializeField]
+    private string hideTriggerName = "Hide";
+
+    [Header("Events")]
+    public UnityEvent InfoClicked = new();
+    public UnityEvent EnterClicked = new();
+
+    private readonly WaitForEndOfFrame waitForEndOfFrame = new();
+    private int showStateHash;
+    private int idleStateHash;
+    private int showTriggerHash;
+    private int hideTriggerHash;
+    private Coroutine idleCoroutine;
+    private bool isPlayerInside;
+
+    private void Awake()
+    {
+        ValidateSerializedFields();
+        CacheAnimatorHashes();
+        BindButtons();
+        UpdateAreaNameLabel();
+
+        var collider = GetComponent<Collider>();
+        collider.isTrigger = true;
+    }
+
+    private void OnValidate()
+    {
+        CacheAnimatorHashes();
+        UpdateAreaNameLabel();
+    }
+
+    private void OnEnable()
+    {
+        UpdateAreaNameLabel();
+    }
+
+    private void OnDisable()
+    {
+        StopIdleCoroutine();
+        isPlayerInside = false;
+    }
+
+    private void OnDestroy()
+    {
+        UnbindButtons();
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (!other.CompareTag(playerTag))
+        {
+            return;
+        }
+
+        isPlayerInside = true;
+        PlayShowAnimation();
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (!other.CompareTag(playerTag))
+        {
+            return;
+        }
+
+        isPlayerInside = false;
+        StopIdleCoroutine();
+        if (tooltipAnimator != null && hideTriggerHash != 0)
+        {
+            tooltipAnimator.ResetTrigger(showTriggerHash);
+            tooltipAnimator.SetTrigger(hideTriggerHash);
+        }
+    }
+
+    /// <summary>
+    /// Updates the tooltip text with the configured area name.
+    /// </summary>
+    public void RefreshAreaName(string newAreaName)
+    {
+        areaName = newAreaName;
+        UpdateAreaNameLabel();
+    }
+
+    private void UpdateAreaNameLabel()
+    {
+        if (areaNameLabel != null)
+        {
+            areaNameLabel.text = areaName;
+        }
+    }
+
+    private void PlayShowAnimation()
+    {
+        if (tooltipAnimator == null)
+        {
+            return;
+        }
+
+        if (hideTriggerHash != 0)
+        {
+            tooltipAnimator.ResetTrigger(hideTriggerHash);
+        }
+
+        if (showTriggerHash == 0)
+        {
+            Debug.LogWarning($"[{nameof(AreaTooltip)}] Show trigger name is empty; cannot play show animation.", this);
+            return;
+        }
+
+        tooltipAnimator.SetTrigger(showTriggerHash);
+
+        RestartIdleCoroutine();
+    }
+
+    private void RestartIdleCoroutine()
+    {
+        if (string.IsNullOrEmpty(idleStateName) || string.IsNullOrEmpty(showStateName) || tooltipAnimator == null)
+        {
+            return;
+        }
+
+        StopIdleCoroutine();
+        idleCoroutine = StartCoroutine(WaitForShowThenIdle());
+    }
+
+    private IEnumerator WaitForShowThenIdle()
+    {
+        // Ensure we are evaluating after Animator updates this frame.
+        yield return waitForEndOfFrame;
+
+        if (tooltipAnimator == null)
+        {
+            yield break;
+        }
+
+        var showInfo = tooltipAnimator.GetCurrentAnimatorStateInfo(0);
+        var startHash = showInfo.shortNameHash;
+
+        if (startHash != showStateHash)
+        {
+            // Wait for the show state to start playing.
+            var watchdog = 0;
+            while (watchdog++ < 60)
+            {
+                yield return null;
+                showInfo = tooltipAnimator.GetCurrentAnimatorStateInfo(0);
+                if (showInfo.shortNameHash == showStateHash)
+                {
+                    break;
+                }
+            }
+        }
+
+        showInfo = tooltipAnimator.GetCurrentAnimatorStateInfo(0);
+        if (showInfo.shortNameHash != showStateHash)
+        {
+            yield break;
+        }
+
+        var normalizedTime = showInfo.normalizedTime;
+        var remainingTime = (1f - (normalizedTime % 1f)) * showInfo.length / Mathf.Max(showInfo.speed, 0.001f);
+        if (remainingTime > 0f)
+        {
+            yield return new WaitForSeconds(remainingTime);
+        }
+
+        if (tooltipAnimator != null && idleStateHash != 0 && isPlayerInside)
+        {
+            tooltipAnimator.CrossFade(idleStateHash, idleCrossFadeDuration);
+        }
+    }
+
+    private void StopIdleCoroutine()
+    {
+        if (idleCoroutine != null)
+        {
+            StopCoroutine(idleCoroutine);
+            idleCoroutine = null;
+        }
+    }
+
+    private void CacheAnimatorHashes()
+    {
+        showStateHash = Animator.StringToHash(showStateName);
+        idleStateHash = Animator.StringToHash(idleStateName);
+        showTriggerHash = Animator.StringToHash(showTriggerName);
+        hideTriggerHash = Animator.StringToHash(hideTriggerName);
+    }
+
+    private void BindButtons()
+    {
+        if (infoButton != null)
+        {
+            infoButton.onClick.AddListener(HandleInfoClicked);
+        }
+
+        if (enterButton != null)
+        {
+            enterButton.onClick.AddListener(HandleEnterClicked);
+        }
+    }
+
+    private void UnbindButtons()
+    {
+        if (infoButton != null)
+        {
+            infoButton.onClick.RemoveListener(HandleInfoClicked);
+        }
+
+        if (enterButton != null)
+        {
+            enterButton.onClick.RemoveListener(HandleEnterClicked);
+        }
+    }
+
+    private void HandleInfoClicked()
+    {
+        InfoClicked.Invoke();
+    }
+
+    private void HandleEnterClicked()
+    {
+        EnterClicked.Invoke();
+    }
+
+    private void ValidateSerializedFields()
+    {
+        if (areaNameLabel == null)
+        {
+            Debug.LogWarning($"[{nameof(AreaTooltip)}] Area name label is not assigned.", this);
+        }
+
+        if (infoButton == null)
+        {
+            Debug.LogWarning($"[{nameof(AreaTooltip)}] Info button is not assigned.", this);
+        }
+
+        if (enterButton == null)
+        {
+            Debug.LogWarning($"[{nameof(AreaTooltip)}] Enter button is not assigned.", this);
+        }
+
+        if (tooltipAnimator == null)
+        {
+            Debug.LogWarning($"[{nameof(AreaTooltip)}] Animator is not assigned.", this);
+        }
+
+        if (string.IsNullOrWhiteSpace(showStateName))
+        {
+            Debug.LogWarning($"[{nameof(AreaTooltip)}] Show state name is empty; idle transition will be skipped.", this);
+        }
+
+        if (string.IsNullOrWhiteSpace(idleStateName))
+        {
+            Debug.LogWarning($"[{nameof(AreaTooltip)}] Idle state name is empty; idle transition will be skipped.", this);
+        }
+
+        if (string.IsNullOrWhiteSpace(showTriggerName))
+        {
+            Debug.LogWarning($"[{nameof(AreaTooltip)}] Show trigger name is empty; tooltip cannot animate in.", this);
+        }
+
+        if (string.IsNullOrWhiteSpace(hideTriggerName))
+        {
+            Debug.LogWarning($"[{nameof(AreaTooltip)}] Hide trigger name is empty; tooltip cannot animate out.", this);
+        }
+    }
+}

--- a/New Unity Project/Assets/Scripts/UI/AreaTooltip.cs.meta
+++ b/New Unity Project/Assets/Scripts/UI/AreaTooltip.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eafcd6f7336d454aa9c29ae642af1b6b


### PR DESCRIPTION
## Summary
- add an AreaTooltip MonoBehaviour to drive show/idle/hide animations, enforce trigger colliders, and surface UnityEvents for the Info and Enter buttons
- update tooltip text handling so the area name stays in sync and animations transition back to idle while the player remains inside the trigger
- document the new world map tooltip interactions, task tracking, and mapping table entry in the living GDD

## Testing
- not run (Unity editor unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68c9d4b5cf5c8333a01812d6a02241ac