### PR TITLE
Add popup feedback to register screen

### DIFF
--- a/GDD.md
+++ b/GDD.md
@@ -1,5 +1,5 @@
 # Game Design Document (Living) — ygoCGPTE
-_Last updated: 2025-09-14 02:23 UTC • Document owner: Codex_
+_Last updated: 2025-09-16 21:33 UTC • Document owner: Codex_
 
 ## 0. Executive Snapshot
 - **Current Phase:** Porting Core Systems to Unity
@@ -14,7 +14,7 @@ _Last updated: 2025-09-14 02:23 UTC • Document owner: Codex_
   - Undefined Unity version — Owner: TBD, due 2025-09-20.
   - Missing Windows Desktop SDK in CI — Owner: TBD, due 2025-09-18.
   - Incomplete mapping of legacy features — Owner: TBD, due 2025-09-25.
-  - Popup window usage inconsistent across scenes — Owner: Codex, due 2025-09-27.
+  - Popup window usage inconsistent across scenes — Owner: Codex, due 2025-09-27 (Login and Register now share PopupWindow prefab; remaining scenes pending audit).
     - GUID corruption in `.meta` files may break asset references — Owner: Codex, due 2025-09-14.
 - **Next Milestone:** Unity Prototype Build, 2025-10-01, exit criteria: player can start battle and load inventory from database.
 
@@ -296,6 +296,16 @@ _Last updated: 2025-09-14 02:23 UTC • Document owner: Codex_
 - **Accessibility:** requirements and status
   - TBD: colorblind mode, text scaling. Owner: TBD, due 2025-10-12.
 
+### Register Screen Feedback
+- **Owner:** Codex
+- **Dependencies:** PopupWindow prefab, DatabaseClientUnity, Register scene Canvas
+- **Progress:** Complete, 100%
+- **Acceptance Criteria:**
+  - Register attempts display PopupWindow messaging for success and failure states.
+  - Success popup transitions to the Login scene after player acknowledgment.
+  - Validation and duplicate username/nickname errors use the popup prefab.
+- **Risks:** PopupWindow reference could be lost during scene merges — Owner: Codex, due 2025-09-27.
+
 ## 9. Data & Persistence
 - **Save format** (JSON/ScriptableObject/etc.)
   - TBD
@@ -356,6 +366,7 @@ _Last updated: 2025-09-14 02:23 UTC • Document owner: Codex_
 | FEAT-INV-001 | Port Inventory UI | feature | TBD | 5d | SYS-ARCH-001 | Items/equipment load/save via SQL | To Do | 0% | - | Must |
 | FEAT-CBT-001 | Create BattleScene | feature | TBD | 7d | SYS-ARCH-001 | Player can start and resolve battle | To Do | 0% | - | Should |
 | FEAT-UI-002 | Implement popup window prefab | feature | Codex | 1d | SYS-ARCH-001 | Popup shows login errors with OK dismissal | Done | 100% | PR TBD | Should |
+| FEAT-UI-003 | Register success popup flow | feature | Codex | 0.5d | PopupWindow prefab, Register scene Canvas | Register screen shows popup on success/failure and returns to Login after confirmation | Done | 100% | PR TBD | Should |
 | FEAT-ANI-001 | Sprite Frame Animator component | feature | Codex | 2d | SYS-ARCH-001 | Lists animate per state at frameRate with tests | Done | 100% | PR TBD | Should |
 | FEAT-WM-001 | World map shift-click navigation | feature | Codex | 2d | SYS-ARCH-001 | Shift+Right sets destination; Shift+Left queues waypoint; agent animates per direction | Done | 100% | PR TBD | Should |
 | FEAT-WM-002 | City node interaction panel | feature | Codex | 1d | FEAT-WM-001 | CityInteraction panel toggles when entering/exiting CityNode radius | Done | 100% | PR TBD | Should |
@@ -425,4 +436,6 @@ _Last updated: 2025-09-14 02:23 UTC • Document owner: Codex_
 
 - 2025-09-16: Authored `recreate_accounts_tables.sql` to rebuild the accounts schema and captured maintenance guidance in the GDD. — Codex
 - 2025-09-16: Added AreaTooltip controller for world map location overlays and documented collider-driven show/idle/hide flow. — Codex
+
+- 2025-09-16: Routed RegisterManager to PopupWindow prefab for validation, duplicate checks, and success confirmation that returns to Login. — Codex
 

