### PR TITLE
Implement structured tavern recruitment flow

### DIFF
--- a/GDD.md
+++ b/GDD.md
@@ -1,5 +1,5 @@
 # Game Design Document (Living) — ygoCGPTE
-_Last updated: 2025-09-23 05:46 UTC • Document owner: Codex_
+_Last updated: 2025-09-23 06:40 UTC • Document owner: Codex_
 ## 0. Executive Snapshot
 - **Current Phase:** Porting Core Systems to Unity
 - **Build Status:** Yellow — Windows-specific tests fail in current Linux environment.
@@ -188,7 +188,7 @@ _Last updated: 2025-09-23 05:46 UTC • Document owner: Codex_
   LocationActivitiesPanel provides keyboard/gamepad friendly navigation for city activities.
 - **Technical notes**
   Built with Unity UGUI.
-- **Progress:** In progress, 15% (popup window prefab, city interaction panel wiring, and location activities panel highlighting).
+- **Progress:** In progress, 25% (popup window prefab, city interaction panel wiring, location activities panel highlighting, and tavern recruitment flow scaffolding).
 - **Open decisions:**
   - TBD: Finalize navigation flow. Owner: TBD, due 2025-09-25.
 
@@ -277,6 +277,7 @@ _Last updated: 2025-09-23 05:46 UTC • Document owner: Codex_
 | InventoryForm | InventoryUI | Not started | TBD | Requires `unity_inventory_load.sql` |
 | BattleForm | BattleScene | In progress | TBD | Basic scene scaffold |
 | ShopForm | ShopUI | Not started | TBD | Pricing logic TBD |
+| TavernForm | TavernPanel + TavernRecruitDetailPanel | In progress | Codex | Search for Party Members flow live; Mercenaries/Work buttons disabled pending specs |
 | PictureBox animations | FrameAnimator component | In progress | Codex | Handles sprite-frame playback |
 
 | WorldMapForm | WorldMap scene + PlayerNavigator | In progress | Codex | Shift-click waypoints queue |
@@ -321,6 +322,16 @@ _Last updated: 2025-09-23 05:46 UTC • Document owner: Codex_
   - Success popup transitions to the Login scene after player acknowledgment.
   - Validation and duplicate username/nickname errors use the popup prefab.
 - **Risks:** PopupWindow reference could be lost during scene merges — Owner: Codex, due 2025-09-27.
+
+### Tavern Panel
+- **Owner:** Codex
+- **Dependencies:** TavernManager, CharacterService cache, RPGManager.RefreshPartyUIAsync, ScrollRect candidate list prefab, TavernRecruitDetailPanel overlay
+- **Progress:** In progress, 45%
+- **Acceptance Criteria:**
+  - "Search for Party Members" generates three recruits through PartyMemberGenerator and populates ScrollRect buttons labeled "NAME – COST gold".
+  - Selecting a recruit opens a modal detail overlay with stats plus Hire and Cancel actions while hiding the list.
+  - Hire triggers TavernManager.HireAsync, updates CharacterService party cache, removes the recruit from available results, and refreshes RPGManager's party display.
+- **Risks:** Detail panel prefab requires Unity editor wiring before QA — Owner: Codex, due 2025-09-25.
 
 ## 9. Data & Persistence
 - **Save format** (JSON/ScriptableObject/etc.)
@@ -383,6 +394,8 @@ _Last updated: 2025-09-23 05:46 UTC • Document owner: Codex_
 | FEAT-CBT-001 | Create BattleScene | feature | TBD | 7d | SYS-ARCH-001 | Player can start and resolve battle | To Do | 0% | - | Should |
 | FEAT-UI-002 | Implement popup window prefab | feature | Codex | 1d | SYS-ARCH-001 | Popup shows login errors with OK dismissal | Done | 100% | PR TBD | Should |
 | FEAT-UI-003 | Register success popup flow | feature | Codex | 0.5d | PopupWindow prefab, Register scene Canvas | Register screen shows popup on success/failure and returns to Login after confirmation | Done | 100% | PR TBD | Should |
+| FEAT-UI-004 | Tavern recruit search & detail overlay | feature | Codex | 2d | TavernManager, CharacterService cache, RPGManager refresh hook | Search button spawns 3 recruits, modal displays stats, Hire updates party UI | In Progress | 45% | - | Should |
+| FEAT-UI-005 | Activate Tavern mercenary/work actions | feature | TBD | 3d | FEAT-UI-004 | Mercenary and Work buttons enabled with dedicated flows | To Do | 0% | - | Could |
 | FEAT-ANI-001 | Sprite Frame Animator component | feature | Codex | 2d | SYS-ARCH-001 | Lists animate per state at frameRate with tests | Done | 100% | PR TBD | Should |
 | FEAT-WM-001 | World map shift-click navigation | feature | Codex | 2d | SYS-ARCH-001 | Shift+Right sets destination; Shift+Left queues waypoint; agent animates per direction | Done | 100% | PR TBD | Should |
 | FEAT-WM-002 | City node interaction panel | feature | Codex | 1d | FEAT-WM-001 | CityInteraction panel toggles when entering/exiting CityNode radius | Done | 100% | PR TBD | Should |
@@ -458,6 +471,7 @@ _Last updated: 2025-09-23 05:46 UTC • Document owner: Codex_
 
 - 2025-09-16: Added CapsuleCollider and kinematic Rigidbody to the world map player for tooltip triggers and documented the setup. — Codex
 - 2025-09-16: Restored RPG scene YAML after merge conflict, reattached AreaTooltip wiring, and reinstated player physics components pending Unity re-save. — Codex
+- 2025-09-23: Documented structured TavernPanel flow, recruit detail overlay, CharacterService party cache updates, and RPGManager refresh hook. — Codex
 
 - 2025-09-22: Updated PlayerNavigator raycast to ignore tooltip triggers, restoring waypoint placement inside area volumes. — Codex
 - 2025-09-22: Tagged world map player and restored `Player` tag in TagManager so AreaTooltip triggers fire on entry/exit. — Codex

--- a/New Unity Project/Assets/Scripts/CharacterService.cs
+++ b/New Unity Project/Assets/Scripts/CharacterService.cs
@@ -8,6 +8,10 @@ using WinFormsApp2;
 
 public static class CharacterService
 {
+    private static readonly List<CharacterData> PartyMembersCache = new();
+
+    public static IReadOnlyList<CharacterData> CachedPartyMembers => PartyMembersCache;
+
     public static async Task<List<CharacterData>> GetPartyMembersAsync()
     {
         try
@@ -32,7 +36,11 @@ public static class CharacterService
                     MaxMana = Convert.ToInt32(row["max_mana"])
                 });
             }
-            return members;
+
+            PartyMembersCache.Clear();
+            PartyMembersCache.AddRange(members);
+
+            return new List<CharacterData>(PartyMembersCache);
         }
         catch (Exception ex)
         {
@@ -95,5 +103,15 @@ public static class CharacterService
             Debug.LogError($"Failed to fetch hired companions: {ex.Message}");
             return new List<CharacterData>();
         }
+    }
+
+    public static Task AddPartyMemberAsync(CharacterData data)
+    {
+        if (data != null)
+        {
+            PartyMembersCache.Add(data);
+        }
+
+        return Task.CompletedTask;
     }
 }

--- a/New Unity Project/Assets/Scripts/RPGManager.cs
+++ b/New Unity Project/Assets/Scripts/RPGManager.cs
@@ -68,7 +68,7 @@ public class RPGManager : MonoBehaviour
 
     private async Task LoadPartyMembersAsync()
     {
-        partyMembers = await CharacterService.GetPartyMembersAsync();
+        partyMembers = new List<CharacterData>(await CharacterService.GetPartyMembersAsync());
         hiredCompanions = await CharacterService.GetHiredCompanionsAsync();
         if (goldText != null)
         {
@@ -304,6 +304,12 @@ public class RPGManager : MonoBehaviour
         await FriendServiceUnity.SendFriendRequestAsync(InventoryServiceUnity.AccountId, nick);
         if (friendInput != null)
             friendInput.text = string.Empty;
+    }
+
+    public async Task RefreshPartyUIAsync()
+    {
+        await LoadPartyMembersAsync();
+        PopulatePartyList();
     }
 }
 