--- a/New Unity Project/Assets/Scenes/Register/Register.unity
+++ b/New Unity Project/Assets/Scenes/Register/Register.unity
@@ -170,6 +170,7 @@ MonoBehaviour:
   debugServerToggle: {fileID: 2134382251}
   kimServerToggle: {fileID: 421655209}
   registerButton: {fileID: 2020028608}
+  popupWindowPrefab: {fileID: 693688904551098799, guid: df2c93a0d30ab894a8ebc54d83702a6f, type: 3}
 --- !u!1 &45358550
 GameObject:
   m_ObjectHideFlags: 0

--- a/New Unity Project/Assets/Scripts/RegisterManager.cs
+++ b/New Unity Project/Assets/Scripts/RegisterManager.cs
@@ -17,6 +17,7 @@ public class RegisterManager : MonoBehaviour
     public Toggle debugServerToggle;
     public Toggle kimServerToggle;
     public Button registerButton;
+    public PopupWindow popupWindowPrefab;
 
     private void Start()
     {
@@ -154,67 +155,83 @@ public class RegisterManager : MonoBehaviour
         if (user.Contains(" ") || pass.Contains(" ") || nick.Contains(" "))
         {
             Debug.Log("No spaces allowed in username, nickname or password");
+            ShowPopup("No spaces allowed in username, nickname or password.");
             return;
         }
         if (user.Length < 3 || user.Length > 12 || pass.Length < 3 || pass.Length > 12 || nick.Length < 3 || nick.Length > 12)
         {
             Debug.Log("Username, nickname and password must be 3-12 characters");
+            ShowPopup("Username, nickname and password must be 3-12 characters.");
             return;
         }
         if (pass != confirm)
         {
             Debug.Log("Passwords do not match");
+            ShowPopup("Passwords do not match.");
             return;
         }
 
         DatabaseConfigUnity.DebugMode = debugServerToggle != null && debugServerToggle.isOn;
         DatabaseConfigUnity.UseKimServer = kimServerToggle != null && kimServerToggle.isOn;
 
-        string checkUserPath = Path.Combine(Application.dataPath, "sql", "unity_register_check_username.sql");
-        var checkUserRows = await DatabaseClientUnity.QueryAsync(File.ReadAllText(checkUserPath), new Dictionary<string, object?> { ["@username"] = user });
-        if (Convert.ToInt32(checkUserRows[0]["cnt"]) > 0)
+        try
         {
-            Debug.Log("Username already exists");
-            return;
-        }
+            string checkUserPath = Path.Combine(Application.dataPath, "sql", "unity_register_check_username.sql");
+            var checkUserRows = await DatabaseClientUnity.QueryAsync(File.ReadAllText(checkUserPath), new Dictionary<string, object?> { ["@username"] = user });
+            if (Convert.ToInt32(checkUserRows[0]["cnt"]) > 0)
+            {
+                Debug.Log("Username already exists");
+                ShowPopup("Username already exists.");
+                return;
+            }
 
-        string checkNickPath = Path.Combine(Application.dataPath, "sql", "unity_register_check_nickname.sql");
-        var checkNickRows = await DatabaseClientUnity.QueryAsync(File.ReadAllText(checkNickPath), new Dictionary<string, object?> { ["@nickname"] = nick });
-        if (Convert.ToInt32(checkNickRows[0]["cnt"]) > 0)
-        {
-            Debug.Log("Nickname already exists");
-            return;
-        }
+            string checkNickPath = Path.Combine(Application.dataPath, "sql", "unity_register_check_nickname.sql");
+            var checkNickRows = await DatabaseClientUnity.QueryAsync(File.ReadAllText(checkNickPath), new Dictionary<string, object?> { ["@nickname"] = nick });
+            if (Convert.ToInt32(checkNickRows[0]["cnt"]) > 0)
+            {
+                Debug.Log("Nickname already exists");
+                ShowPopup("Nickname already exists.");
+                return;
+            }
 
-        var parameters = new Dictionary<string, object?>
-        {
-            ["@username"] = user,
-            ["@nickname"] = nick,
-            ["@password"] = pass
-        };
-        Debug.Log($"Register params - username: {user}, nickname: {nick}");
+            var parameters = new Dictionary<string, object?>
+            {
+                ["@username"] = user,
+                ["@nickname"] = nick,
+                ["@password"] = pass
+            };
+            Debug.Log($"Register params - username: {user}, nickname: {nick}");
 
-        string insertPath = Path.Combine(Application.dataPath, "sql", "unity_register_insert_plain.sql");
-        int rows = await DatabaseClientUnity.ExecuteAsync(File.ReadAllText(insertPath), parameters);
-        Debug.Log($"Insert result: {rows}");
-        if (rows > 0)
-        {
-            string idPath = Path.Combine(Application.dataPath, "sql", "unity_register_get_id.sql");
-            var idRows = await DatabaseClientUnity.QueryAsync(File.ReadAllText(idPath), new Dictionary<string, object?> { ["@username"] = user });
-            int newId = Convert.ToInt32(idRows[0]["id"]);
+            string insertPath = Path.Combine(Application.dataPath, "sql", "unity_register_insert_plain.sql");
+            int rows = await DatabaseClientUnity.ExecuteAsync(File.ReadAllText(insertPath), parameters);
+            Debug.Log($"Insert result: {rows}");
+            if (rows > 0)
+            {
+                string idPath = Path.Combine(Application.dataPath, "sql", "unity_register_get_id.sql");
+                var idRows = await DatabaseClientUnity.QueryAsync(File.ReadAllText(idPath), new Dictionary<string, object?> { ["@username"] = user });
+                int newId = Convert.ToInt32(idRows[0]["id"]);
 
-            string ensureNodePath = Path.Combine(Application.dataPath, "sql", "unity_register_ensure_node.sql");
-            await DatabaseClientUnity.ExecuteAsync(File.ReadAllText(ensureNodePath), new Dictionary<string, object?> { ["@node"] = "nodeRiverVillage", ["@name"] = "River Village" });
+                string ensureNodePath = Path.Combine(Application.dataPath, "sql", "unity_register_ensure_node.sql");
+                await DatabaseClientUnity.ExecuteAsync(File.ReadAllText(ensureNodePath), new Dictionary<string, object?> { ["@node"] = "nodeRiverVillage", ["@name"] = "River Village" });
 
-            string initTravelPath = Path.Combine(Application.dataPath, "sql", "unity_register_init_travel.sql");
-            await DatabaseClientUnity.ExecuteAsync(File.ReadAllText(initTravelPath), new Dictionary<string, object?> { ["@accountId"] = newId, ["@node"] = "nodeRiverVillage" });
+                string initTravelPath = Path.Combine(Application.dataPath, "sql", "unity_register_init_travel.sql");
+                await DatabaseClientUnity.ExecuteAsync(File.ReadAllText(initTravelPath), new Dictionary<string, object?> { ["@accountId"] = newId, ["@node"] = "nodeRiverVillage" });
 
-            Debug.Log("Account created");
-            SceneManager.LoadScene("Login");
-        }
-        else
-        {
+                Debug.Log("Account created");
+                if (!ShowPopup("Account created successfully.", () => SceneManager.LoadScene("Login")))
+                {
+                    SceneManager.LoadScene("Login");
+                }
+                return;
+            }
+
             Debug.Log("No account created");
+            ShowPopup("Account could not be created. Please try again.");
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"Register error: {ex.Message}");
+            ShowPopup($"Error creating account: {ex.Message}");
         }
     }
 
@@ -222,5 +239,19 @@ public class RegisterManager : MonoBehaviour
     {
 
         SceneManager.LoadScene("Login");
+    }
+
+    private bool ShowPopup(string message, Action onOk = null)
+    {
+        if (popupWindowPrefab == null)
+        {
+            Debug.LogWarning("PopupWindow prefab not assigned.");
+            return false;
+        }
+
+        var canvas = FindObjectOfType<Canvas>();
+        var popup = Instantiate(popupWindowPrefab, canvas != null ? canvas.transform : null);
+        popup.Show(message, onOk);
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
- use the shared PopupWindow prefab in RegisterManager to surface validation, duplicate, and success messages
- gate register scene navigation on the popup acknowledgement and fall back if the prefab is missing
- document the register feedback workflow in the GDD with updated risks, backlog, and changelog entries

## Testing
- not run (Unity scene change)

------
https://chatgpt.com/codex/tasks/task_e_68c9d69d586c8333b3085299ba9fa8fd