--- a/New Unity Project/Assets/Scripts/UI/PartyMemberGenerator.cs
+++ b/New Unity Project/Assets/Scripts/UI/PartyMemberGenerator.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+/// <summary>
+/// Helper responsible for enriching tavern recruits with display-ready data.
+/// </summary>
+public class PartyMemberGenerator
+{
+    private const int BaseStatMinimum = 4;
+
+    /// <summary>
+    /// Build generated recruit entries from the raw tavern data.
+    /// </summary>
+    /// <param name="baseRecruits">Raw recruits returned by TavernManager.</param>
+    /// <param name="count">Number of entries to produce.</param>
+    public List<GeneratedRecruit> BuildCandidates(IEnumerable<TavernManager.Recruit> baseRecruits, int count)
+    {
+        var pool = baseRecruits?.Take(count) ?? Enumerable.Empty<TavernManager.Recruit>();
+        var generated = new List<GeneratedRecruit>();
+
+        foreach (var recruit in pool)
+        {
+            var stats = GenerateStats(recruit.level);
+            int cost = Mathf.Max(25, Mathf.RoundToInt(stats.Total * 12f));
+            generated.Add(new GeneratedRecruit(recruit, stats, cost));
+        }
+
+        return generated;
+    }
+
+    private RecruitStats GenerateStats(int level)
+    {
+        int levelBonus = Mathf.Clamp(level, 1, 20);
+        return new RecruitStats
+        {
+            Strength = RollStat(levelBonus),
+            Agility = RollStat(levelBonus),
+            Intelligence = RollStat(levelBonus),
+            Vitality = RollStat(levelBonus)
+        };
+    }
+
+    private static int RollStat(int levelBonus)
+    {
+        return BaseStatMinimum + Random.Range(levelBonus, levelBonus + 6);
+    }
+
+    /// <summary>
+    /// Immutable view model describing a generated recruit.
+    /// </summary>
+    public class GeneratedRecruit
+    {
+        public GeneratedRecruit(TavernManager.Recruit source, RecruitStats stats, int cost)
+        {
+            Source = source;
+            Stats = stats;
+            Cost = cost;
+        }
+
+        public TavernManager.Recruit Source { get; }
+
+        public string Name => string.IsNullOrEmpty(Source.name)
+            ? "Unknown Adventurer"
+            : Source.name;
+
+        public RecruitStats Stats { get; }
+
+        public int Cost { get; }
+
+        public string DisplayLabel => $"{Name} – {Cost} gold";
+
+        public string BuildStatsDescription()
+        {
+            return $"STR {Stats.Strength}\nAGI {Stats.Agility}\nINT {Stats.Intelligence}\nVIT {Stats.Vitality}";
+        }
+
+        public CharacterData ToCharacterData()
+        {
+            return new CharacterData
+            {
+                Name = Name,
+                MaxHP = Stats.Vitality * 10,
+                HP = Stats.Vitality * 10,
+                MaxMana = Mathf.Max(1, Stats.Intelligence * 5),
+                Mana = Mathf.Max(1, Stats.Intelligence * 5)
+            };
+        }
+    }
+
+    /// <summary>
+    /// Simple stat block representation.
+    /// </summary>
+    public struct RecruitStats
+    {
+        public int Strength;
+        public int Agility;
+        public int Intelligence;
+        public int Vitality;
+
+        public int Total => Strength + Agility + Intelligence + Vitality;
+    }
+}

--- a/New Unity Project/Assets/Scripts/UI/TavernPanel.cs
+++ b/New Unity Project/Assets/Scripts/UI/TavernPanel.cs
@@ -1,108 +1,250 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using WinFormsApp2;
-using TMPro;
 
 /// <summary>
-/// Unity UI wrapper for TavernManager interactions.
-/// Displays recruit candidates and allows hiring or joining parties.
+/// Structured controller for Tavern activities. Manages recruit discovery, detail overlays,
+/// and wiring to tavern services.
 /// </summary>
 public class TavernPanel : MonoBehaviour
 {
-    [SerializeField] private RectTransform candidateListParent = null!;
+    [Header("Top-Level Actions")]
+    [SerializeField] private Button searchPartyMembersButton = null!;
+    [SerializeField] private Button hireMercenariesButton = null!;
+    [SerializeField] private Button lookForWorkButton = null!;
+
+    [Header("Candidate List")]
+    [SerializeField] private ScrollRect candidateScrollRect = null!;
+    [SerializeField] private GameObject candidateButtonPrefab = null!;
+
+    [Header("Detail Overlay")]
+    [SerializeField] private TavernRecruitDetailPanel recruitDetailPanel = null!;
+
+    [Header("Services")]
     [SerializeField] private TavernManager tavernManager = null!;
+    [SerializeField] private RPGManager rpgManager = null!;
 
-    private readonly List<TavernManager.Recruit> _candidates = new();
+    private readonly PartyMemberGenerator _generator = new();
+    private readonly List<PartyMemberGenerator.GeneratedRecruit> _availableRecruits = new();
+    private readonly List<Button> _spawnedButtons = new();
+    private PartyMemberGenerator.GeneratedRecruit? _selectedRecruit;
 
-    private async void Start()
+    private Transform? CandidateContent => candidateScrollRect != null ? candidateScrollRect.content : null;
+
+    private void Awake()
+    {
+        if (recruitDetailPanel != null)
+        {
+            recruitDetailPanel.HideInstant();
+        }
+
+        if (candidateScrollRect != null)
+        {
+            candidateScrollRect.gameObject.SetActive(true);
+        }
+    }
+
+    private void Start()
     {
         if (tavernManager == null)
+        {
             tavernManager = FindObjectOfType<TavernManager>();
-        await RefreshAsync();
-    }
-
-    /// <summary>
-    /// Reload candidate list from the server and rebuild the UI.
-    /// </summary>
-    private async Task RefreshAsync()
-    {
-        int accountId = InventoryServiceUnity.AccountId;
-        _candidates.Clear();
-        _candidates.AddRange(await tavernManager.GetCandidatesAsync(accountId));
-
-        if (candidateListParent == null)
-        {
-            var canvas = FindObjectOfType<Canvas>() ?? new GameObject("Canvas", typeof(Canvas)).GetComponent<Canvas>();
-            candidateListParent = canvas.transform as RectTransform;
         }
 
-        foreach (Transform child in candidateListParent)
-            Destroy(child.gameObject);
-
-        foreach (var c in _candidates)
+        if (rpgManager == null)
         {
-            var entry = new GameObject($"Candidate_{c.id}", typeof(RectTransform));
-            entry.transform.SetParent(candidateListParent, false);
+            rpgManager = FindObjectOfType<RPGManager>();
+        }
 
-            var nameGO = new GameObject("Name", typeof(RectTransform), typeof(CanvasRenderer), typeof(TextMeshProUGUI));
-            var nameRT = nameGO.GetComponent<RectTransform>();
-            nameRT.SetParent(entry.transform);
-            nameRT.sizeDelta = new Vector2(200, 30);
-            var label = nameGO.GetComponent<TextMeshProUGUI>();
-            label.text = $"{c.name} (Lv {c.level})";
-            label.color = Color.black;
+        WireTopLevelButtons();
+        ConfigureTodoButton(hireMercenariesButton);
+        ConfigureTodoButton(lookForWorkButton);
+    }
 
-            var hireBtn = CreateButton(entry.transform, "Hire", new Vector2(110, 0));
-            int recruitId = c.id;
-            hireBtn.onClick.AddListener(async () =>
+    private void WireTopLevelButtons()
+    {
+        if (searchPartyMembersButton != null)
+        {
+            searchPartyMembersButton.onClick.RemoveAllListeners();
+            searchPartyMembersButton.onClick.AddListener(() => _ = OnSearchForPartyMembersAsync());
+        }
+    }
+
+    private void ConfigureTodoButton(Button? button)
+    {
+        if (button == null)
+        {
+            return;
+        }
+
+        button.onClick.RemoveAllListeners();
+        button.interactable = false;
+
+        var label = button.GetComponentInChildren<TMP_Text>();
+        if (label != null)
+        {
+            label.text = $"{label.text} (Coming Soon)";
+            label.alpha = 0.5f;
+        }
+    }
+
+    private async Task OnSearchForPartyMembersAsync()
+    {
+        if (searchPartyMembersButton != null)
+        {
+            searchPartyMembersButton.interactable = false;
+        }
+
+        try
+        {
+            await PopulateRecruitListAsync();
+        }
+        finally
+        {
+            if (searchPartyMembersButton != null)
             {
-                if (await tavernManager.HireAsync(accountId, recruitId))
-                    await RefreshAsync();
-            });
-
-            var joinBtn = CreateButton(entry.transform, "Join Party", new Vector2(220, 0));
-            joinBtn.onClick.AddListener(OnJoinParty);
+                searchPartyMembersButton.interactable = true;
+            }
         }
     }
 
-    /// <summary>
-    /// Helper for dynamically creating UI buttons.
-    /// </summary>
-    private Button CreateButton(Transform parent, string label, Vector2 position)
+    private async Task PopulateRecruitListAsync()
     {
-        var go = new GameObject(label + "Button", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button));
-        var rt = go.GetComponent<RectTransform>();
-        rt.SetParent(parent);
-        rt.sizeDelta = new Vector2(90, 30);
-        rt.anchoredPosition = position;
+        if (tavernManager == null || candidateScrollRect == null || candidateButtonPrefab == null)
+        {
+            Debug.LogWarning("TavernPanel missing required references for candidate generation.");
+            return;
+        }
 
-        var textGO = new GameObject("Text", typeof(RectTransform), typeof(CanvasRenderer), typeof(TextMeshProUGUI));
-        var textRT = textGO.GetComponent<RectTransform>();
-        textRT.SetParent(go.transform);
-        textRT.anchorMin = Vector2.zero;
-        textRT.anchorMax = Vector2.one;
-        textRT.offsetMin = Vector2.zero;
-        textRT.offsetMax = Vector2.zero;
-        var text = textGO.GetComponent<TextMeshProUGUI>();
-        text.text = label;
-        text.alignment = TextAlignmentOptions.Center;
-        text.color = Color.black;
+        int accountId = InventoryServiceUnity.AccountId;
+        List<TavernManager.Recruit> baseRecruits = await tavernManager.GetCandidatesAsync(accountId);
+        _availableRecruits.Clear();
+        _availableRecruits.AddRange(_generator.BuildCandidates(baseRecruits, 3));
 
-        return go.GetComponent<Button>();
+        RebuildCandidateButtons();
     }
 
-    /// <summary>
-    /// Placeholder for opening the multiplayer party join flow.
-    /// Refreshes candidate list afterward.
-    /// </summary>
-    private async void OnJoinParty()
+    private void RebuildCandidateButtons()
     {
-        // Placeholder: actual implementation would open a join-party window.
-        await RefreshAsync();
+        foreach (var button in _spawnedButtons)
+        {
+            if (button != null)
+            {
+                Destroy(button.gameObject);
+            }
+        }
+        _spawnedButtons.Clear();
+
+        var content = CandidateContent;
+        if (content == null)
+        {
+            Debug.LogWarning("TavernPanel candidate content is not assigned.");
+            return;
+        }
+
+        foreach (Transform child in content)
+        {
+            Destroy(child.gameObject);
+        }
+
+        foreach (var recruit in _availableRecruits)
+        {
+            var candidateGO = Instantiate(candidateButtonPrefab, content);
+            var button = candidateGO.GetComponent<Button>();
+            if (button == null)
+            {
+                button = candidateGO.AddComponent<Button>();
+            }
+
+            var label = candidateGO.GetComponentInChildren<TMP_Text>();
+            if (label != null)
+            {
+                label.text = recruit.DisplayLabel;
+            }
+
+            button.onClick.RemoveAllListeners();
+            button.onClick.AddListener(() => OnRecruitSelected(recruit));
+            _spawnedButtons.Add(button);
+        }
+
+        candidateScrollRect.gameObject.SetActive(_availableRecruits.Count > 0);
+    }
+
+    private void OnRecruitSelected(PartyMemberGenerator.GeneratedRecruit recruit)
+    {
+        _selectedRecruit = recruit;
+        if (candidateScrollRect != null)
+        {
+            candidateScrollRect.gameObject.SetActive(false);
+        }
+
+        if (recruitDetailPanel == null)
+        {
+            Debug.LogWarning("Recruit detail panel not assigned.");
+            if (candidateScrollRect != null)
+            {
+                candidateScrollRect.gameObject.SetActive(true);
+            }
+            return;
+        }
+
+        recruitDetailPanel.Show(
+            recruit,
+            () => _ = HireSelectedRecruitAsync(),
+            CloseDetailPanel);
+    }
+
+    private async Task HireSelectedRecruitAsync()
+    {
+        if (_selectedRecruit == null || tavernManager == null)
+        {
+            return;
+        }
+
+        int accountId = InventoryServiceUnity.AccountId;
+        bool success = await tavernManager.HireAsync(accountId, _selectedRecruit.Source.id);
+        if (!success)
+        {
+            Debug.LogWarning($"Failed to hire recruit {_selectedRecruit.Source.name}.");
+            CloseDetailPanel();
+            return;
+        }
+
+        await CharacterService.AddPartyMemberAsync(_selectedRecruit.ToCharacterData());
+
+        _availableRecruits.Remove(_selectedRecruit);
+        _selectedRecruit = null;
+
+        CloseDetailPanel();
+        RebuildCandidateButtons();
+        await RefreshPartyDisplayAsync();
+    }
+
+    private void CloseDetailPanel()
+    {
+        recruitDetailPanel?.Hide();
+        _selectedRecruit = null;
+        if (candidateScrollRect != null)
+        {
+            candidateScrollRect.gameObject.SetActive(true);
+        }
+    }
+
+    private async Task RefreshPartyDisplayAsync()
+    {
+        if (rpgManager == null)
+        {
+            rpgManager = FindObjectOfType<RPGManager>();
+        }
+
+        if (rpgManager != null)
+        {
+            await rpgManager.RefreshPartyUIAsync();
+        }
     }
 
     public void BackToMain() => MainRPGNavigation.OpenMain();
 }
-

--- a/New Unity Project/Assets/Scripts/UI/TavernRecruitDetailPanel.cs
+++ b/New Unity Project/Assets/Scripts/UI/TavernRecruitDetailPanel.cs
@@ -1,0 +1,94 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.UI;
+
+/// <summary>
+/// Modal overlay for showing recruit details and hire actions.
+/// </summary>
+public class TavernRecruitDetailPanel : MonoBehaviour
+{
+    [SerializeField] private GameObject root = null!;
+    [SerializeField] private TMP_Text nameText = null!;
+    [SerializeField] private TMP_Text statsText = null!;
+    [SerializeField] private TMP_Text costText = null!;
+    [SerializeField] private Button hireButton = null!;
+    [SerializeField] private Button cancelButton = null!;
+
+    private void Awake()
+    {
+        if (root == null)
+        {
+            root = gameObject;
+        }
+
+        HideInstant();
+    }
+
+    public void Show(
+        PartyMemberGenerator.GeneratedRecruit recruit,
+        UnityAction onHire,
+        UnityAction onCancel)
+    {
+        if (root == null)
+        {
+            Debug.LogWarning("Tavern recruit detail root not assigned.");
+            return;
+        }
+
+        root.SetActive(true);
+
+        if (nameText != null)
+        {
+            nameText.text = recruit.Name;
+        }
+
+        if (statsText != null)
+        {
+            statsText.text = recruit.BuildStatsDescription();
+        }
+
+        if (costText != null)
+        {
+            costText.text = $"Cost: {recruit.Cost} gold";
+        }
+
+        if (hireButton != null)
+        {
+            hireButton.onClick.RemoveAllListeners();
+            hireButton.onClick.AddListener(onHire);
+        }
+
+        if (cancelButton != null)
+        {
+            cancelButton.onClick.RemoveAllListeners();
+            cancelButton.onClick.AddListener(onCancel);
+        }
+    }
+
+    public void Hide()
+    {
+        if (hireButton != null)
+        {
+            hireButton.onClick.RemoveAllListeners();
+        }
+
+        if (cancelButton != null)
+        {
+            cancelButton.onClick.RemoveAllListeners();
+        }
+
+        if (root != null)
+        {
+            root.SetActive(false);
+        }
+    }
+
+    public void HideInstant()
+    {
+        if (root != null)
+        {
+            root.SetActive(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the TavernPanel MonoBehaviour with a structured activities controller that drives the Search for Party Members flow, launches a recruit detail modal, and refreshes party data after hires
- add PartyMemberGenerator and TavernRecruitDetailPanel helpers to produce recruit data, populate the ScrollRect, and manage the hire/cancel overlay lifecycle
- extend CharacterService with a local party cache and RPGManager with a refresh hook, plus document the tavern UI progress and backlog updates in the living GDD

## Testing
- not run (Unity editor and play mode checks required)


------
https://chatgpt.com/codex/tasks/task_e_68d289aa3cb083338c89d7cdafd3c79c